### PR TITLE
chore(security): CodeQL, dependency-review, and Scorecard workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,65 @@
+# =============================================================================
+# CodeQL — static analysis (SAST) for the app code and the workflows.
+#
+# Why a workflow file instead of GitHub's "default setup": this repo treats
+# everything as code (ADRs, CI, compose), and the classic-PAT default-setup
+# endpoint isn't available here. The workflow authenticates with the built-in
+# GITHUB_TOKEN (security-events: write), so no secrets are needed.
+#
+# Scope: the TypeScript/JavaScript app + the GitHub Actions workflows
+# themselves (the `actions` language catches injection / untrusted-input bugs
+# in CI). Runs on PRs, pushes to main, and weekly to catch newly-published
+# CodeQL queries against unchanged code. The `security-extended` suite is used
+# because this is an auth/RBAC/DNS app where extra security queries earn their
+# keep.
+# =============================================================================
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "27 3 * * 1" # Mondays 03:27 UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to the Security tab
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, actions]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          language: ${{ matrix.language }}
+          queries: security-extended
+
+      # JS/TS is interpreted and the Actions language has nothing to compile,
+      # so autobuild is a no-op here — kept for portability if a compiled
+      # language is ever added.
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,40 @@
+# =============================================================================
+# Dependency review — blocks a PR that adds a dependency with a known
+# high/critical CVE or a disallowed license, before it ever lands on main.
+#
+# This complements, rather than duplicates, the other layers:
+#   • Renovate          — opens PRs to *update* deps (incl. immediate security PRs).
+#   • Dependabot alerts — flag CVEs in deps *already* on main.
+#   • CI `npm audit`    — gates the production dep tree on high/critical CVEs.
+#   • THIS              — gates the *diff*: catches a vulnerable/odd-licensed dep
+#                         at the moment a PR introduces it.
+#
+# Uses the dependency graph (on by default for public repos). No secrets.
+# =============================================================================
+
+name: Dependency review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write # post the summary comment on failure
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          # MIT project — keep the dep tree to permissive/compatible licenses.
+          deny-licenses: AGPL-1.0-only, AGPL-3.0-only, GPL-2.0-only, GPL-3.0-only
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,58 @@
+# =============================================================================
+# OpenSSF Scorecard — supply-chain security posture audit.
+#
+# Scores the repo against the OpenSSF checks (branch protection, pinned
+# dependencies, token permissions, dangerous workflow patterns, signed
+# releases, etc.) and uploads the results to the Security → Code scanning tab
+# as SARIF, so regressions show up alongside CodeQL findings. With
+# `publish_results: true` the score also feeds the public Scorecard badge.
+#
+# Runs weekly and whenever a branch-protection rule changes (the event
+# Scorecard recommends). No secrets — uses GITHUB_TOKEN + OIDC.
+# =============================================================================
+
+name: Scorecard supply-chain
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "23 4 * * 1" # Mondays 04:23 UTC
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to code scanning
+      id-token: write # OIDC token for publish_results
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## What

Adds three version-controlled security workflows and documents the repo-level toggles enabled alongside them.

### New workflows
- **`codeql.yml`** — CodeQL SAST (`security-extended`) over the TypeScript/JS app **and** the GitHub Actions workflows; runs on PRs, pushes to `main`, and weekly. Authenticates with the built-in `GITHUB_TOKEN` (`security-events: write`).
- **`dependency-review.yml`** — gates each PR's dependency *diff*: fails on a newly-introduced high/critical CVE and denies copyleft licenses (MIT project). Complements `npm audit` (which gates the whole tree) by catching things at introduction time.
- **`scorecard.yml`** — OpenSSF Scorecard supply-chain audit weekly + on branch-protection changes; uploads SARIF to the Security tab.

### Enabled out-of-band via the GitHub API (settings, not code)
- ✅ Dependabot **alerts** + **security updates**
- ✅ **Secret scanning** + **push protection**
- ❌ Secret-scanning *validity checks* / *non-provider patterns* — require GitHub Advanced Security, unavailable on this plan.
- ❌ CodeQL *default setup* — the management endpoint 404s for the classic PAT, hence this workflow file instead.

## Why no `dependabot.yml`?
Renovate (`renovate.json`) already owns **version updates** (npm + Actions, weekly, grouped, auto-merge patches, immediate vulnerability PRs). A Dependabot version-update config would double every dependency PR. Dependabot's **alerting/security** half is enabled instead, which doesn't conflict.

## Follow-ups (not in this PR)
- Pin third-party Actions to commit SHAs (Scorecard's `Pinned-Dependencies` check will flag the `@vN` tags, including the existing CI workflow).
- Consider a dedicated dependency-malware scanner (e.g. Socket.dev app) if you want install-time malware detection beyond CVE matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)