### PR TITLE
ci+docs: pin scorecard-action to its commit SHA; README badge + compat-matrix tidy

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,7 +39,9 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        # Pin to a real release tag — ossf/scorecard-action publishes no
+        # floating `v2` major tag, so `@v2` fails to resolve at runtime.
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,9 +39,10 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        # Pin to a real release tag — ossf/scorecard-action publishes no
-        # floating `v2` major tag, so `@v2` fails to resolve at runtime.
-        uses: ossf/scorecard-action@v2.4.3
+        # Pinned to an immutable commit SHA (not a tag): a moved tag is a
+        # supply-chain vector, and `@v2` doesn't resolve at all. CodeQL's
+        # actions query enforces this. Bump the SHA + comment together.
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@
 [![Next.js 16](https://img.shields.io/badge/Next.js-16-000000?logo=next.js)](https://nextjs.org)
 [![TypeScript strict](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)](tsconfig.json)
 
+[![PowerDNS 4.6](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-46.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-46.yml)
+[![PowerDNS 4.7](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-47.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-47.yml)
+[![PowerDNS 4.8](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-48.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-48.yml)
+[![PowerDNS 4.9](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-49.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-49.yml)
+[![PowerDNS 5.0](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-50.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-50.yml)
+
 PowerDNS-AuthAdmin manages one or many PowerDNS Authoritative backends from a single web app. It
 ships with a permissive RBAC engine, OIDC single sign-on with group→role mapping, transactional
 zone editing, NOTIFY-aware sync probes for cluster + primary/secondary topologies, an append-only
@@ -320,26 +326,6 @@ npm run validate                   # lint + typecheck + format + test
 ```
 
 Full workflow + troubleshooting in [`docs/dev-setup.md`](./docs/dev-setup.md).
-
-## PowerDNS Authoritative compatibility
-
-The full end-to-end suite runs against every supported official PowerDNS
-Authoritative image — one workflow per version, so each badge below is the **live**
-GitHub Actions status of that version's last run (no manual updates). They run on
-every minor/major release tag (`vX.Y.0`), monthly to catch upstream `:latest` drift,
-and on demand — not on every push, so the matrix stays honest without slowing PR CI.
-
-[![PowerDNS 4.6](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-46.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-46.yml)
-[![PowerDNS 4.7](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-47.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-47.yml)
-[![PowerDNS 4.8](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-48.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-48.yml)
-[![PowerDNS 4.9](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-49.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-49.yml)
-[![PowerDNS 5.0](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-50.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-50.yml)
-
-The same modern-name INI configs and gsqlite3/gmysql schema work unchanged across
-4.6 → 5.0 (4.5 renamed replication settings to primary/secondary, which we use; 5.0
-only dropped the legacy master/slave aliases and added an optional YAML config it
-still reads old-style INI alongside). Older majors aren't tested; newer ones are
-added to the matrix as they ship.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 > audit log with diffs, SSO with group-driven role mapping, optimistic concurrency in the editor,
 > and a UI built for teams that actually run multi-backend infrastructure.
 
-[![CI](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/ci.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/ci.yml)
+[![CI](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/ci.yml?query=branch%3Amain)
 [![Release](https://img.shields.io/github/v/release/PowerDNS-AuthAdmin/powerdns-authadmin)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/releases/latest)
 [![Container: GHCR](https://img.shields.io/badge/ghcr.io-powerdns--authadmin-2496ED?logo=docker&logoColor=white)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/pkgs/container/powerdns-authadmin)
 [![GHCR version](https://ghcr-badge.egpl.dev/powerdns-authadmin/powerdns-authadmin/latest_tag?ignore=latest,edge&label=ghcr.io&color=%232ea44f)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/pkgs/container/powerdns-authadmin)


### PR DESCRIPTION
Bundled CI + README housekeeping (all CI/docs, no app code).

### CI
- The Scorecard workflow referenced `ossf/scorecard-action@v2` (no floating `v2`
  tag exists) — the post-merge run failed at *Set up job*. Pinned to the **v2.4.3
  commit SHA** (`4eaacf0…`), which also clears CodeQL's "unpinned Action" alert.

### README
- **CI badge** pinned to `?branch=main` (badge) + `?query=branch:main` (link) so it
  reflects the default branch, not whichever run — including PR runs — was latest.
- **PowerDNS compatibility matrix** moved into the top badge block; removed the
  standalone section's header + prose (the live per-version badges are
  self-describing).