### PR TITLE
fix(db): backend_advisories first/last_seen_at default parity on SQLite

### DIFF
--- a/lib/db/schema-sqlite/backend-advisories.ts
+++ b/lib/db/schema-sqlite/backend-advisories.ts
@@ -18,8 +18,12 @@ export const backendAdvisories = sqliteTable(
     severity: text("severity").notNull(),
     title: text("title").notNull(),
     detail: text("detail").notNull(),
-    firstSeenAt: integer("first_seen_at", { mode: "timestamp_ms" }).notNull().$defaultFn(() => new Date()),
-    lastSeenAt: integer("last_seen_at", { mode: "timestamp_ms" }).notNull().$defaultFn(() => new Date()),
+    firstSeenAt: integer("first_seen_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    lastSeenAt: integer("last_seen_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(() => new Date()),
     acknowledgedAt: integer("acknowledged_at", { mode: "timestamp_ms" }),
   },
   (t) => ({

--- a/lib/db/schema-sqlite/backend-advisories.ts
+++ b/lib/db/schema-sqlite/backend-advisories.ts
@@ -18,8 +18,8 @@ export const backendAdvisories = sqliteTable(
     severity: text("severity").notNull(),
     title: text("title").notNull(),
     detail: text("detail").notNull(),
-    firstSeenAt: integer("first_seen_at", { mode: "timestamp_ms" }).notNull(),
-    lastSeenAt: integer("last_seen_at", { mode: "timestamp_ms" }).notNull(),
+    firstSeenAt: integer("first_seen_at", { mode: "timestamp_ms" }).notNull().$defaultFn(() => new Date()),
+    lastSeenAt: integer("last_seen_at", { mode: "timestamp_ms" }).notNull().$defaultFn(() => new Date()),
     acknowledgedAt: integer("acknowledged_at", { mode: "timestamp_ms" }),
   },
   (t) => ({

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/jadseifeddine/Documents/GitHub/PowerDNS-AuthUI/node_modules


### PR DESCRIPTION
## Summary

Fixes #7. On Postgres, `backend_advisories.first_seen_at` / `last_seen_at` have
`.defaultNow()`, but the parallel SQLite schema declared them `notNull()` with
**no default** — so an insert that relied on the DB to stamp the timestamps
behaved differently (or failed) on the SQLite path.

Add `$defaultFn(() => new Date())` to both columns on the SQLite schema, matching
the Postgres behavior. `$defaultFn` is an application-level default (Drizzle
fills it at insert time), so it emits no DDL — no migration is generated.

Closes #7