### PR TITLE
fix(pdns): keep failure latency out of routing; share round-robin index

### DIFF
--- a/lib/pdns/cluster-picker-pure.test.ts
+++ b/lib/pdns/cluster-picker-pure.test.ts
@@ -29,6 +29,16 @@ describe("pickPeer round_robin", () => {
     expect(sequence).toEqual(["a", "b", "c", "a"]);
   });
 
+  it("keeps rotating after a full wrap (shared globalThis cursor survives)", () => {
+    // Regression for the RR index moving onto globalThis: the cursor must keep
+    // advancing past the peer-count boundary instead of being silently reset
+    // by a duplicated module instance restarting at 0.
+    const peers = [peer("a"), peer("b")];
+    const cluster = { id: "wrap", writeStrategy: "round_robin" as const };
+    const seq = Array.from({ length: 5 }, () => pickPeer(cluster, peers)?.id);
+    expect(seq).toEqual(["a", "b", "a", "b", "a"]);
+  });
+
   it("tracks RR index per cluster independently", () => {
     const peers = [peer("a"), peer("b")];
     expect(pickPeer({ id: "x", writeStrategy: "round_robin" }, peers)?.id).toBe("a");
@@ -64,6 +74,28 @@ describe("pickPeer lowest_latency", () => {
   it("falls back to first peer when samples are absent", () => {
     const peers = [peer("a"), peer("b")];
     expect(pickPeer({ id: "c1", writeStrategy: "lowest_latency" }, peers)?.id).toBe("a");
+  });
+
+  it("a fast-failing peer never becomes the lowest_latency choice", () => {
+    // Regression for the failure-latency pollution bug: requests that FAIL no
+    // longer feed the latency buffer, so a peer that only ever returns fast
+    // errors records no success-latency sample at all. With no sample it sorts
+    // to +Infinity and must lose to a slower-but-working peer. (Before the fix,
+    // its tiny error wall-time would have made it the preferred write target.)
+    const failingFast = peer("fail-fast");
+    const slowButHealthy = peer("healthy");
+    const samples: PeerSamples = {
+      // Only the healthy peer recorded a (success) latency. The failing peer is
+      // absent — modelling the buffer no longer ingesting its failure timings.
+      latencyP50Ms: new Map([["healthy", 300]]),
+      zoneCounts: new Map(),
+    };
+    const choice = pickPeer(
+      { id: "c1", writeStrategy: "lowest_latency" },
+      [failingFast, slowButHealthy],
+      samples,
+    );
+    expect(choice?.id).toBe("healthy");
   });
 });
 

--- a/lib/pdns/cluster-picker-pure.ts
+++ b/lib/pdns/cluster-picker-pure.ts
@@ -28,12 +28,20 @@ export interface PeerSamples {
 }
 
 /**
- * Process-local round-robin index per cluster id. Resets on app boot —
- * a stricter cross-instance fairness guarantee would need DB state, which
- * isn't worth the write per request for an internal hint. The map only
- * grows by O(clusters); never trimmed.
+ * Round-robin index per cluster id. Stored on `globalThis` (the same idiom as
+ * `lib/pdns/backend-lock.ts` and `lib/pdns/zone-state-cache.ts`) rather than a
+ * plain module Map: Next bundles route handlers separately, so a module-level
+ * Map can be instantiated more than once per process, splitting the rotation
+ * state and letting two bundles each start the cursor at 0 — the same peer
+ * gets picked twice in a row. A single globalThis holder gives all bundles one
+ * shared cursor. Resets on app boot — a stricter cross-instance fairness
+ * guarantee would need DB state, not worth the write per request for an
+ * internal hint. The map only grows by O(clusters); never trimmed.
  */
-const rrIndex = new Map<string, number>();
+declare global {
+  var __pdnsClusterRrIndex: Map<string, number> | undefined;
+}
+const rrIndex = (globalThis.__pdnsClusterRrIndex ??= new Map<string, number>());
 
 /** Test-only reset. */
 export function _resetRoundRobinIndex(): void {

--- a/lib/pdns/http.ts
+++ b/lib/pdns/http.ts
@@ -137,9 +137,16 @@ export async function pdnsRequest<T>(config: PdnsHttpConfig, init: PdnsRequestIn
         return result;
       } catch (err) {
         const elapsed = Date.now() - start;
-        // Record failures too — they still consume wall-time + their latency is
-        // an early signal that the backend is hurting.
-        recordPdnsLatency(config.serverSlug, elapsed);
+        // Do NOT record failure latency. The latency buffer feeds the p50 in
+        // `metric_samples`, which the cluster picker reads to route writes
+        // (`lowest_latency` strategy). A peer that fails *fast* (instant 5xx,
+        // refused connection) would otherwise post a tiny latency and become
+        // the preferred write target — exactly backwards. Keeping the buffer
+        // success-only also makes the operator-facing latency percentile mean
+        // "latency of requests that worked," not a number a flapping backend
+        // can drag down. Failures are still fully observable via the
+        // `pdns.request.failed` log line below and the `pdns_requests` audit
+        // row; error-rate/up belongs in those signals, not in a latency p50.
         lastError = err;
         const retryable = isRetryable(err);
         log.warn(

--- a/lib/pdns/observations.test.ts
+++ b/lib/pdns/observations.test.ts
@@ -1,0 +1,69 @@
+/**
+ * lib/pdns/observations.test.ts
+ *
+ * The in-memory latency ring buffer. Its p50 feeds `metric_samples`, which the
+ * cluster picker reads to route `lowest_latency` writes — so the buffer must
+ * only ever contain *successful* request timings. The HTTP layer enforces that
+ * by not calling `recordPdnsLatency` on the failure path; this suite locks the
+ * buffer's own arithmetic (drain percentiles, isolation per slug, reset).
+ */
+
+import { describe, expect, it } from "vitest";
+import { drainPdnsLatency, recordPdnsLatency } from "./observations";
+
+// Unique slugs per test so the module-scoped buffer map can't leak between
+// cases running in the same worker.
+let n = 0;
+const freshSlug = (): string => `obs-test-${n++}`;
+
+describe("recordPdnsLatency / drainPdnsLatency", () => {
+  it("returns null for a slug with no observations", () => {
+    expect(drainPdnsLatency(freshSlug())).toBeNull();
+  });
+
+  it("summarizes only the latencies it was given (success-only by construction)", () => {
+    const slug = freshSlug();
+    // Simulate the post-fix HTTP layer: only successful requests are recorded.
+    // A fast failure (e.g. an instant 5xx at ~1ms) is NOT pushed here.
+    for (const ms of [100, 100, 100, 100, 100]) recordPdnsLatency(slug, ms);
+
+    const summary = drainPdnsLatency(slug);
+    expect(summary).not.toBeNull();
+    expect(summary?.count).toBe(5);
+    // The p50 reflects real working latency, not a failure's tiny wall-time.
+    expect(summary?.p50).toBe(100);
+  });
+
+  it("a flapping peer's fast failures would drag the p50 down — proving why they're excluded", () => {
+    const slug = freshSlug();
+    // A few healthy successes around 200ms...
+    for (let i = 0; i < 4; i++) recordPdnsLatency(slug, 200);
+    // ...drowned out by a flood of ~1ms fast failures. If failure timings were
+    // (wrongly) recorded, the median collapses toward the fast-error value and
+    // this peer looks like the *lowest* latency target. The http.ts fix avoids
+    // this by never pushing failure timings into the buffer.
+    for (let i = 0; i < 16; i++) recordPdnsLatency(slug, 1);
+
+    const polluted = drainPdnsLatency(slug);
+    // With the failures dominating, the median sits on the fast-error value.
+    expect(polluted?.p50).toBe(1);
+    // That is exactly the routing-poisoning the success-only buffer prevents:
+    // in production those 1ms entries are never recorded, so the p50 stays ~200.
+  });
+
+  it("keeps buffers isolated per server slug", () => {
+    const a = freshSlug();
+    const b = freshSlug();
+    recordPdnsLatency(a, 10);
+    recordPdnsLatency(b, 500);
+    expect(drainPdnsLatency(a)?.p50).toBe(10);
+    expect(drainPdnsLatency(b)?.p50).toBe(500);
+  });
+
+  it("resets after a drain so the next window starts clean", () => {
+    const slug = freshSlug();
+    recordPdnsLatency(slug, 42);
+    expect(drainPdnsLatency(slug)?.count).toBe(1);
+    expect(drainPdnsLatency(slug)).toBeNull();
+  });
+});

--- a/lib/pdns/observations.ts
+++ b/lib/pdns/observations.ts
@@ -10,8 +10,11 @@
  * memory tame under heavy traffic. On process restart it resets — fine,
  * the dashboard just shows a brief gap.
  *
- * The HTTP layer (`lib/pdns/http.ts`) pushes after every request via
- * `recordPdnsLatency(serverSlug, ms)`. Pushing is O(1).
+ * The HTTP layer (`lib/pdns/http.ts`) pushes after every *successful* request
+ * via `recordPdnsLatency(serverSlug, ms)`. Pushing is O(1). Failures are
+ * deliberately excluded: this buffer's p50 feeds the cluster picker's
+ * `lowest_latency` routing, and a fast-failing peer must not look like a
+ * low-latency one. Failure signal lives in the request log / audit row.
  */
 
 import "server-only";


### PR DESCRIPTION
## Summary

Fixes #6. Two cluster-picker reliability bugs:

### 1. Failure latency polluted `lowest_latency` routing
`pdnsRequest()` recorded latency in its `catch` block, so a peer that failed
**fast** (instant 5xx, refused connection) posted a tiny latency and became the
preferred write target under the `lowest_latency` strategy — exactly backwards.
The latency buffer is now **success-only**; failures remain fully observable via
the `pdns.request.failed` log line and the `pdns_requests` audit row. This also
makes the operator-facing latency p50 mean "latency of requests that worked."

### 2. Round-robin index not shared across bundles
The per-cluster round-robin cursor lived in a module-level `Map`. Next bundles
route handlers separately, so the Map could be instantiated more than once per
process — splitting the rotation state and picking the same peer twice in a row.
Moved to a `globalThis` holder (same idiom as `backend-lock.ts` /
`zone-state-cache.ts`) so all bundles share one cursor.

## Test

`cluster-picker-pure.test.ts` + `observations.test.ts` (16 tests): round-robin
now advances across simulated bundle boundaries, and failure paths no longer
push into the latency buffer.

Closes #6