### PR TITLE
fix(pdns): pin guard-validated IP into the request (DNS-rebinding)

### DIFF
--- a/docs/03-CONFIGURATION.md
+++ b/docs/03-CONFIGURATION.md
@@ -102,9 +102,10 @@ group → role mapping** — that requires a DB provider.
 
 ## PowerDNS connectivity (SSRF guard)
 
-The app re-resolves backend hostnames before each request as a DNS-rebinding
-defense. Link-local addresses (incl. the `169.254.169.254` cloud-metadata IP) are
-**always** blocked. See [Connecting PowerDNS backends](./04-BACKENDS.md).
+The app re-resolves backend hostnames before each request and pins the validated
+IP into the connection as a DNS-rebinding defense. Link-local addresses (incl. the
+`169.254.169.254` cloud-metadata IP) are **always** blocked. See
+[Connecting PowerDNS backends](./04-BACKENDS.md).
 
 | Variable                          | Default                                 | Notes                                                                                               |
 | --------------------------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------- |

--- a/docs/04-BACKENDS.md
+++ b/docs/04-BACKENDS.md
@@ -46,7 +46,10 @@ client.
 ## The SSRF guard
 
 The app refuses backend URLs that could be used to reach internal services, and
-**re-resolves the hostname before every request** as a DNS-rebinding defense.
+**re-resolves the hostname before every request** as a DNS-rebinding defense. The
+validated address is then **pinned into the connection** — the request reaches the
+exact IP the guard checked, so a hostile resolver can't hand a safe IP to the guard
+and a private one to the HTTP client between the two lookups.
 
 - **Link-local addresses are always blocked**, including the
   `169.254.169.254` cloud-metadata endpoint — no flag overrides this.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -219,7 +219,11 @@ can jump straight into the code that owns each feature.
 - **What.** Config-time + runtime IP-range checks on PDNS `base_url`. Link-local
   (incl. 169.254.169.254 cloud metadata) is always blocked. Private networks gated by
   `APP_PDNS_ALLOW_PRIVATE_NETWORKS`; `http://` gated by `APP_PDNS_ALLOW_INSECURE_HTTP`.
-- **Where.** `lib/pdns/url-safety.ts`.
+  At request time the guard re-resolves the host and **pins the validated IP into
+  the connection**, so undici reaches the exact address the guard checked (closes
+  the DNS-rebinding window).
+- **Where.** `lib/pdns/url-safety.ts` (the guard); `lib/pdns/http.ts` (request-time
+  re-check + pinned dispatcher).
 
 ---
 

--- a/lib/pdns/dispatcher.ts
+++ b/lib/pdns/dispatcher.ts
@@ -1,7 +1,7 @@
 /**
  * lib/pdns/dispatcher.ts
  *
- * Shared undici Agent used by every PdnsClient instance. Configured to:
+ * undici Agent configuration for every PDNS-facing request. The options are:
  *
  *   - **Negotiate HTTP/2 via ALPN** (`allowH2: true`). Some upstream PDNS
  *     deployments live behind a Cloudflare / nginx / Envoy front that
@@ -17,8 +17,10 @@
  *     own `AbortController` is the authoritative timeout — these are belt-
  *     and-braces.
  *
- * One Agent serves every backend; undici's pool keys by origin so this is
- * still per-host pooling under the hood.
+ * `http.ts` builds a per-request Agent from {@link PDNS_AGENT_OPTIONS} with a
+ * pinned `connect.lookup` (DNS-rebinding defense), so the long-lived shared
+ * Agent from {@link pdnsDispatcher} is not on the live request path; it remains
+ * for callers that want a pooled dispatcher without per-request address pinning.
  */
 
 import "server-only";
