### PR TITLE
fix(db): real transactions on the SQLite path (atomic write+audit)

### DIFF
--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -29,6 +29,7 @@ import Database from "better-sqlite3";
 import pg from "pg";
 import { env } from "@/lib/env";
 import { dialect } from "./_dialect";
+import { createSqliteTransactionRunner } from "./sqlite-transaction";
 import * as schema from "@/lib/db/schema";
 
 type PgPool = InstanceType<typeof pg.Pool>;
@@ -92,15 +93,15 @@ function buildBundle(): DbBundle {
     // ("Transaction function cannot return a promise"). The app's write+audit
     // pattern is async (it awaits the mutation, then `appendAudit`, inside one
     // `db.transaction(async (tx) => …)`) and is used by ~46 call sites plus the
-    // seed/provision boot scripts — all of which throw on SQLite otherwise.
-    // Override `transaction` to run the async callback directly on the
-    // connection. Tradeoff: SQLite loses strict multi-statement atomicity for
-    // these writes (statements autocommit individually). That's an acceptable
-    // cost for the lightweight, single-writer SQLite option; Postgres (the
-    // production path) keeps full transactional atomicity via node-postgres.
-    const runDirect = ((callback: (tx: AppDatabase) => unknown) =>
-      callback(sqliteDb)) as unknown as AppDatabase["transaction"];
-    sqliteDb.transaction = runDirect;
+    // seed/provision boot scripts. Replace `transaction` with a runner that
+    // wraps the async callback in a real BEGIN/COMMIT/ROLLBACK (serialized,
+    // since one connection can't hold overlapping transactions) so the mutation
+    // and its audit row commit atomically — matching the Postgres path. See
+    // ./sqlite-transaction.ts for the serialization + nesting details.
+    sqliteDb.transaction = createSqliteTransactionRunner(
+      handle,
+      sqliteDb,
+    ) as unknown as AppDatabase["transaction"];
 
     return { db: sqliteDb, pool: null, sqliteHandle: handle };
   }

