### PR TITLE
fix(csp): drop 'self' + Turnstile host from script-src (strict-dynamic)

### DIFF
--- a/lib/security/csp.test.ts
+++ b/lib/security/csp.test.ts
@@ -1,0 +1,77 @@
+/**
+ * lib/security/csp.test.ts
+ *
+ * Guards the script-src shape that issue #28 was about: under 'strict-dynamic',
+ * 'self' and host-sources are ignored by CSP3 browsers, so listing them is dead
+ * weight that emits a console warning. They must NOT appear in script-src.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildCsp } from "./csp";
+
+const NONCE = "test-nonce-abc123";
+const TURNSTILE = "https://challenges.cloudflare.com";
+
+/** Parse a CSP header string into { directive: [sources] }. */
+function parse(csp: string): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const part of csp.split(";")) {
+    const [name, ...sources] = part.trim().split(/\s+/);
+    if (name) out[name] = sources;
+  }
+  return out;
+}
+
+describe("buildCsp — script-src under strict-dynamic", () => {
+  it("does NOT include 'self' in script-src (it's ignored under strict-dynamic — issue #28)", () => {
+    for (const dev of [false, true]) {
+      for (const turnstile of [false, true]) {
+        const d = parse(buildCsp(NONCE, dev, turnstile));
+        expect(d["script-src"]).not.toContain("'self'");
+        expect(d["script-src"]).not.toContain("'unsafe-inline'");
+      }
+    }
+  });
+
+  it("authorizes scripts via nonce + strict-dynamic only", () => {
+    const d = parse(buildCsp(NONCE, false, false));
+    expect(d["script-src"]).toContain(`'nonce-${NONCE}'`);
+    expect(d["script-src"]).toContain("'strict-dynamic'");
+  });
+
+  it("keeps 'unsafe-eval' in dev only (strict-dynamic does not ignore it)", () => {
+    expect(parse(buildCsp(NONCE, true, false))["script-src"]).toContain("'unsafe-eval'");
+    expect(parse(buildCsp(NONCE, false, false))["script-src"]).not.toContain("'unsafe-eval'");
+  });
+
+  it("never puts the Turnstile origin in script-src (ignored under strict-dynamic)", () => {
+    // Even with the captcha enabled — the loader carries the nonce instead.
+    expect(parse(buildCsp(NONCE, false, true))["script-src"]).not.toContain(TURNSTILE);
+  });
+});
+
+describe("buildCsp — Turnstile origin on honored directives", () => {
+  it("adds the Turnstile origin to frame-src + connect-src when enabled", () => {
+    const d = parse(buildCsp(NONCE, false, true));
+    expect(d["frame-src"]).toContain(TURNSTILE);
+    expect(d["connect-src"]).toContain(TURNSTILE);
+  });
+
+  it("omits it everywhere when the captcha is disabled", () => {
+    const csp = buildCsp(NONCE, false, false);
+    expect(csp).not.toContain(TURNSTILE);
+  });
+});
+
+describe("buildCsp — baseline hardening stays intact", () => {
+  it("keeps the strict non-script directives", () => {
+    const d = parse(buildCsp(NONCE, false, false));
+    expect(d["default-src"]).toEqual(["'self'"]);
+    expect(d["object-src"]).toEqual(["'none'"]);
+    expect(d["frame-ancestors"]).toEqual(["'none'"]);
+    expect(d["base-uri"]).toEqual(["'self'"]);
+    expect(d["form-action"]).toEqual(["'self'"]);
+    // valueless directive is emitted bare (no sources)
+    expect(d["upgrade-insecure-requests"]).toEqual([]);
+  });
+});