@@ -27,17 +29,25 @@ import { Agent } from "undici";
 let dispatcher: Agent | null = null;
 
 /**
+ * Shared timeout/protocol options for every PDNS-facing Agent. Exported so the
+ * per-request DNS-rebinding-pinned Agent in `http.ts` inherits the exact same
+ * TLS/H2 negotiation and timeout behavior as the shared pool — the only
+ * difference between the two is the pinned `connect.lookup`.
+ */
+export const PDNS_AGENT_OPTIONS: Agent.Options = {
+  allowH2: true,
+  keepAliveTimeout: 30_000,
+  keepAliveMaxTimeout: 600_000,
+  connectTimeout: 10_000,
+  headersTimeout: 30_000,
+  bodyTimeout: 30_000,
+};
+
+/**
  * Lazily build the shared Agent on first use. Lazy because constructing it at
  * module-load time fires before env validation in some test scenarios.
  */
 export function pdnsDispatcher(): Agent {
-  dispatcher ??= new Agent({
-    allowH2: true,
-    keepAliveTimeout: 30_000,
-    keepAliveMaxTimeout: 600_000,
-    connectTimeout: 10_000,
-    headersTimeout: 30_000,
-    bodyTimeout: 30_000,
-  });
+  dispatcher ??= new Agent(PDNS_AGENT_OPTIONS);
   return dispatcher;
 }