--- a/lib/db/sqlite-transaction.test.ts
+++ b/lib/db/sqlite-transaction.test.ts
@@ -1,0 +1,222 @@
+/**
+ * lib/db/sqlite-transaction.test.ts
+ *
+ * The portable cases drive a fake exec-handle that records the SQL it's asked
+ * to run, so they assert the BEGIN/COMMIT/ROLLBACK ordering, top-level
+ * serialization, and SAVEPOINT nesting without a native module — they run in
+ * any environment.
+ *
+ * The final block opens a real in-memory better-sqlite3 database to prove
+ * genuine atomicity (a thrown callback leaves no rows; concurrent "single
+ * default" writers converge on exactly one). It's skipped where the native
+ * binding can't load (e.g. an ABI mismatch in a dev sandbox); CI runs it.
+ */
+
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+import type DatabaseDefault from "better-sqlite3";
+import { createSqliteTransactionRunner } from "./sqlite-transaction";
+
+function fakeHandle() {
+  const calls: string[] = [];
+  return {
+    calls,
+    exec(sql: string) {
+      calls.push(sql);
+    },
+  };
+}
+
+const DB = { marker: "db" } as const;
+
+describe("createSqliteTransactionRunner (fake handle)", () => {
+  it("wraps a successful callback in BEGIN/COMMIT and returns its result", async () => {
+    const h = fakeHandle();
+    const run = createSqliteTransactionRunner(h, DB);
+
+    const result = await run((tx) => {
+      expect(tx).toBe(DB); // callback receives the db handle
+      return "ok";
+    });
+
+    expect(result).toBe("ok");
+    expect(h.calls).toEqual(["BEGIN", "COMMIT"]);
+  });
+
+  it("rolls back and rethrows when the callback throws", async () => {
+    const h = fakeHandle();
+    const run = createSqliteTransactionRunner(h, DB);
+
+    await expect(
+      run(() => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(h.calls).toEqual(["BEGIN", "ROLLBACK"]);
+  });
+
+  it("swallows a ROLLBACK error so the original error propagates", async () => {
+    const calls: string[] = [];
+    const h = {
+      exec(sql: string) {
+        calls.push(sql);
+        // SQLite may have already auto-rolled-back on a constraint error.
+        if (sql === "ROLLBACK") throw new Error("no transaction is active");
+      },
+    };
+    const run = createSqliteTransactionRunner(h, DB);
+
+    await expect(run(() => Promise.reject(new Error("constraint")))).rejects.toThrow("constraint");
+    expect(calls).toEqual(["BEGIN", "ROLLBACK"]);
+  });
+
+  it("serializes top-level transactions (never two open at once)", async () => {
+    const h = fakeHandle();
+    const run = createSqliteTransactionRunner(h, DB);
+
+    let release1!: () => void;
+    const gate1 = new Promise<void>((resolve) => {
+      release1 = resolve;
+    });
+
+    const order: string[] = [];
+    const t1 = run(async () => {
+      order.push("t1-start");
+      await gate1; // hold the first transaction open
+      order.push("t1-end");
+    });
+    const t2 = run(() => {
+      order.push("t2-start");
+    });
+
+    // While t1 holds the transaction, t2's callback must not have run and no
+    // second BEGIN may have been issued.
+    await Promise.resolve();
+    expect(order).toEqual(["t1-start"]);
+    expect(h.calls.filter((c) => c === "BEGIN")).toHaveLength(1);
+
+    release1();
+    await Promise.all([t1, t2]);
+
+    expect(order).toEqual(["t1-start", "t1-end", "t2-start"]);
+    // Strictly serialized — never BEGIN,BEGIN.
+    expect(h.calls).toEqual(["BEGIN", "COMMIT", "BEGIN", "COMMIT"]);
+  });
+
+  it("uses a SAVEPOINT for a nested transaction and commits both", async () => {
+    const h = fakeHandle();
+    const run = createSqliteTransactionRunner(h, DB);
+
+    const result = await run(async () => {
+      const inner = (await run(() => "inner")) as string; // nested call on the same runner
+      return `${inner}/outer`;
+    });
+
+    expect(result).toBe("inner/outer");
+    expect(h.calls).toEqual([
+      "BEGIN",
+      "SAVEPOINT app_sp_1",
+      "RELEASE SAVEPOINT app_sp_1",
+      "COMMIT",
+    ]);
+  });
+
+  it("rolls back only the inner SAVEPOINT when a nested transaction fails", async () => {
+    const h = fakeHandle();
+    const run = createSqliteTransactionRunner(h, DB);
+
+    const result = await run(async () => {
+      try {
+        await run(() => {
+          throw new Error("inner-fail");
+        });
+      } catch {
+        // outer recovers and still commits
+      }
+      return "outer-ok";
+    });
+
+    expect(result).toBe("outer-ok");
+    expect(h.calls).toEqual([
+      "BEGIN",
+      "SAVEPOINT app_sp_1",
+      "ROLLBACK TO SAVEPOINT app_sp_1",
+      "RELEASE SAVEPOINT app_sp_1",
+      "COMMIT",
+    ]);
+  });
+});
+
+// --- Real better-sqlite3 (CI; skipped where the native binding can't load) ---
+type DatabaseCtorType = typeof DatabaseDefault;
+let DatabaseCtor: DatabaseCtorType | null = null;
+try {
+  const ctor = createRequire(import.meta.url)("better-sqlite3") as DatabaseCtorType;
+  // The JS wrapper requires fine, but the native binding only loads on first
+  // instantiation — so probe it here. An ABI mismatch (dev sandbox) then skips
+  // the suite instead of failing it; CI's matching ABI runs it.
+  new ctor(":memory:").close();
+  DatabaseCtor = ctor;
+} catch {
+  DatabaseCtor = null;
+}
+
+describe.skipIf(DatabaseCtor === null)(
+  "createSqliteTransactionRunner (real better-sqlite3)",
+  () => {
+    const Database = DatabaseCtor!;
+
+    it("commits a successful transaction and rolls back a thrown one", async () => {
+      const handle = new Database(":memory:");
+      handle.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+      const run = createSqliteTransactionRunner(handle, handle);
+
+      await run((tx) => {
+        tx.prepare("INSERT INTO t (v) VALUES (?)").run("a");
+      });
+      expect((handle.prepare("SELECT COUNT(*) AS c FROM t").get() as { c: number }).c).toBe(1);
+
+      await expect(
+        run((tx) => {
+          tx.prepare("INSERT INTO t (v) VALUES (?)").run("b");
+          throw new Error("rollback me");
+        }),
+      ).rejects.toThrow("rollback me");
+      // The "b" insert must have been rolled back — still exactly one row.
+      expect((handle.prepare("SELECT COUNT(*) AS c FROM t").get() as { c: number }).c).toBe(1);
+
+      handle.close();
+    });
+
+    it("keeps the single-default invariant under concurrent writers", async () => {
+      const handle = new Database(":memory:");
+      handle.exec(
+        "CREATE TABLE backends (id INTEGER PRIMARY KEY, is_default INTEGER NOT NULL DEFAULT 0)",
+      );
+      handle.exec("INSERT INTO backends (id, is_default) VALUES (1, 1)");
+      const run = createSqliteTransactionRunner(handle, handle);
+
+      // Two concurrent "make me the only default" writers. With real, serialized
+      // transactions the clear-then-set runs atomically, so exactly one row is
+      // default afterwards (the no-op override could leave zero or two).
+      const setDefault = (id: number) =>
+        run((tx) => {
+          tx.prepare("UPDATE backends SET is_default = 0 WHERE is_default = 1").run();
+          tx.prepare("INSERT INTO backends (id, is_default) VALUES (?, 1)").run(id);
+        });
+
+      await Promise.all([setDefault(2), setDefault(3)]);
+
+      expect(
+        (
+          handle.prepare("SELECT COUNT(*) AS c FROM backends WHERE is_default = 1").get() as {
+            c: number;
+          }
+        ).c,
+      ).toBe(1);
+
+      handle.close();
+    });
+  },
+);

--- a/lib/db/sqlite-transaction.ts
+++ b/lib/db/sqlite-transaction.ts
@@ -1,0 +1,111 @@
+/**
+ * lib/db/sqlite-transaction.ts
+ *
+ * Real BEGIN/COMMIT/ROLLBACK transactions for the better-sqlite3 path.
+ *
+ * better-sqlite3's own `transaction()` helper is synchronous and rejects an
+ * async callback ("Transaction function cannot return a promise"). The app's
+ * write+audit pattern is `db.transaction(async (tx) => …)` (~46 call sites),
+ * so we can't hand the callback to it directly. This wraps the async callback
+ * in an explicit transaction on the raw connection, restoring the atomicity
+ * the DbExecutor pattern (mutation + `appendAudit` committing together) and the
+ * "exactly one default backend" invariant depend on. Previously `transaction`
+ * was a no-op that ran the callback with no transaction boundary, so each
+ * statement autocommitted and a failed `appendAudit` left the mutation
+ * committed with no audit trail.
+ *
+ * Serialization: one SQLite connection cannot hold two overlapping
+ * transactions, and the callbacks are async, so two requests could otherwise
+ * interleave their BEGIN/COMMIT across `await` points. Top-level transactions
+ * are therefore queued through a promise chain and run strictly one at a time —
+ * which is also SQLite's real concurrency model (a single writer). In practice
+ * the callbacks only `await` better-sqlite3 queries, which resolve
+ * synchronously, so nothing interleaves mid-transaction anyway; the chain is
+ * belt-and-suspenders that also keeps a genuinely-async callback safe.
+ *
+ * Nesting: a callback that itself calls `db.transaction` would deadlock on the
+ * chain (it would await a promise that can't settle until the callback
+ * returns), so a nested call takes a SAVEPOINT and skips the chain. No call
+ * site nests today; this keeps a future one correct. Detection assumes a
+ * transaction callback never `await`s non-DB async work (true for this
+ * codebase), so a concurrent top-level call is never mistaken for a nested one.
+ */
+
+/** The slice of the better-sqlite3 connection this needs. */
+export interface SqliteExecHandle {
+  exec(sql: string): unknown;
+}
+
+/**
+ * Build a drop-in replacement for Drizzle's `db.transaction` on the
+ * better-sqlite3 driver. The caller casts the result to the Drizzle
+ * `transaction` signature; the runtime contract is `(callback) => Promise`.
+ */
+export function createSqliteTransactionRunner<TDb>(
+  handle: SqliteExecHandle,
+  db: TDb,
+): (callback: (tx: TDb) => unknown) => Promise<unknown> {
+  // The tail of the serialized transaction chain. Each new top-level
+  // transaction chains onto it so they never overlap on the single connection.
+  let tail: Promise<unknown> = Promise.resolve();
+  // 0 = no transaction in flight; >0 = inside a transaction callback (the value
+  // is the current nesting level, used to name SAVEPOINTs uniquely).
+  let depth = 0;
+
+  return (callback) => {
+    // Nested: we're already inside a transaction callback on this connection
+    // (the BEGIN is open). Use a SAVEPOINT for partial-rollback semantics and
+    // skip the chain — re-entering it would deadlock.
+    if (depth > 0) {
+      const savepoint = `app_sp_${depth}`;
+      depth += 1;
+      const runNested = async () => {
+        handle.exec(`SAVEPOINT ${savepoint}`);
+        try {
+          const result = await callback(db);
+          handle.exec(`RELEASE SAVEPOINT ${savepoint}`);
+          return result;
+        } catch (err) {
+          handle.exec(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+          handle.exec(`RELEASE SAVEPOINT ${savepoint}`);
+          throw err;
+        } finally {
+          depth -= 1;
+        }
+      };
+      return runNested();
+    }
+
+    const runTop = async () => {
+      depth = 1;
+      handle.exec("BEGIN");
+      try {
+        const result = await callback(db);
+        handle.exec("COMMIT");
+        return result;
+      } catch (err) {
+        // A constraint violation can make SQLite auto-rollback the transaction;
+        // a follow-up ROLLBACK then throws "cannot rollback - no transaction is
+        // active". Swallow that so the original error is what propagates.
+        try {
+          handle.exec("ROLLBACK");
+        } catch {
+          /* transaction already rolled back by SQLite */
+        }
+        throw err;
+      } finally {
+        depth = 0;
+      }
+    };
+
+    // Run after any in-flight transaction settles, success or failure.
+    const result = tail.then(runTop, runTop);
+    // Keep the chain alive without forwarding this transaction's result/error
+    // to the next link (each caller awaits its own `result`).
+    tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+}


### PR DESCRIPTION
## Summary

Fixes #5. On the better-sqlite3 path, `db.transaction()` was overridden to a
**no-op** — it ran the async callback directly with no `BEGIN`/`COMMIT`, so
every statement autocommitted individually. Consequences:

- A mutation whose follow-up `appendAudit` insert threw was committed with **no
  audit trail**, defeating the append-on-every-write guarantee (the DbExecutor
  pattern) on SQLite.
- `insertPdnsServer`/`updatePdnsServer`'s clear-then-set could be observed with
  zero or two defaults; `syncBackendAdvisories` lost its delete+upsert snapshot.

This held on Postgres (real pooled transactions) but silently not on SQLite.

## Fix

New `lib/db/sqlite-transaction.ts` → `createSqliteTransactionRunner(handle, db)`
wraps the async callback in a real `BEGIN`/`COMMIT`/`ROLLBACK` on the
connection. Since one SQLite connection can't hold overlapping transactions and
the callbacks are async, **top-level transactions are serialized through a
promise chain** — SQLite's actual single-writer model. A **nested** call takes a
`SAVEPOINT` (skipping the chain, which it would otherwise deadlock on). The
callback contract — only awaiting DB work, never nesting today — is documented
in the module.

## Test

- **Portable** (fake exec-handle, runs anywhere): asserts BEGIN/COMMIT on
  success, ROLLBACK + rethrow on throw, a swallowed ROLLBACK error, strict
  serialization (never two open at once), and SAVEPOINT nesting incl.
  rollback-to-savepoint.
- **Real `:memory:` better-sqlite3** (runs in CI; auto-skips on an ABI mismatch
  in a dev sandbox): a thrown callback leaves zero rows; two concurrent
  single-default writers converge on exactly one default row.

Closes #5