### PR TITLE
fix(ui): SelectMenu flips upward near the viewport bottom

### DIFF
--- a/components/ui/select-menu.tsx
+++ b/components/ui/select-menu.tsx
@@ -40,9 +40,13 @@ interface SelectMenuProps<T extends string> {
 }
 
 interface Anchor {
-  top: number;
   left: number;
   width: number;
+  /** Exactly one of `top` / `bottom` is set, depending on the flip direction. */
+  top?: number;
+  bottom?: number;
+  /** Cap the listbox to the space on the chosen side so it scrolls, never clips. */
+  maxHeight: number;
 }
 
 export function SelectMenu<T extends string>({
@@ -60,11 +64,38 @@ export function SelectMenu<T extends string>({
   const listRef = useRef<HTMLUListElement>(null);
   const listId = useId();
 
-  // Anchor the portaled listbox to the trigger. Recomputed on open and on any
-  // scroll/resize so it tracks the trigger instead of drifting.
+  // Anchor the portaled listbox to the trigger. Opens downward by default, but
+  // flips upward when the trigger sits near the viewport bottom (e.g. a table's
+  // page-size selector, which lives in the pager at the foot of the page) so the
+  // options aren't clipped off-screen. Recomputed on open and on any
+  // scroll/resize so it tracks the trigger and re-flips as it moves.
   const reposition = useCallback(() => {
     const b = btnRef.current?.getBoundingClientRect();
-    if (b) setAnchor({ top: b.bottom + 4, left: b.left, width: b.width });
+    if (!b) return;
+    const GAP = 4; // breathing room between the trigger and the menu
+    const EDGE = 8; // keep the menu off the very edge of the screen
+    const MENU_MAX = 288; // the listbox's natural cap (the old max-h-72 = 18rem)
+    const spaceBelow = window.innerHeight - b.bottom - GAP - EDGE;
+    const spaceAbove = b.top - GAP - EDGE;
+    // Flip up only when the menu can't get its full height below AND there's more
+    // room above. Anchoring the up-menu by its BOTTOM edge means it sits directly
+    // above the trigger regardless of how many options it holds — no measuring.
+    const openUp = spaceBelow < MENU_MAX && spaceAbove > spaceBelow;
+    if (openUp) {
+      setAnchor({
+        bottom: window.innerHeight - b.top + GAP,
+        left: b.left,
+        width: b.width,
+        maxHeight: Math.max(0, Math.min(MENU_MAX, spaceAbove)),
+      });
+    } else {
+      setAnchor({
+        top: b.bottom + GAP,
+        left: b.left,
+        width: b.width,
+        maxHeight: Math.max(0, Math.min(MENU_MAX, spaceBelow)),
+      });
+    }
   }, []);
 
   useEffect(() => {
@@ -139,8 +170,14 @@ export function SelectMenu<T extends string>({
               ref={listRef}
               id={listId}
               role="listbox"
-              style={{ top: anchor.top, left: anchor.left, width: anchor.width }}
-              className="fixed z-[200] max-h-72 overflow-auto rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] py-1 text-sm shadow-lg"
+              style={{
+                top: anchor.top,
+                bottom: anchor.bottom,
+                left: anchor.left,
+                width: anchor.width,
+                maxHeight: anchor.maxHeight,
+              }}
+              className="fixed z-[200] overflow-auto rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] py-1 text-sm shadow-lg"
             >
               {options.map((o) => (
                 <li


### PR DESCRIPTION
Closes #13.

## Problem
The themed dropdown (`components/ui/select-menu.tsx`) always anchored its listbox **below** the trigger. The data-table page-size ("Rows") selector lives in the pager at the foot of the page, so its menu opened downward and was clipped by the window edge / OS dock — options were unreachable. Every paginated table (`components/ui/data-table.tsx` renders the selector via `SelectMenu`) was affected.

## Fix
`reposition()` now compares the space below vs. above the trigger and **flips the menu upward** when it can't fit its full height below and there's more room above:
- The up-menu is anchored by its **bottom** edge (`bottom: innerHeight - rect.top + gap`), so it sits directly above the trigger regardless of how many options it holds — no content measuring, no flash.
- The listbox `max-height` is capped to the chosen side's available space (replacing the static `max-h-72`), so it scrolls rather than clipping in **either** direction.
- It re-flips on the existing scroll/resize listeners.

Because every consumer uses the shared `SelectMenu`, this fixes the page-size selector on all tables (and the zone-kind chooser, algorithm pickers, etc.) in one change.

## Testing
- `tsc --noEmit`, `eslint`, `prettier --check` — all clean.
- Positioning depends on real layout (`getBoundingClientRect` + `window.innerHeight`), which jsdom doesn't compute, so no unit test was added; verified the logic by inspection. Manual check: open a paginated table (e.g. `/admin/audit`) with the pager at the viewport bottom → the **Rows** menu now opens upward and is fully visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)