--- a/lib/security/csp.ts
+++ b/lib/security/csp.ts
@@ -1,0 +1,96 @@
+/**
+ * lib/security/csp.ts
+ *
+ * Builds the Content-Security-Policy header value. Pure (no request/runtime
+ * deps) so it can be unit-tested in isolation; `middleware.ts` calls it with a
+ * fresh per-request nonce. See ADR-0006 for the nonce + `'strict-dynamic'`
+ * rationale.
+ *
+ * Strict by default; relaxed only where the framework or our own UI patterns
+ * genuinely need it. Pre-flight test before relaxing any source: are there fewer
+ * than 3 distinct inline scripts we'd need to allow? If yes, refactor them to
+ * external files instead.
+ */
+
+/** Cloudflare Turnstile origin — its script, iframe, and API calls. */
+const TURNSTILE_ORIGIN = "https://challenges.cloudflare.com";
+
+export function buildCsp(nonce: string, isDev: boolean, turnstileEnabled: boolean): string {
+  const directives: Record<string, string[]> = {
+    "default-src": ["'self'"],
+    "script-src": [
+      // NO 'self' / host-source / 'unsafe-inline' here: under CSP Level 3 the
+      // presence of 'strict-dynamic' (below) makes browsers IGNORE all of them
+      // in script-src — listing them does nothing and emits a console warning
+      // ("Ignoring 'self' within script-src: 'strict-dynamic' specified").
+      // Script trust comes solely from the per-request nonce plus
+      // strict-dynamic propagation to scripts those nonced scripts load.
+      `'nonce-${nonce}'`,
+      // Trust scripts loaded *by* already-trusted (nonced) scripts, so we don't
+      // have to enumerate every Next.js chunk URL.
+      "'strict-dynamic'",
+      // Dev hot-reload uses eval(). 'unsafe-eval' is a SEPARATE capability that
+      // 'strict-dynamic' does not ignore, so it's still honored here. Never
+      // enabled in production.
+      ...(isDev ? ["'unsafe-eval'"] : []),
+      // Turnstile is intentionally NOT listed here. Its loader is a `next/script`
+      // tag (components/ui/turnstile-widget.tsx) that carries the nonce, so
+      // 'strict-dynamic' authorizes it; a host-source would just be ignored.
+      // The origin is allowed on frame-src + connect-src below, where
+      // 'strict-dynamic' does not apply and the host source is honored.
+    ],
+    "style-src": [
+      "'self'",
+      // `'unsafe-inline'` is retained here deliberately, and cannot be
+      // dropped without an app-wide refactor. Two hard constraints:
+      //   1. React/Radix render `style="…"` ATTRIBUTES throughout (every
+      //      dialog/dropdown/chart). Style attributes cannot carry a nonce
+      //      — only `<style>`/`<link>` elements can — so the only CSP source
+      //      that permits them is `'unsafe-inline'`.
+      //   2. Adding a nonce does NOT help: under CSP3, the presence of a
+      //      nonce makes Chromium/WebKit *ignore* `'unsafe-inline'` for both
+      //      elements and attributes, which would then break those style
+      //      attributes. And the granular `style-src-attr`/`style-src-elem`
+      //      split that could thread this needle is ignored by Firefox
+      //      (it falls back to `style-src`), so it can't be relied on.
+      // Net: dropping `'unsafe-inline'` requires eliminating every inline
+      // style attribute first. Tracked as future work. The risk is low —
+      // `style-src` is the lowest-value CSP relaxation (no script, no
+      // external load, no exfil-via-form); `script-src` stays strict
+      // (nonce + 'strict-dynamic', no 'unsafe-inline').
+      "'unsafe-inline'",
+    ],
+    // Images: own origin, inline data URIs, blob URLs, plus arbitrary https
+    // origins. The HTTPS opening exists for operator-set brand logo URLs in
+    // /admin/settings and future OIDC avatar URLs. We do NOT open script-src or
+    // style-src — only the image directive, the lowest-risk channel. `http:` is
+    // added in dev so localhost-served logos work; production stays https-only.
+    "img-src": ["'self'", "data:", "blob:", "https:", ...(isDev ? ["http:"] : [])],
+    "font-src": ["'self'"],
+    // `connect-src` is the network egress allow-list. Defaults to self; the auth
+    // layer extends it for OIDC discovery URLs at runtime.
+    "connect-src": [
+      "'self'",
+      ...(isDev ? ["ws:", "wss:"] : []),
+      ...(turnstileEnabled ? [TURNSTILE_ORIGIN] : []),
+    ],
+    "frame-src": ["'self'", ...(turnstileEnabled ? [TURNSTILE_ORIGIN] : [])],
+    "frame-ancestors": ["'none'"],
+    "base-uri": ["'self'"],
+    "form-action": ["'self'"],
+    "object-src": ["'none'"],
+    "upgrade-insecure-requests": [],
+    // Browsers POST a JSON body describing each blocked load to this endpoint;
+    // the handler logs at warn level. We emit BOTH the legacy `report-uri`
+    // (deprecated but still the only mechanism older browsers / some Firefox
+    // configs honor) and the modern `report-to` (names a group declared in the
+    // `Reporting-Endpoints` response header, the path forward for Chromium) so
+    // no browser silently drops violation reports.
+    "report-uri": ["/api/csp-report"],
+    "report-to": ["csp-endpoint"],
+  };
+
+  return Object.entries(directives)
+    .map(([k, v]) => (v.length ? `${k} ${v.join(" ")}` : k))
+    .join("; ");
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -13,6 +13,7 @@
  */
 
 import { type NextRequest, NextResponse } from "next/server";
+import { buildCsp } from "@/lib/security/csp";
 
 // Cryptographically random nonce. 16 random bytes → 24 base64 chars. Generated on
 // every request because that's the whole point — a stale nonce defeats CSP.
@@ -31,99 +32,6 @@ function generateNonce(): string {
  */
 function isPlausibleRequestId(value: string): boolean {
   return value.length > 0 && value.length <= 200 && /^[A-Za-z0-9_.:-]+$/.test(value);
-}
-
-/**
- * Build the Content-Security-Policy header value. Strict by default; relaxed only
- * where the framework or our own UI patterns genuinely need it.
- *
- * Pre-flight test before relaxing any source: are there fewer than 3 distinct
- * inline scripts we'd need to allow? If yes, refactor them to external files.
- */
-function buildCsp(nonce: string, isDev: boolean, turnstileEnabled: boolean): string {
-  // Cloudflare Turnstile (S-4): loaded from challenges.cloudflare.com and
-  // renders inside an iframe served from the same origin. We open
-  // script-src, frame-src, and connect-src to that single host ONLY when
-  // the operator has configured the captcha — keeps the CSP tight
-  // otherwise. Reading TURNSTILE_SITE_KEY directly from process.env is
-  // safe: the site key is public by design (it ships to every browser).
-  const turnstileOrigin = "https://challenges.cloudflare.com";
-
-  const directives: Record<string, string[]> = {
-    "default-src": ["'self'"],
-    "script-src": [
-      "'self'",
-      `'nonce-${nonce}'`,
-      // 'strict-dynamic' tells browsers to trust scripts loaded *by* trusted
-      // scripts. Lets us avoid listing every chunk URL explicitly.
-      "'strict-dynamic'",
-      // Dev hot-reload eval()s. We never enable this in production.
-      ...(isDev ? ["'unsafe-eval'"] : []),
-      ...(turnstileEnabled ? [turnstileOrigin] : []),
-    ],
-    "style-src": [
-      "'self'",
-      // `'unsafe-inline'` is retained here deliberately, and cannot be
-      // dropped without an app-wide refactor. Two hard constraints:
-      //   1. React/Radix render `style="…"` ATTRIBUTES throughout (every
-      //      dialog/dropdown/chart). Style attributes cannot carry a nonce
-      //      — only `<style>`/`<link>` elements can — so the only CSP source
-      //      that permits them is `'unsafe-inline'`.
-      //   2. Adding a nonce does NOT help: under CSP3, the presence of a
-      //      nonce makes Chromium/WebKit *ignore* `'unsafe-inline'` for both
-      //      elements and attributes, which would then break those style
-      //      attributes. And the granular `style-src-attr`/`style-src-elem`
-      //      split that could thread this needle is ignored by Firefox
-      //      (it falls back to `style-src`), so it can't be relied on.
-      // Net: dropping `'unsafe-inline'` requires eliminating every inline
-      // style attribute first. Tracked as future work. The risk is low —
-      // `style-src` is the lowest-value CSP relaxation (no script, no
-      // external load, no exfil-via-form); `script-src` stays strict
-      // (nonce + 'strict-dynamic', no 'unsafe-inline').
-      "'unsafe-inline'",
-    ],
-    // Images: anything from our own origin, inline data URIs, blob URLs, plus
-    // arbitrary https origins. The HTTPS opening exists for operator-set brand
-    // logo URLs in /admin/settings (e.g. https://example.com/logo.svg) and for
-    // future avatar URLs from OIDC IdPs. We do NOT open script-src or
-    // style-src — only the image directive, which is the lowest-risk channel
-    // (no JS, no CSS, no exfil-via-form). `http:` is added in dev so
-    // localhost-served logos work; production remains https-only.
-    "img-src": ["'self'", "data:", "blob:", "https:", ...(isDev ? ["http:"] : [])],
-    "font-src": ["'self'"],
-    // `connect-src` is the network egress allow-list. Defaults to self; the auth
-    // layer extends this for OIDC discovery URLs at runtime .
-    "connect-src": [
-      "'self'",
-      ...(isDev ? ["ws:", "wss:"] : []),
-      ...(turnstileEnabled ? [turnstileOrigin] : []),
-    ],
-    "frame-src": ["'self'", ...(turnstileEnabled ? [turnstileOrigin] : [])],
-    "frame-ancestors": ["'none'"],
-    "base-uri": ["'self'"],
-    "form-action": ["'self'"],
-    "object-src": ["'none'"],
-    "upgrade-insecure-requests": [],
-    // S-20 from `reports/audit-2026-05-16.md`. Browsers POST a JSON
-    // body describing each blocked load to this endpoint; the handler
-    // logs at warn level. No storage or admin UI yet  — the
-    // logs are visible in any log aggregator and surface violations
-    // that would otherwise be silent (the inevitable "we added a
-    // third-party script and forgot to extend script-src" moment).
-    //
-    // We emit BOTH the legacy `report-uri` and the modern `report-to`.
-    // `report-uri` is deprecated but still the only mechanism older
-    // browsers (and some current Firefox configs) honor. `report-to`
-    // names a group declared in the `Reporting-Endpoints` response
-    // header (set below) and is the path forward for Chromium. Keeping
-    // both means no browser silently drops violation reports.
-    "report-uri": ["/api/csp-report"],
-    "report-to": ["csp-endpoint"],
-  };
-
-  return Object.entries(directives)
-    .map(([k, v]) => (v.length ? `${k} ${v.join(" ")}` : k))
-    .join("; ");
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #28. The production console logged:

```
Content-Security-Policy: Ignoring "'self'" within script-src: 'strict-dynamic' specified
```

`script-src` listed `'self'` next to `'nonce-…'` + `'strict-dynamic'`. Under CSP
Level 3, `'strict-dynamic'` makes browsers **ignore** `'self'`, host allowlists,
and `'unsafe-inline'` in `script-src` — so `'self'` was dead weight and the
browser warned about it. The Turnstile origin had the same issue (ignored under
strict-dynamic; its `next/script` loader carries the nonce, so strict-dynamic
already authorizes it).

## Change

- `script-src` now carries only `'nonce-<n>'` + `'strict-dynamic'` (+ `'unsafe-eval'`
  in dev — a separate capability strict-dynamic does **not** ignore). No `'self'`,
  no Turnstile host.
- The Turnstile origin stays on `frame-src` + `connect-src`, where there's no
  `'strict-dynamic'` and the host source is honored (iframe + API calls).
- Extracted `buildCsp` from `middleware.ts` into a pure `lib/security/csp.ts` so
  the policy shape is unit-testable; `middleware.ts` imports it.

No security regression — script trust still comes solely from the per-request
nonce + strict-dynamic. The policy is now cleaner and warning-free.

## Test

New `lib/security/csp.test.ts`: asserts `script-src` has no `'self'`/`'unsafe-inline'`,
carries the nonce + `'strict-dynamic'`, gates `'unsafe-eval'` to dev, never puts the
Turnstile origin in `script-src` (even enabled), and keeps it on `frame-src`/`connect-src`
— plus the baseline hardening directives.

> Note: my local sandbox's `node_modules` got into a broken symlink state, so I
> couldn't run vitest locally for this one — `tsc` + eslint passed, and CI runs
> the new test in a clean environment.

Closes #28