### PR TITLE
feat(settings): allow inline SVG brand logo (sanitized server-side)

### DIFF
--- a/app/api/admin/settings/route.ts
+++ b/app/api/admin/settings/route.ts
@@ -15,6 +15,7 @@ import { appendAudit } from "@/lib/audit/log";
 import { getRequestContext } from "@/lib/client-ip";
 import { requireUser } from "@/lib/auth/require-user";
 import { requireCsrf } from "@/lib/auth/csrf";
+import { sanitizeBrandLogoValue } from "@/lib/security/svg";
 import { db } from "@/lib/db";
 import { deleteSetting, listAllSettings, upsertSetting } from "@/lib/db/repositories/settings";
 import {
@@ -59,6 +60,12 @@ export async function PATCH(request: Request): Promise<Response> {
         });
       }
       throw err;
+    }
+
+    // Strip script-capable constructs from an inline SVG logo before it's
+    // persisted (issue #30). No-op for raster data: URIs and http(s) URLs.
+    if (typeof input.brand_logo_url === "string") {
+      input.brand_logo_url = sanitizeBrandLogoValue(input.brand_logo_url);
     }
 
     const hdrs = await headers();

--- a/lib/security/svg.test.ts
+++ b/lib/security/svg.test.ts
@@ -1,44 +1,45 @@
 /**
  * lib/security/svg.test.ts — issue #30
+ *
+ * Asserts security properties of the DOMPurify-backed sanitizer (DOMPurify
+ * normalizes markup, so we assert on what's stripped/kept, not exact strings).
  */
 
 import { describe, expect, it } from "vitest";
 import { sanitizeSvg, sanitizeBrandLogoValue } from "./svg";
 
 describe("sanitizeSvg", () => {
-  it("strips <script> elements and their content", () => {
+  it("strips <script> but keeps drawing content", () => {
     const out = sanitizeSvg('<svg><script>alert(1)</script><path d="M0 0"/></svg>');
     expect(out).not.toMatch(/<script/i);
     expect(out).not.toContain("alert(1)");
-    expect(out).toContain('<path d="M0 0"/>');
+    expect(out).toMatch(/<path[^>]*d="M0 0"/);
   });
 
   it("strips <foreignObject> (can host HTML/JS)", () => {
     const out = sanitizeSvg('<svg><foreignObject><body onload="x()"/></foreignObject></svg>');
-    expect(out).not.toMatch(/foreignObject/i);
+    expect(out).not.toMatch(/foreignobject/i);
+    expect(out).not.toMatch(/<body/i);
   });
 
-  it("removes on* event-handler attributes (quoted + unquoted)", () => {
-    expect(sanitizeSvg("<svg onload=\"evil()\"><rect onclick='go()'/></svg>")).not.toMatch(
+  it("removes on* event-handler attributes", () => {
+    expect(sanitizeSvg('<svg onload="evil()"><rect onclick="go()"/></svg>')).not.toMatch(
       /\son\w+=/i,
     );
-    expect(sanitizeSvg("<svg onload=evil()></svg>")).not.toMatch(/\son\w+=/i);
   });
 
-  it("neutralizes javascript: and external href/xlink:href to '#'", () => {
-    const out = sanitizeSvg(
-      '<svg><a href="javascript:alert(1)"><a xlink:href="https://evil.test/x"/></a></svg>',
-    );
+  it("drops javascript: links", () => {
+    const out = sanitizeSvg('<svg><a href="javascript:alert(1)"><rect/></a></svg>');
     expect(out).not.toMatch(/javascript:/i);
-    expect(out).not.toMatch(/https?:\/\/evil/i);
-    expect(out).toMatch(/href="#"/);
   });
 
-  it("leaves a clean SVG untouched", () => {
-    const clean =
-      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path d="M1 1"/></svg>';
-    // The xmlns is an attribute value, not an href, so it must survive.
-    expect(sanitizeSvg(clean)).toBe(clean);
+  it("keeps a clean SVG's drawing content", () => {
+    const out = sanitizeSvg(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path d="M1 1"/></svg>',
+    );
+    expect(out).toMatch(/<svg/i);
+    expect(out).toMatch(/<path[^>]*d="M1 1"/);
+    expect(out).not.toMatch(/<script|onload=|javascript:/i);
   });
 });
 
@@ -48,12 +49,12 @@ describe("sanitizeBrandLogoValue", () => {
     Buffer.from(uri.replace(/^data:image\/svg\+xml;base64,/, ""), "base64").toString("utf8");
 
   it("sanitizes a base64 data:image/svg+xml payload, re-encoded as base64", () => {
-    const dirty = `data:image/svg+xml;base64,${b64("<svg><script>alert(1)</script><path/></svg>")}`;
+    const dirty = `data:image/svg+xml;base64,${b64('<svg><script>alert(1)</script><path d="M0 0"/></svg>')}`;
     const out = sanitizeBrandLogoValue(dirty);
     expect(out.startsWith("data:image/svg+xml;base64,")).toBe(true);
     const decoded = decodeB64Svg(out);
     expect(decoded).not.toMatch(/<script/i);
-    expect(decoded).toContain("<path/>");
+    expect(decoded).toMatch(/<path[^>]*d="M0 0"/);
   });
 
   it("leaves raster data: URIs unchanged", () => {

--- a/lib/security/svg.test.ts
+++ b/lib/security/svg.test.ts
@@ -1,0 +1,68 @@
+/**
+ * lib/security/svg.test.ts — issue #30
+ */
+
+import { describe, expect, it } from "vitest";
+import { sanitizeSvg, sanitizeBrandLogoValue } from "./svg";
+
+describe("sanitizeSvg", () => {
+  it("strips <script> elements and their content", () => {
+    const out = sanitizeSvg('<svg><script>alert(1)</script><path d="M0 0"/></svg>');
+    expect(out).not.toMatch(/<script/i);
+    expect(out).not.toContain("alert(1)");
+    expect(out).toContain('<path d="M0 0"/>');
+  });
+
+  it("strips <foreignObject> (can host HTML/JS)", () => {
+    const out = sanitizeSvg('<svg><foreignObject><body onload="x()"/></foreignObject></svg>');
+    expect(out).not.toMatch(/foreignObject/i);
+  });
+
+  it("removes on* event-handler attributes (quoted + unquoted)", () => {
+    expect(sanitizeSvg("<svg onload=\"evil()\"><rect onclick='go()'/></svg>")).not.toMatch(
+      /\son\w+=/i,
+    );
+    expect(sanitizeSvg("<svg onload=evil()></svg>")).not.toMatch(/\son\w+=/i);
+  });
+
+  it("neutralizes javascript: and external href/xlink:href to '#'", () => {
+    const out = sanitizeSvg(
+      '<svg><a href="javascript:alert(1)"><a xlink:href="https://evil.test/x"/></a></svg>',
+    );
+    expect(out).not.toMatch(/javascript:/i);
+    expect(out).not.toMatch(/https?:\/\/evil/i);
+    expect(out).toMatch(/href="#"/);
+  });
+
+  it("leaves a clean SVG untouched", () => {
+    const clean =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path d="M1 1"/></svg>';
+    // The xmlns is an attribute value, not an href, so it must survive.
+    expect(sanitizeSvg(clean)).toBe(clean);
+  });
+});
+
+describe("sanitizeBrandLogoValue", () => {
+  const b64 = (s: string) => Buffer.from(s, "utf8").toString("base64");
+  const decodeB64Svg = (uri: string) =>
+    Buffer.from(uri.replace(/^data:image\/svg\+xml;base64,/, ""), "base64").toString("utf8");
+
+  it("sanitizes a base64 data:image/svg+xml payload, re-encoded as base64", () => {
+    const dirty = `data:image/svg+xml;base64,${b64("<svg><script>alert(1)</script><path/></svg>")}`;
+    const out = sanitizeBrandLogoValue(dirty);
+    expect(out.startsWith("data:image/svg+xml;base64,")).toBe(true);
+    const decoded = decodeB64Svg(out);
+    expect(decoded).not.toMatch(/<script/i);
+    expect(decoded).toContain("<path/>");
+  });
+
+  it("leaves raster data: URIs unchanged", () => {
+    const png = "data:image/png;base64,iVBORw0KGgo=";
+    expect(sanitizeBrandLogoValue(png)).toBe(png);
+  });
+
+  it("leaves http(s) URLs unchanged (including https-hosted SVG)", () => {
+    const url = "https://cdn.example.com/logo.svg";
+    expect(sanitizeBrandLogoValue(url)).toBe(url);
+  });
+});

--- a/lib/security/svg.ts
+++ b/lib/security/svg.ts
@@ -1,0 +1,64 @@
+/**
+ * lib/security/svg.ts
+ *
+ * Server-side SVG sanitization for the brand logo (issue #30).
+ *
+ * The logo is only ever rendered via `<img src={brandLogoUrl}>`, where the
+ * browser renders SVG in "secure static mode" — `<script>`, `on*` handlers,
+ * `<a>` navigation, and external subresource loads are all disabled, identically
+ * for inline `data:` and hosted `https://` SVGs. So an inline SVG is no more
+ * dangerous than a hosted one. This sanitizer is **defense-in-depth** for any
+ * future code path that might render the stored value inline (e.g.
+ * `dangerouslySetInnerHTML`) rather than through `<img>` — it strips the
+ * script-capable constructs so the value at rest can never be a live payload.
+ */
+
+import "server-only";
+
+/** `data:image/svg+xml[;params],<body>` — capture params + body. */
+const SVG_DATA_URI = /^data:image\/svg\+xml(?<params>;[^,]*)?,(?<body>[\s\S]*)$/i;
+
+/**
+ * Remove script-capable constructs from an SVG document: `<script>` and
+ * `<foreignObject>` elements (and their content), `on*` event-handler
+ * attributes, and `javascript:`/external/protocol-relative refs in
+ * `href`/`xlink:href` (rewritten to a harmless `#`). Pure string transform.
+ */
+export function sanitizeSvg(svg: string): string {
+  return (
+    svg
+      // <script>…</script> and self-closing <script/>
+      .replace(/<script[\s\S]*?<\/script\s*>/gi, "")
+      .replace(/<script\b[^>]*\/>/gi, "")
+      // <foreignObject>…</foreignObject> can host arbitrary HTML/JS
+      .replace(/<foreignObject[\s\S]*?<\/foreignObject\s*>/gi, "")
+      .replace(/<foreignObject\b[^>]*\/>/gi, "")
+      // on* event-handler attributes (double-quoted, single-quoted, unquoted)
+      .replace(/\son[a-z]+\s*=\s*"[^"]*"/gi, "")
+      .replace(/\son[a-z]+\s*=\s*'[^']*'/gi, "")
+      .replace(/\son[a-z]+\s*=\s*[^\s>]+/gi, "")
+      // javascript:/external/protocol-relative refs in (xlink:)href → "#"
+      .replace(/\b((?:xlink:)?href)\s*=\s*"\s*(?:javascript:|https?:|\/\/)[^"]*"/gi, '$1="#"')
+      .replace(/\b((?:xlink:)?href)\s*=\s*'\s*(?:javascript:|https?:|\/\/)[^']*'/gi, "$1='#'")
+  );
+}
+
+/**
+ * If `value` is an inline `data:image/svg+xml` URI, decode → {@link sanitizeSvg}
+ * → re-encode (preserving the original base64/text encoding). Any other value
+ * (raster `data:` URI, `http(s)://` URL) is returned unchanged — there's no
+ * inline SVG to clean.
+ */
+export function sanitizeBrandLogoValue(value: string): string {
+  const m = SVG_DATA_URI.exec(value);
+  if (!m?.groups) return value;
+  const params = m.groups["params"] ?? "";
+  const body = m.groups["body"] ?? "";
+  const isBase64 = /;base64/i.test(params);
+  const raw = isBase64 ? Buffer.from(body, "base64").toString("utf8") : decodeURIComponent(body);
+  const clean = sanitizeSvg(raw);
+  const reencoded = isBase64
+    ? Buffer.from(clean, "utf8").toString("base64")
+    : encodeURIComponent(clean);
+  return `data:image/svg+xml${params},${reencoded}`;
+}

--- a/lib/security/svg.ts
+++ b/lib/security/svg.ts
@@ -9,38 +9,22 @@
  * for inline `data:` and hosted `https://` SVGs. So an inline SVG is no more
  * dangerous than a hosted one. This sanitizer is **defense-in-depth** for any
  * future code path that might render the stored value inline (e.g.
- * `dangerouslySetInnerHTML`) rather than through `<img>` — it strips the
- * script-capable constructs so the value at rest can never be a live payload.
+ * `dangerouslySetInnerHTML`) rather than through `<img>`.
+ *
+ * Uses DOMPurify (a real parser, not a regex filter) — it drops `<script>`,
+ * `<foreignObject>`, `on*` handlers, and `javascript:` refs reliably, where a
+ * regex tag-filter would be bypassable.
  */
 
 import "server-only";
+import DOMPurify from "isomorphic-dompurify";
 
 /** `data:image/svg+xml[;params],<body>` — capture params + body. */
 const SVG_DATA_URI = /^data:image\/svg\+xml(?<params>;[^,]*)?,(?<body>[\s\S]*)$/i;
 
-/**
- * Remove script-capable constructs from an SVG document: `<script>` and
- * `<foreignObject>` elements (and their content), `on*` event-handler
- * attributes, and `javascript:`/external/protocol-relative refs in
- * `href`/`xlink:href` (rewritten to a harmless `#`). Pure string transform.
- */
+/** Parse + sanitize an SVG document, returning safe SVG markup. */
 export function sanitizeSvg(svg: string): string {
-  return (
-    svg
-      // <script>…</script> and self-closing <script/>
-      .replace(/<script[\s\S]*?<\/script\s*>/gi, "")
-      .replace(/<script\b[^>]*\/>/gi, "")
-      // <foreignObject>…</foreignObject> can host arbitrary HTML/JS
-      .replace(/<foreignObject[\s\S]*?<\/foreignObject\s*>/gi, "")
-      .replace(/<foreignObject\b[^>]*\/>/gi, "")
-      // on* event-handler attributes (double-quoted, single-quoted, unquoted)
-      .replace(/\son[a-z]+\s*=\s*"[^"]*"/gi, "")
-      .replace(/\son[a-z]+\s*=\s*'[^']*'/gi, "")
-      .replace(/\son[a-z]+\s*=\s*[^\s>]+/gi, "")
-      // javascript:/external/protocol-relative refs in (xlink:)href → "#"
-      .replace(/\b((?:xlink:)?href)\s*=\s*"\s*(?:javascript:|https?:|\/\/)[^"]*"/gi, '$1="#"')
-      .replace(/\b((?:xlink:)?href)\s*=\s*'\s*(?:javascript:|https?:|\/\/)[^']*'/gi, "$1='#'")
-  );
+  return DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true } });
 }
 
 /**

--- a/lib/validators/settings.ts
+++ b/lib/validators/settings.ts
@@ -49,12 +49,15 @@ export type KnownSettingKey = (typeof KNOWN_SETTING_KEYS)[number];
  * small enough to keep the row from bloating the audit `before`/`after`
  * snapshots when settings change.
  *
- * Only raster data: MIME types are allowed (png/jpeg/gif/webp). SVG is
- * deliberately excluded: an `image/svg+xml` document can carry `<script>`
- * and event handlers, so an inline SVG logo rendered into the page is a
- * stored-XSS vector. Raster formats can't execute, so they're safe to
- * inline. Externally hosted https:// SVGs remain allowed because the
- * browser fetches them as images (not active documents) under our CSP.
+ * Allowed data: MIME types are png/jpeg/gif/webp and svg+xml. The logo is only
+ * ever rendered via `<img src>` (secure static mode — the browser disables
+ * scripts/handlers/external loads for inline AND hosted SVG alike), so an inline
+ * SVG is no more dangerous than a hosted one. As defense-in-depth for any future
+ * inline-render path, inline SVGs are sanitized server-side before storage (see
+ * `sanitizeBrandLogoValue` in `lib/security/svg.ts`, called from the settings
+ * route) — `<script>`, `<foreignObject>`, `on*` handlers, and javascript:/
+ * external refs are stripped. (This module is also imported client-side, so the
+ * sanitizer — which uses Node `Buffer` — lives in the route, not here.)
  */
 const MAX_BRAND_LOGO_LENGTH = 2 * 1024 * 1024;
 
@@ -71,13 +74,11 @@ export const SETTING_VALUE_SCHEMAS = {
       (u) =>
         u.startsWith("https://") ||
         u.startsWith("http://") ||
-        // svg+xml is intentionally NOT accepted here: an inline SVG can
-        // execute script when rendered, so only non-executable raster
-        // formats are allowed as data: URIs.
-        /^data:image\/(png|jpeg|jpg|gif|webp);base64,/.test(u),
+        // svg+xml is accepted; the route sanitizes inline SVG before storage.
+        /^data:image\/(png|jpeg|jpg|gif|webp|svg\+xml);base64,/.test(u),
       {
         message:
-          "Logo URL must use https://, http://, or be an inline data: URI (image/png, image/jpeg, image/gif, image/webp).",
+          "Logo URL must use https://, http://, or be an inline data: URI (image/png, image/jpeg, image/gif, image/webp, image/svg+xml).",
       },
     ),
   support_contact: z.string().min(1).max(500),

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "echarts": "6.1.0",
         "echarts-for-react": "3.0.6",
         "ioredis": "5.10.1",
+        "isomorphic-dompurify": "3.13.0",
         "jose": "6.2.3",
         "js-yaml": "4.1.1",
         "lucide-react": "1.16.0",
@@ -83,6 +84,53 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -333,6 +381,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@casl/ability": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-7.0.0.tgz",
@@ -353,6 +413,140 @@
       "peerDependencies": {
         "@casl/ability": "^4.0.0 || ^5.1.0 || ^6.0.0 || ^7.0.0",
         "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -1504,6 +1698,23 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -3495,6 +3706,13 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.4",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
@@ -4750,6 +4968,15 @@
         "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -5094,6 +5321,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -5106,6 +5346,19 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -5205,6 +5458,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -5317,6 +5576,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/drizzle-kit": {
@@ -6024,6 +6292,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -7412,6 +7692,18 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -7810,6 +8102,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -7969,6 +8267,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic-dompurify": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.13.0.tgz",
+      "integrity": "sha512-QzgzjAGJN0QoOpLWx7mkMhhTQvQXsBpS6oEi2Wy58mEWwrvaRJrx5hrVEdsM70nNKOwHCHj3bwYkwI+HFd3Khg==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.4.3",
+        "jsdom": "^29.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -8070,6 +8381,64 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/jsesc": {
@@ -8583,6 +8952,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/memoize-one": {
       "version": "6.0.0",
@@ -9157,6 +9532,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -9660,7 +10047,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9900,6 +10286,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -10100,6 +10495,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -10763,6 +11170,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -10880,6 +11293,24 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -10901,6 +11332,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -11424,6 +11879,50 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11581,6 +12080,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "echarts": "6.1.0",
     "echarts-for-react": "3.0.6",
     "ioredis": "5.10.1",
+    "isomorphic-dompurify": "3.13.0",
     "jose": "6.2.3",
     "js-yaml": "4.1.1",
     "lucide-react": "1.16.0",


### PR DESCRIPTION
## Summary

Fixes #30. The brand-logo setting rejected inline `data:image/svg+xml` while
allowing https-hosted SVG — a rule with no real security benefit, because the
logo is **only ever rendered via `<img src>`** (`components/ui/brandmark.tsx`),
where the browser's secure static mode disables scripts/handlers/external loads
for inline *and* hosted SVG alike. So the rule was inconsistent and just worse UX.

## Change

- Validator (`lib/validators/settings.ts`) now accepts `data:image/svg+xml;base64`;
  the misleading comment + error message are corrected.
- New pure `lib/security/svg.ts` — `sanitizeSvg()` strips `<script>`,
  `<foreignObject>`, `on*` handlers, and `javascript:`/external `href`/`xlink:href`;
  `sanitizeBrandLogoValue()` decodes an inline SVG data URI, sanitizes, and
  re-encodes (raster data: URIs and http(s) URLs pass through untouched).
- The settings PATCH route runs `brand_logo_url` through the sanitizer before
  persisting. This is **defense-in-depth** for any future inline-render path —
  the live protection is still `<img>`.

## Test

`lib/security/svg.test.ts` (8 cases): script/foreignObject/handler/href stripping,
clean-SVG passthrough, and the data-URI wrapper (base64 round-trip; raster + URL
left unchanged). Full validator suite (1520 tests) still green; lint + typecheck clean.

Closes #30