### PR TITLE
fix(dashboard): count active sessions in the sampler (KPI was always 0)

### DIFF
--- a/lib/db/repositories/sessions.test.ts
+++ b/lib/db/repositories/sessions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DbExecutor } from "@/lib/db";
+import { countActiveSessions } from "./sessions";
+
+/**
+ * Build a stand-in executor whose `select().from().where()` chain resolves to
+ * `rows`. Casting through `unknown` keeps the test off a live DB without an
+ * `any` (lint forbids it); we only exercise the count-extraction logic, not
+ * Drizzle's SQL generation — that's the integration suite's job.
+ */
+function executorReturning(rows: Array<{ count: number }>): DbExecutor {
+  const where = vi.fn(() => Promise.resolve(rows));
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+  return { select } as unknown as DbExecutor;
+}
+
+describe("countActiveSessions", () => {
+  it("returns the counted active-session total as a number", async () => {
+    await expect(countActiveSessions(executorReturning([{ count: 7 }]))).resolves.toBe(7);
+  });
+
+  it("defaults to 0 when the count query yields no rows", async () => {
+    // A count(*) always returns one row in real SQL, but guard the empty-array
+    // edge so a future query shape change can't surface NaN to the dashboard.
+    await expect(countActiveSessions(executorReturning([]))).resolves.toBe(0);
+  });
+
+  it("coerces a string count (some drivers stringify aggregates) to a number", async () => {
+    const stringy = [{ count: "12" }] as unknown as Array<{ count: number }>;
+    await expect(countActiveSessions(executorReturning(stringy))).resolves.toBe(12);
+  });
+});

--- a/lib/db/repositories/sessions.ts
+++ b/lib/db/repositories/sessions.ts
@@ -11,6 +11,7 @@
 import "server-only";
 import { and, eq, gt, sql } from "drizzle-orm";
 import { db, type DbExecutor } from "@/lib/db";
+import { countStar } from "@/lib/db/sql-dialect";
 import { sessions, type NewSession, type Session } from "@/lib/db/schema";
 
 /** Create a new session row. Returns the persisted row including its id. */
@@ -57,6 +58,22 @@ export async function revokeSessionsForUser(
     .where(eq(sessions.userId, userId))
     .returning({ id: sessions.id });
   return result.length;
+}
+
+/**
+ * Count active sessions app-wide — the metric sampler's source for the
+ * dashboard "Active sessions" KPI + 7-day chart. "Active" == not expired;
+ * revocation is a row DELETE (there is no revoked flag), so a present,
+ * unexpired row is the whole definition — same predicate as
+ * `listSessionsForUser`. The optional executor keeps this unit-testable
+ * without a live DB, mirroring the write helpers above.
+ */
+export async function countActiveSessions(executor: DbExecutor = db): Promise<number> {
+  const rows = await executor
+    .select({ count: countStar() })
+    .from(sessions)
+    .where(gt(sessions.expiresAt, new Date()));
+  return Number(rows[0]?.count ?? 0);
 }
 
 /** List a user's active sessions for the "your sessions" UI. */

--- a/lib/db/schema/metric-samples.ts
+++ b/lib/db/schema/metric-samples.ts
@@ -12,10 +12,11 @@
  *     row uses `serverId = null` for app-wide metrics — simpler than
  *     two tables for the same shape).
  *
- * The sampler in `lib/metrics/sampler.ts` writes rows on-access (triggered
- * by dashboard page loads) rather than via a background scheduler — keeps
- * the data fresh enough for the dashboard without a separate worker
- * deployment. Real prod observability is Prometheus's job.
+ * The sampler in `lib/realtime/zone-poller.ts` writes rows from the poll cycle
+ * (which any SSE subscriber or dashboard page load keeps running) rather than
+ * via a standalone scheduler — keeps the data fresh enough for the dashboard
+ * without a separate worker deployment. Real prod observability is
+ * Prometheus's job.
  */
 
 import {

--- a/lib/realtime/zone-poller.ts
+++ b/lib/realtime/zone-poller.ts
@@ -34,6 +34,7 @@
 
 import "server-only";
 import { listAllActiveBackends, markPdnsServersSeen } from "@/lib/db/repositories/pdns-servers";
+import { countActiveSessions } from "@/lib/db/repositories/sessions";
 import { getPdnsProbeClientForRow } from "@/lib/pdns/registry";
 import { isReadOnlyMirror, isWriteCapable } from "@/lib/pdns/capabilities";
 import { backendAddressSet, resolveMastersToBackendId } from "@/lib/pdns/topology-resolve";
@@ -586,6 +587,13 @@ async function runPollCycle({ full }: { full: boolean }): Promise<void> {
     }
   }
 
+  // One app-wide row per metric tick carries the active-session count
+  // (`serverId = null`) — counted once here, never on the per-backend rows.
+  if (dueForMetric) {
+    const appWide = await appWideMetricRow(sampledAt);
+    if (appWide) metricRows.push(appWide);
+  }
+
   // Single-shot DB writes outside the per-backend Promise.all so a slow
   // insert doesn't block subsequent polls.
   await persistSamples(metricRows, statsRows);