--- a/lib/pdns/http.test.ts
+++ b/lib/pdns/http.test.ts
@@ -127,7 +127,24 @@ describe("pdns http transport — DNS-rebinding pinning (issue #10)", () => {
     // the guard-validated PUBLIC IP — NOT trigger a fresh DNS query that would
     // hand back the rebind loopback address.
     const before = dnsCallCount;
-    const pinned = await new Promise<{ address: unknown; family: number | undefined }>(
+
+    // Node's net.connect uses Happy Eyeballs by default, calling lookup with
+    // `{ all: true }` and expecting an ARRAY of { address, family }. This is the
+    // form that actually flows at connect time, so assert it returns the pinned
+    // address in array shape (a single-form-only lookup would hand undici
+    // `undefined` here and the real connect would fail).
+    const pinnedAll = await new Promise<Array<{ address: string; family: number }>>(
+      (resolve, reject) => {
+        lookup!("pdns.example.test", { all: true }, (err, address) => {
+          if (err) reject(err);
+          else resolve(address as unknown as Array<{ address: string; family: number }>);
+        });
+      },
+    );
+    expect(pinnedAll).toEqual([{ address: PUBLIC_IP, family: 4 }]);
+
+    // The single-address form (all:false / legacy callers) must also pin.
+    const pinnedSingle = await new Promise<{ address: unknown; family: number | undefined }>(
       (resolve, reject) => {
         lookup!("pdns.example.test", {}, (err, address, family) => {
           if (err) reject(err);
@@ -135,8 +152,9 @@ describe("pdns http transport — DNS-rebinding pinning (issue #10)", () => {
         });
       },
     );
-    expect(pinned.address).toBe(PUBLIC_IP);
-    expect(pinned.family).toBe(4);
+    expect(pinnedSingle.address).toBe(PUBLIC_IP);
+    expect(pinnedSingle.family).toBe(4);
+
     // No second resolution happened — the address is pinned, not re-fetched.
     expect(dnsCallCount).toBe(before);
 

--- a/lib/pdns/http.test.ts
+++ b/lib/pdns/http.test.ts
@@ -1,0 +1,167 @@
+/**
+ * lib/pdns/http.test.ts
+ *
+ * Regression test for the DNS-rebinding hardening (issue #10): the PDNS
+ * transport must PIN the address its SSRF guard validated into the actual
+ * connect, so undici cannot independently re-resolve the hostname to a
+ * different (blocked) IP between the guard's lookup and the socket connect.
+ *
+ * Strategy — fully hermetic, no network:
+ *   - Stub `node:dns` so the guard's resolution and a hypothetical second
+ *     resolution return DIFFERENT addresses (a public IP first, a loopback IP
+ *     after — the classic 0-TTL rebind).
+ *   - Capture the `connect.lookup` undici is handed (via the Agent ctor) and
+ *     prove it returns the FIRST (guard-validated) address — i.e. the connect
+ *     is pinned and never consults DNS a second time.
+ *   - A second test drives the guard to reject when the (single) current
+ *     resolution lands in a blocked range, confirming the request never fires.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LookupFunction } from "node:net";
+import type * as EnvModule from "@/lib/env";
+
+const PUBLIC_IP = "203.0.113.10"; // TEST-NET-3, globally routable + guard-safe
+const REBIND_IP = "127.0.0.1"; // loopback — blocked unless private allowed
+
+// A resolver that hands out a different answer on each call: the guard sees the
+// safe public IP; any *later* independent lookup (what undici would do without
+// pinning) would get the loopback address.
+let dnsCallCount = 0;
+const lookupAll = vi.fn();
+
+vi.mock("node:dns", () => {
+  const lookup = (
+    _host: string,
+    _opts: unknown,
+  ): Promise<Array<{ address: string; family: number }>> => {
+    return lookupAll(_host, _opts) as Promise<Array<{ address: string; family: number }>>;
+  };
+  return { promises: { lookup } };
+});
+
+// Capture what the per-request Agent is constructed with so we can invoke the
+// pinned `connect.lookup` directly, and stub `fetch` so no socket is opened.
+const agentCtor = vi.fn();
+const fetchMock = vi.fn();
+
+vi.mock("undici", () => {
+  class FakeAgent {
+    public readonly opts: unknown;
+    constructor(opts: unknown) {
+      this.opts = opts;
+      agentCtor(opts);
+    }
+    close(): Promise<void> {
+      return Promise.resolve();
+    }
+  }
+  return {
+    Agent: FakeAgent,
+    fetch: (...args: unknown[]) => fetchMock(...args) as unknown,
+  };
+});
+
+// Keep the audit recorder out of the test (it transitively pulls the DB layer).
+vi.mock("./request-log", () => ({ recordPdnsRequest: vi.fn() }));
+
+// Force the permissive-private policy off so a rebind to loopback is "blocked"
+// — the harder, security-relevant configuration.
+vi.mock("@/lib/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof EnvModule>();
+  return {
+    ...actual,
+    isProduction: false,
+    env: {
+      ...actual.env,
+      APP_PDNS_ALLOW_PRIVATE_NETWORKS: false,
+      APP_PDNS_ALLOW_INSECURE_HTTP: true,
+    },
+  };
+});
+
+function lookupResultFor(): Array<{ address: string; family: number }> {
+  dnsCallCount += 1;
+  // First call (the guard) → public IP; any subsequent call → rebind to loopback.
+  return dnsCallCount === 1
+    ? [{ address: PUBLIC_IP, family: 4 }]
+    : [{ address: REBIND_IP, family: 4 }];
+}
+
+describe("pdns http transport — DNS-rebinding pinning (issue #10)", () => {
+  beforeEach(() => {
+    dnsCallCount = 0;
+    agentCtor.mockClear();
+    fetchMock.mockReset();
+    lookupAll.mockReset();
+    lookupAll.mockImplementation(() => Promise.resolve(lookupResultFor()));
+    fetchMock.mockResolvedValue({
+      status: 200,
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ ok: true })),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("pins the guard-validated address into the request's connect.lookup", async () => {
+    const { pdnsRequest } = await import("./http");
+
+    await pdnsRequest(
+      { baseUrl: "http://pdns.example.test:8081", apiKey: "k", serverSlug: "s" },
+      { method: "GET", path: "/api/v1/servers", op: "test.pin" },
+    );
+
+    // The guard resolved exactly once.
+    expect(dnsCallCount).toBe(1);
+
+    // undici got a per-request Agent carrying a pinned lookup.
+    expect(agentCtor).toHaveBeenCalledTimes(1);
+    const opts = agentCtor.mock.calls[0]?.[0] as { connect?: { lookup?: LookupFunction } };
+    const lookup = opts.connect?.lookup;
+    expect(typeof lookup).toBe("function");
+
+    // Invoking the pinned lookup (what undici does at connect time) must return
+    // the guard-validated PUBLIC IP — NOT trigger a fresh DNS query that would
+    // hand back the rebind loopback address.
+    const before = dnsCallCount;
+    const pinned = await new Promise<{ address: unknown; family: number | undefined }>(
+      (resolve, reject) => {
+        lookup!("pdns.example.test", {}, (err, address, family) => {
+          if (err) reject(err);
+          else resolve({ address, family });
+        });
+      },
+    );
+    expect(pinned.address).toBe(PUBLIC_IP);
+    expect(pinned.family).toBe(4);
+    // No second resolution happened — the address is pinned, not re-fetched.
+    expect(dnsCallCount).toBe(before);
+
+    // The fetch itself targeted the original hostname (Host header / SNI stay
+    // the hostname; only the connect address is pinned).
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+    expect(calledUrl).toContain("pdns.example.test");
+  });
+
+  it("refuses the request when the current resolution lands in a blocked range", async () => {
+    // Every resolution returns loopback → guard must reject before any fetch.
+    lookupAll.mockImplementation(() => Promise.resolve([{ address: REBIND_IP, family: 4 }]));
+
+    const { pdnsRequest } = await import("./http");
+
+    await expect(
+      pdnsRequest(
+        { baseUrl: "http://pdns.example.test:8081", apiKey: "k", serverSlug: "s" },
+        { method: "GET", path: "/api/v1/servers", op: "test.block" },
+      ),
+    ).rejects.toThrow(/unsafe URL/i);
+
+    // The guard short-circuited: no Agent built, no fetch attempted.
+    expect(agentCtor).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/lib/pdns/http.ts
+++ b/lib/pdns/http.ts
@@ -333,12 +333,23 @@ function pinnedDispatcher(addresses: string[]): Agent {
   const pinned = addresses.find((addr) => isIP(addr) === 4) ?? addresses[0];
   const family = pinned !== undefined ? isIP(pinned) : 0;
 
-  const lookup: LookupFunction = (_hostname, _options, callback) => {
+  const lookup: LookupFunction = (_hostname, options, callback) => {
     if (pinned === undefined) {
       callback(new Error("no validated address to pin"), "", 0);
       return;
     }
-    callback(null, pinned, family);
+    // Node's net.connect uses Happy Eyeballs (`autoSelectFamily`, default-on in
+    // Node 20+), which calls `lookup` with `{ all: true }` and expects an ARRAY
+    // of { address, family }; other callers use the single (err, address,
+    // family) form. Support both — handing the single form to an all:true caller
+    // leaves the address `undefined`, so the connect fails with "Invalid IP
+    // address: undefined" (the regression real undici hits but a direct unit
+    // call does not).
+    if (options.all === true) {
+      callback(null, [{ address: pinned, family }]);
+    } else {
+      callback(null, pinned, family);
+    }
   };
 
   return new Agent({ ...PDNS_AGENT_OPTIONS, connect: { lookup } });

--- a/lib/pdns/http.ts
+++ b/lib/pdns/http.ts
@@ -17,11 +17,13 @@
  */
 
 import "server-only";
-import { fetch as undiciFetch } from "undici";
+import { isIP } from "node:net";
+import type { LookupFunction } from "node:net";
+import { Agent, fetch as undiciFetch } from "undici";
 import { logger } from "@/lib/logger";
 import { redact } from "@/lib/errors/redact";
 import { PdnsError, PdnsUpstreamError, classifyPdnsHttpError } from "./errors";
-import { pdnsDispatcher } from "./dispatcher";
+import { PDNS_AGENT_OPTIONS } from "./dispatcher";
 import { recordPdnsLatency } from "./observations";
 import { withBackendLock } from "./backend-lock";
 import { checkPdnsUrlSafe } from "./url-safety";
@@ -227,17 +229,13 @@ async function singleRequest<T>(args: SingleRequestArgs): Promise<T> {
   };
 
   // DNS-rebinding defense. The hostname passed config-time safety, but DNS is
-  // mutable — re-resolve immediately before the call and reject if the
-  // current resolution lands in a blocked range. `checkPdnsUrlSafe` itself
-  // looks up the hostname; the resolution result is intentionally NOT pinned
-  // into `undici.fetch` (which performs its own lookup). Pinning would require
-  // a per-request Agent with a custom `connect.lookup`, which defeats the
-  // shared keep-alive connection pool (a real, per-call TLS-handshake cost).
-  // Both lookups go through the OS resolver within a few ms, so a rebind
-  // narrow enough to escape both is not realistic over standard cached
-  // resolvers — an accepted residual risk, not an oversight. The hard
-  // controls below (always-blocked metadata range + `redirect: "error"`)
-  // are what actually close the SSRF vector.
+  // mutable — re-resolve immediately before the call and reject if the current
+  // resolution lands in a blocked range. `checkPdnsUrlSafe` returns the exact
+  // addresses it validated; we PIN one of them into the request (see
+  // `pinnedDispatcher` below) so the peer undici connects to is byte-for-byte
+  // the address the guard checked — closing the rebinding window where undici's
+  // own independent lookup could resolve the same hostname to a different
+  // (blocked) IP between the guard's lookup and the connect.
   const safety = await checkPdnsUrlSafe(url);
   if (!safety.safe) {
     writeAudit(null, `Refusing to call unsafe URL: ${safety.reason}`);
@@ -245,6 +243,11 @@ async function singleRequest<T>(args: SingleRequestArgs): Promise<T> {
       status: 0,
     });
   }
+
+  // `addresses` is non-empty here: the PDNS policy never sets
+  // `treatUnresolvableAsSafe`, so `safe: true` implies at least one validated
+  // address (a literal IP, or the resolved A/AAAA set).
+  const dispatcher = pinnedDispatcher(safety.addresses);
 
   const controller = new AbortController();
   const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
@@ -259,7 +262,7 @@ async function singleRequest<T>(args: SingleRequestArgs): Promise<T> {
     response = await undiciFetch(url, {
       method,
       signal,
-      dispatcher: pdnsDispatcher(),
+      dispatcher,
       headers: outboundHeaders,
       body: body !== undefined ? JSON.stringify(body) : undefined,
       // SSRF guard: never follow redirects. `checkPdnsUrlSafe` validates only
@@ -278,6 +281,13 @@ async function singleRequest<T>(args: SingleRequestArgs): Promise<T> {
     throw new PdnsUpstreamError(redact(message), { status: 0, cause: err });
   } finally {
     clearTimeout(timeoutHandle);
+    // The pinned dispatcher is single-use: it carries this request's validated
+    // address and must not be reused for a hostname that may now resolve
+    // elsewhere. Tear it down once the request settles. `close()` waits for
+    // in-flight work; body bytes are fully drained below before we return, so
+    // closing here (vs. after the read) would race the body — fire-and-forget
+    // and let it drain. A close failure is irrelevant to the caller.
+    void dispatcher.close().catch(() => undefined);
   }
 
   // Audit the completed request once we know the upstream status. We
@@ -297,6 +307,41 @@ async function singleRequest<T>(args: SingleRequestArgs): Promise<T> {
     throw classifyPdnsHttpError(response.status, parsed, redact(message));
   }
   return parsed as T;
+}
+
+/**
+ * Build a single-use undici dispatcher whose `connect.lookup` returns one of
+ * the guard-validated addresses instead of doing its own DNS resolution — so
+ * the connected peer is byte-for-byte the IP `checkPdnsUrlSafe` classified as
+ * safe. This closes the DNS-rebinding window between the guard's lookup and
+ * undici's connect (an attacker-controlled host returning a public IP to the
+ * guard and a private/loopback IP to undici with a 0-TTL record). The original
+ * hostname still flows to undici as Host header + TLS SNI; only the address
+ * resolution is overridden.
+ *
+ * Tradeoff: a per-request Agent forgoes the shared keep-alive/TLS-session pool
+ * (`pdnsDispatcher`), so each call pays a fresh handshake. That cost is
+ * accepted here — pinning is the whole point, and a shared pool can't carry a
+ * per-request pinned address. The Agent mirrors `PDNS_AGENT_OPTIONS` so TLS/H2
+ * negotiation and timeouts match the shared pool exactly.
+ */
+function pinnedDispatcher(addresses: string[]): Agent {
+  // Prefer an IPv4 address when available — matches the OS resolver's common
+  // default and avoids surprising IPv6-only connects in IPv4-only networks.
+  // Any address in the list already passed the guard, so the choice is purely
+  // about reachability, not safety.
+  const pinned = addresses.find((addr) => isIP(addr) === 4) ?? addresses[0];
+  const family = pinned !== undefined ? isIP(pinned) : 0;
+
+  const lookup: LookupFunction = (_hostname, _options, callback) => {
+    if (pinned === undefined) {
+      callback(new Error("no validated address to pin"), "", 0);
+      return;
+    }
+    callback(null, pinned, family);
+  };
+
+  return new Agent({ ...PDNS_AGENT_OPTIONS, connect: { lookup } });
 }
 
 /**


### PR DESCRIPTION
## Problem

The PDNS SSRF guard re-validates the backend URL before every request via `checkPdnsUrlSafe` (re-resolves the host and rejects blocked ranges — good). But `singleRequest` in `lib/pdns/http.ts` then handed the bare **hostname** to `undici.fetch`, which performs its **own independent DNS lookup**. The guard's lookup and undici's lookup weren't pinned to the same address, leaving a DNS-rebinding window: an attacker-controlled host can return a public IP to the guard and a private/loopback IP to undici with a 0-TTL record.

This is residual hardening, not a live bypass — the always-blocked `169.254.0.0/16` metadata range and `redirect: "error"` already close the high-impact vector. But installs that enable `APP_PDNS_ALLOW_PRIVATE_NETWORKS` are weaker, so pinning is worth it.

## Fix

`checkOutboundUrlSafe` already returns the exact addresses it validated (`{ safe: true, addresses }`), so no signature change was needed — `singleRequest` just consumes `safety.addresses`.

- A new per-request `pinnedDispatcher(addresses)` builds a single-use `undici.Agent` whose `connect.lookup` returns one of the **guard-validated** addresses instead of re-resolving. undici therefore connects to byte-for-byte the IP the guard checked. The original hostname still flows as the Host header and TLS SNI; only the address resolution is overridden (undici's connector spreads the `lookup` into `net.connect`/`tls.connect` while keeping `servername`/`host` as the hostname).
- `PDNS_AGENT_OPTIONS` was extracted from `dispatcher.ts` so the pinned Agent mirrors the shared pool's TLS/H2 negotiation and timeouts exactly (`allowH2`, `connectTimeout`, keep-alive/body/headers timeouts).
- The per-request Agent is torn down (`close()`) once the request settles. It forgoes the shared keep-alive/TLS-session pool — an accepted per-call handshake cost, since a shared pool can't carry a per-request pinned address. This tradeoff is called out in the code comment.
- `redirect: "error"` and all other existing controls are unchanged.

## Test

`lib/pdns/http.test.ts` (new, hermetic — no network, mocks `node:dns` + `undici` + the audit recorder):

- **Pinning**: the stubbed resolver returns a safe public IP on the first lookup (the guard) and a loopback IP on any later lookup (the rebind). The test asserts the captured `connect.lookup` returns the validated public IP **without a second resolution** — i.e. undici would connect to the pinned safe address, not the rebound loopback one. It also confirms the fetch URL still carries the original hostname.
- **Block path**: when the current resolution lands in a blocked range (private not allowed), the request is refused before any Agent is built or fetch attempted.

## Validation

`npm run lint`, `npm run typecheck`, `npm run format:check`, and `npm run test` (665 unit tests, incl. the 2 new ones) all pass.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)