### PR TITLE
fix(dns): correct TXT bare-text escape order (RFC 1035 §5.1)

### DIFF
--- a/lib/validators/rr-types/txt.ts
+++ b/lib/validators/rr-types/txt.ts
@@ -67,7 +67,9 @@ export const txtValidator: RRTypeValidator = {
 
     // Bare text — auto-quote, but warn if it's longer than what fits in one
     // character-string.
-    const inner = trimmed.replace(/"/g, '\\"').replace(/\\/g, "\\\\");
+    // RFC 1035 § 5.1 requires `\` to be escaped before `"` — doing it
+    // the other way around doubles the just-inserted backslash.
+    const inner = trimmed.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
     if (octetLength(trimmed) > 255) {
       issues.push({
         level: "warning",

--- a/lib/validators/rr-types/validators.test.ts
+++ b/lib/validators/rr-types/validators.test.ts
@@ -146,7 +146,7 @@ describe("TXT validator", () => {
     expect(r.issues.some((i) => i.message.includes("255"))).toBe(true);
   });
 
-  it("escapes \\ before \" when auto-quoting bare text (RFC 1035 § 5.1 escape order)", () => {
+  it('escapes \\ before " when auto-quoting bare text (RFC 1035 § 5.1 escape order)', () => {
     // Regression for issue #2: the old code escaped `"` first, then `\`,
     // so the backslash inserted by the quote pass got doubled. The value
     // `a "b" c\d` must round-trip through extractQuotedStrings back to the

--- a/lib/validators/rr-types/validators.test.ts
+++ b/lib/validators/rr-types/validators.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { extractQuotedStrings } from "@/lib/dns/txt";
 import { aValidator } from "./a";
 import { aaaaValidator } from "./aaaa";
 import { caaValidator } from "./caa";
@@ -143,6 +144,23 @@ describe("TXT validator", () => {
     const long = `"${"a".repeat(300)}"`;
     const r = txtValidator.validate(long);
     expect(r.issues.some((i) => i.message.includes("255"))).toBe(true);
+  });
+
+  it("escapes \\ before \" when auto-quoting bare text (RFC 1035 § 5.1 escape order)", () => {
+    // Regression for issue #2: the old code escaped `"` first, then `\`,
+    // so the backslash inserted by the quote pass got doubled. The value
+    // `a "b" c\d` must round-trip through extractQuotedStrings back to the
+    // original bare string.
+    const raw = 'a "b" c\\d';
+    const r = txtValidator.validate(raw);
+    expect(hasErrors(r)).toBe(false);
+    // Normalized form must be a quoted string.
+    expect(r.normalized.startsWith('"')).toBe(true);
+    expect(r.normalized.endsWith('"')).toBe(true);
+    // Round-trip: parsing the normalized value must recover the original.
+    const parsed = extractQuotedStrings(r.normalized);
+    expect(parsed).not.toBeNull();
+    expect(parsed![0]).toBe(raw);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #2. When auto-quoting bare TXT text, the code escaped `"` **before** `\`:

```ts
const inner = trimmed.replace(/"/g, '\\"').replace(/\\/g, "\\\\");
```

The second pass then doubled the backslash that the first pass had just
inserted in front of every quote — corrupting any value containing `"` or `\`.
Per RFC 1035 §5.1 the backslash must be escaped **first**:

```ts
const inner = trimmed.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
```

## Test

Adds a round-trip regression: a value containing both `"` and `\` now normalizes
to a quoted character-string that `extractQuotedStrings()` parses back to the
exact original. Full `validators.test.ts` suite green (110 tests).

Closes #2