@@ -622,6 +630,36 @@ function statisticsToRows(
     }
   }
   return rows;
+}
+
+/**
+ * Build the single app-wide metric row for this tick — `serverId = null`, with
+ * only `activeSessions` populated (the backend-scoped fields stay null per the
+ * schema's app-wide-row design). Active sessions are an app-wide quantity, so it
+ * is counted ONCE per metric tick and written as one row — never duplicated
+ * across the per-backend rows, which would pollute the series the dashboard
+ * reads. Best-effort: a failed count just drops the app-wide row for this tick
+ * rather than failing the whole sample (the next tick re-samples in 5 min).
+ */
+async function appWideMetricRow(
+  sampledAt: Date,
+): Promise<typeof metricSamples.$inferInsert | null> {
+  try {
+    return {
+      serverId: null,
+      sampledAt,
+      zoneCount: null,
+      latencyP50Ms: null,
+      latencyP95Ms: null,
+      activeSessions: await countActiveSessions(),
+    };
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : "unknown" },
+      "pdns.zone-poller.active-sessions.failed",
+    );
+    return null;
+  }
 }
 
 /** Persist the cycle's time-series rows; chunked + best-effort (see callers). */
@@ -713,6 +751,15 @@ async function sampleTimeSeries(
         "pdns.zone-poller.mark-seen.failed",
       );
     }
+  }
+
+  // The idle and full paths are mutually exclusive per tick (runPollCycle
+  // returns after the idle branch), so emitting the single app-wide row here
+  // too keeps the active-session series flowing while idle without ever
+  // double-writing it within one tick.
+  if (dueForMetric) {
+    const appWide = await appWideMetricRow(sampledAt);
+    if (appWide) metricRows.push(appWide);
   }
   await persistSamples(metricRows, statsRows);
 }


### PR DESCRIPTION
## Root cause

The dashboard **Active sessions** KPI always read `0` and the companion **"Active sessions — last 7 days"** chart was always empty.

The metric sampler in `lib/realtime/zone-poller.ts` wrote `activeSessions: null` on every per-server `metric_samples` row (at both sample sites — the full poll path and the idle stats-only path) and never computed a session count. It also never emitted the **app-wide** row the schema documents (`serverId = null` carries app-wide metrics — `lib/db/schema/metric-samples.ts`). The reader `sessionsSeries` (`lib/db/repositories/dashboard.ts`) filters `isNotNull(metricSamples.activeSessions)`, so the series came back empty and the KPI fell back to `?? 0` (`app/(app)/dashboard/page.tsx`).

## Fix

1. **`lib/db/repositories/sessions.ts`** — add `countActiveSessions()`. "Active" == not expired; revocation is a row DELETE (no revoked flag), so a present, unexpired row is the whole definition — same predicate as `listSessionsForUser`. Uses the dialect-safe `countStar()` (PG `::int`, SQLite plain count), and takes an optional `DbExecutor` (mirroring the file's write helpers) so it's unit-testable without a live DB.

2. **`lib/realtime/zone-poller.ts`** — count active sessions **once per metric tick** and write **one** app-wide `metric_samples` row (`serverId = null`; `zoneCount`/`latencyP50Ms`/`latencyP95Ms` left null per the schema's app-wide-row design; only `activeSessions` set). The per-server rows keep writing `activeSessions: null` as before, so the app-wide value is never duplicated across N backends (which would pollute the series).

   **Insertion point (the one ambiguity, resolved):** there are two sampling paths gated on `dueForMetric` — the full poll cycle (`runPollCycle`) and the idle `sampleTimeSeries`. They are **mutually exclusive within a tick** (`runPollCycle` `return`s after the idle branch), so the single app-wide row is emitted in both, immediately before each path's `persistSamples` flush. This guarantees exactly one app-wide row per metric tick whether the app is busy or idle, with no double-write. The count is best-effort: a failure logs and drops just the app-wide row for that tick rather than failing the whole sample.

3. **`lib/db/schema/metric-samples.ts`** — fix the stale doc comment that pointed at a non-existent `lib/metrics/sampler.ts`; sampling actually lives in `lib/realtime/zone-poller.ts`.

No schema columns changed (the columns were already nullable), so **no migration** is needed.

## Tests

`lib/db/repositories/sessions.test.ts` covers `countActiveSessions` with a mock executor (no live DB): returns the count as a number, defaults to 0 on an empty result, and coerces a stringified aggregate. The DB-backed behavior (the SQL predicate) is the integration suite's job.

## Validation

- `npm run lint` — clean (`--max-warnings=0`)
- `npm run typecheck` — clean
- `npm run format:check` — clean
- `npm run test` — 666 passed (63 files), incl. 3 new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #25