### PR TITLE
feat(auth): self-service signup (SIGNUP_ENABLED)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,8 +139,25 @@ APP_PDNS_ALLOW_INSECURE_HTTP=true
 
 # Enable local accounts. Default true.
 # LOCAL_AUTH_ENABLED=true
-# Public self-service signup. Default false (admins create users).
+
+# --- Public self-service signup ---
+# Off by default. When false the /signup page and POST /api/auth/signup both
+# return 404 — the feature does not exist for the deployment. When true:
+#   - visitors register at /signup with email + password (Argon2id, min 12 chars);
+#   - the account is created UNVERIFIED and CANNOT log in until the email is
+#     verified (any unverified local account is blocked from login while signup
+#     is on — verify via the link, then sign in);
+#   - the verification link is EMAILED when SMTP is configured below, otherwise
+#     it is recorded in the audit log (action `auth.email.verify.sent`) for the
+#     operator to share out-of-band. Configure SMTP_* for real delivery.
 # SIGNUP_ENABLED=false
+# Role (slug) every signup receives. MUST be low-privilege — the seed step
+# refuses to boot when this is missing or admin-equivalent (holds user/role/
+# settings/server/audit/etc permissions). Default: read-only.
+# SIGNUP_DEFAULT_ROLE=read-only
+# Comma-separated email-domain allow-list for signups. Empty/unset = any domain.
+# Exact-domain match, case-insensitive. Out-of-list addresses are rejected.
+# SIGNUP_ALLOWED_EMAIL_DOMAINS=example.com,contractors.example.com
 
 
 # -----------------------------------------------------------------------------

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -110,6 +110,11 @@ export function LoginForm({
           setError(`Account locked until ${new Date(data.unlockAt).toLocaleString()}.`);
         } else if (res.status === 429 && data?.retryAfterSeconds) {
           setError(`Too many attempts. Try again in ${data.retryAfterSeconds}s.`);
+        } else if (data?.reason === "email-unverified") {
+          // Signup-enabled deployments block login until the email is verified.
+          setError(
+            "Verify your email before signing in. Check your inbox for the verification link (or ask your administrator if email isn't configured).",
+          );
         } else if (data?.reason === "captcha-required" || data?.reason === "captcha-failed") {
           setError(
             data.reason === "captcha-required"

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -158,6 +158,16 @@ export default async function LoginPage({
               </Link>
             </p>
           ) : null}
+          {/* Self-service signup link — only when SIGNUP_ENABLED. The page
+              itself 404s when disabled, so this is the matching UI gate. */}
+          {env.SIGNUP_ENABLED ? (
+            <p className="mt-2 text-xs text-[color:var(--color-fg-muted)]">
+              Don&apos;t have an account?{" "}
+              <Link href="/signup" className="underline">
+                Create an account
+              </Link>
+            </p>
+          ) : null}
         </>
       ) : null}
 

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,0 +1,48 @@
+/**
+ * app/(auth)/signup/page.tsx
+ *
+ * Public self-service signup. Server component — it reads `env` and returns
+ * `notFound()` (a real 404) when `SIGNUP_ENABLED` is false, so the page does
+ * not exist for deployments that haven't opted in. Mirrors the login route's
+ * "feature off → 404" contract on the API side.
+ *
+ * A signed-in visitor is bounced to the dashboard (same as the login page).
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { env } from "@/lib/env";
+import { getCurrentUser } from "@/lib/auth/get-current-user";
+import { SignupForm } from "./signup-form";
+
+export const metadata: Metadata = { title: "Create an account" };
+
+export default async function SignupPage() {
+  // Feature gate — invisible when disabled.
+  if (!env.SIGNUP_ENABLED) notFound();
+
+  const current = await getCurrentUser();
+  if (current) redirect("/dashboard");
+
+  return (
+    <>
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight">Create an account</h1>
+        <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">
+          Sign up with your email and a password. We&apos;ll send a verification link — you must
+          verify before you can sign in.
+        </p>
+      </header>
+
+      <SignupForm turnstileSiteKey={env.TURNSTILE_SITE_KEY ?? undefined} />
+
+      <p className="mt-6 text-xs text-[color:var(--color-fg-muted)]">
+        Already have an account?{" "}
+        <Link href="/login" className="underline">
+          Sign in
+        </Link>
+      </p>
+    </>
+  );
+}

--- a/app/(auth)/signup/signup-form.tsx
+++ b/app/(auth)/signup/signup-form.tsx
@@ -13,7 +13,7 @@
  */
 
 import { useState, type FormEvent } from "react";
-import { MIN_PASSWORD_LENGTH } from "@/lib/validators/users";
+import { MIN_PASSWORD_LENGTH } from "@/lib/validators/password-policy";
 import { TurnstileWidget } from "@/components/ui/turnstile-widget";
 
 export function SignupForm({ turnstileSiteKey }: { turnstileSiteKey?: string }) {

--- a/app/(auth)/signup/signup-form.tsx
+++ b/app/(auth)/signup/signup-form.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+/**
+ * app/(auth)/signup/signup-form.tsx
+ *
+ * Client form for self-service signup. Collects email, password (+ confirm),
+ * an optional display name, and the captcha token when configured. Posts to
+ * /api/auth/signup, which returns a uniform OK (the body never reveals whether
+ * the email already exists), so on success we always render the same
+ * "check your email / ask your admin" confirmation.
+ *
+ * Styling mirrors the login form so the two pages feel like one set.
+ */
+
+import { useState, type FormEvent } from "react";
+import { MIN_PASSWORD_LENGTH } from "@/lib/validators/users";
+import { TurnstileWidget } from "@/components/ui/turnstile-widget";
+
+export function SignupForm({ turnstileSiteKey }: { turnstileSiteKey?: string }) {
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState<string | null>(null);
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+  const [captchaResetKey, setCaptchaResetKey] = useState(0);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+
+    // Client-side mirror of the server policy so users get instant feedback;
+    // the server re-validates regardless.
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+      return;
+    }
+    if (password !== confirm) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await fetch("/api/auth/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email,
+          password,
+          ...(name.trim() ? { name: name.trim() } : {}),
+          ...(captchaToken ? { captchaToken } : {}),
+        }),
+      });
+
+      const data = (await res.json().catch(() => null)) as {
+        ok?: boolean;
+        message?: string;
+        error?: string;
+        retryAfterSeconds?: number;
+        reason?: string;
+        details?: { fieldErrors?: Record<string, string[]> };
+      } | null;
+
+      if (!res.ok) {
+        if (res.status === 429 && data?.retryAfterSeconds) {
+          setError(`Too many requests. Try again in ${data.retryAfterSeconds}s.`);
+        } else if (data?.reason === "captcha-required" || data?.reason === "captcha-failed") {
+          setError(
+            data.reason === "captcha-required"
+              ? "Please complete the captcha challenge."
+              : "Captcha verification failed. Try again.",
+          );
+        } else if (data?.details?.fieldErrors) {
+          const first = Object.values(data.details.fieldErrors).flat()[0];
+          setError(first ?? data.error ?? "Sign-up failed.");
+        } else {
+          setError(data?.error ?? "Sign-up failed.");
+        }
+        // Captcha tokens are single-use server-side; refresh the widget.
+        setCaptchaResetKey((n) => n + 1);
+        return;
+      }
+
+      setDone(data?.message ?? "Thanks for signing up. Check your email to verify your address.");
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (done) {
+    return (
+      <div
+        role="status"
+        className="rounded-md border border-[color:var(--color-success)] bg-[color:var(--color-success)]/10 p-3 text-sm"
+      >
+        {done}
+      </div>
+    );
+  }
+
+  const submitDisabled = loading || (turnstileSiteKey !== undefined && captchaToken === null);
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="email" className="block text-sm font-medium">
+          Email
+        </label>
+        <input
+          id="email"
+          type="email"
+          autoComplete="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="mt-1 block w-full rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2 text-sm focus:ring-2 focus:ring-[color:var(--color-accent)] focus:outline-none"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="name" className="block text-sm font-medium">
+          Name <span className="text-[color:var(--color-fg-muted)]">(optional)</span>
+        </label>
+        <input
+          id="name"
+          type="text"
+          autoComplete="name"
+          maxLength={120}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="mt-1 block w-full rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2 text-sm focus:ring-2 focus:ring-[color:var(--color-accent)] focus:outline-none"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="password" className="block text-sm font-medium">
+          Password
+        </label>
+        <input
+          id="password"
+          type="password"
+          autoComplete="new-password"
+          required
+          minLength={MIN_PASSWORD_LENGTH}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="mt-1 block w-full rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2 text-sm focus:ring-2 focus:ring-[color:var(--color-accent)] focus:outline-none"
+        />
+        <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">
+          At least {MIN_PASSWORD_LENGTH} characters.
+        </p>
+      </div>
+
+      <div>
+        <label htmlFor="confirm" className="block text-sm font-medium">
+          Confirm password
+        </label>
+        <input
+          id="confirm"
+          type="password"
+          autoComplete="new-password"
+          required
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          className="mt-1 block w-full rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2 text-sm focus:ring-2 focus:ring-[color:var(--color-accent)] focus:outline-none"
+        />
+      </div>
+
+      <TurnstileWidget
+        siteKey={turnstileSiteKey}
+        onToken={setCaptchaToken}
+        resetKey={captchaResetKey}
+      />
+
+      {error ? (
+        <p className="text-sm text-[color:var(--color-error)]" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={submitDisabled}
+        className="block w-full rounded-md bg-[color:var(--color-accent)] px-4 py-2 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95 disabled:opacity-50"
+      >
+        {loading ? "Creating account…" : "Create account"}
+      </button>
+    </form>
+  );
+}

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -151,6 +151,33 @@ export async function POST(request: Request): Promise<Response> {
     return jsonError(401, "Invalid email or password.");
   }
 
+  // 3b. Email-verification gate. When public self-service signup is enabled,
+  // the deployment commits to "verify your email before you get in" — otherwise
+  // an attacker could register `someone-else@org.com` and access the app without
+  // ever owning that mailbox. We block any local-password account whose email
+  // isn't verified yet. SSO-only accounts (no passwordHash) never reach this
+  // branch; admins clear the gate out-of-band via the verification link recorded
+  // in the audit log, and a repeat POST to /api/auth/signup re-sends it.
+  //
+  // Entirely inert when SIGNUP_ENABLED=false: deployments that never turn on
+  // public signup keep the pre-existing soft-banner behavior unchanged.
+  if (
+    env.SIGNUP_ENABLED &&
+    outcome.user.passwordHash !== null &&
+    outcome.user.emailVerifiedAt === null
+  ) {
+    await appendAudit({
+      actor: { type: "user", id: outcome.user.id },
+      action: "auth.login.failure",
+      resource: { type: "user", id: outcome.user.id },
+      after: { reason: "email-unverified" },
+      request: { ip, userAgent, requestId: getRequestId(hdrs) },
+    });
+    return jsonError(403, "Verify your email address before signing in.", {
+      reason: "email-unverified",
+    });
+  }
+
   // 4. MFA challenge — when the user has TOTP enrolled, do NOT
   // start a session yet. Mint a single-use challenge token bound to
   // the constant actor "_mfa-pending" (the operator isn't logged in

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,0 +1,316 @@
+/**
+ * app/api/auth/signup/route.ts
+ *
+ * POST /api/auth/signup — public self-service registration, gated by
+ * `SIGNUP_ENABLED`. Off by default; when disabled the route is a 404 (the
+ * feature simply does not exist for that deployment).
+ *
+ * Security model (every property here is load-bearing — see issue #32):
+ *   - Disabled → 404, before anything else runs.
+ *   - Per-IP rate limit (same `sensitiveLimiter` tier as forgot-password).
+ *   - CSRF handled like the other unauthenticated auth POSTs (no-op pre-session;
+ *     `requireCsrf` only enforces when a session cookie is present, so it can't
+ *     be CSRF-forged into an existing session).
+ *   - Zod validation + the app-wide Argon2id password policy.
+ *   - Email-domain allow-list (`SIGNUP_ALLOWED_EMAIL_DOMAINS`) enforced before
+ *     any DB write; the audit row records the *domain* only, never the address.
+ *   - No user enumeration: the response is identical whether or not the email
+ *     already exists. A duplicate silently no-ops (re-sending verification to an
+ *     existing UNVERIFIED local account) and never reveals that the account is
+ *     there. We do NOT touch an already-verified account or an SSO/admin one.
+ *   - The new account is created UNVERIFIED and assigned exactly the
+ *     low-privilege `SIGNUP_DEFAULT_ROLE` — never an admin role (boot guard in
+ *     `scripts/seed.ts` refuses to start otherwise). The user can't log in until
+ *     they verify (see the gate in /api/auth/login).
+ *   - User insert + role assignment + both audit rows commit in one
+ *     transaction; a crash mid-sequence can't leave an unaudited/unroled user.
+ *   - MFA is not required at signup; role policy can require it later.
+ */
+
+import { headers } from "next/headers";
+import { ZodError } from "zod";
+import { appendAudit } from "@/lib/audit/log";
+import { getClientIp, getRequestContext } from "@/lib/client-ip";
+import { sensitiveLimiter } from "@/lib/auth/rate-limit";
+import { requireCsrf } from "@/lib/auth/csrf";
+import { verifyTurnstile } from "@/lib/auth/captcha";
+import { hashPassword } from "@/lib/auth/password";
+import { emailDomainAllowed } from "@/lib/auth/email-domain-allowlist";
+import { mintVerifyToken } from "@/lib/auth/email-verification-token";
+import { sendEmail } from "@/lib/email/send";
+import { verifyEmailMessage } from "@/lib/email/templates";
+import { db } from "@/lib/db";
+import { findUserByEmail, insertUser } from "@/lib/db/repositories/users";
+import { createRoleAssignment, findRoleBySlug } from "@/lib/db/repositories/roles";
+import { signupSchema } from "@/lib/validators/users";
+import { env } from "@/lib/env";
+import { logger } from "@/lib/logger";
+import { ValidationError } from "@/lib/errors";
+
+/**
+ * Uniform success body. Returned for a fresh signup AND for a duplicate so the
+ * endpoint is never an account-existence oracle. The copy is deliberately
+ * agnostic about whether mail was sent vs. recorded in the audit log.
+ */
+const GENERIC_OK = {
+  ok: true,
+  message:
+    "Thanks for signing up. If the address is eligible, a verification link is on its way — check your inbox (or ask your administrator if email isn't configured) and verify before signing in.",
+};
+
+function jsonError(status: number, message: string, extra: Record<string, unknown> = {}) {
+  return Response.json(
+    { error: message, ...extra },
+    { status, headers: { "Cache-Control": "no-store" } },
+  );
+}
+
+function ok() {
+  return Response.json(GENERIC_OK, { headers: { "Cache-Control": "no-store" } });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  // 1. Feature gate. A disabled deployment returns 404 — the route is invisible.
+  if (!env.SIGNUP_ENABLED) {
+    return jsonError(404, "Not found.");
+  }
+
+  const hdrs = await headers();
+  const ip = getClientIp(hdrs);
+  const reqContext = getRequestContext(hdrs);
+
+  // 2. CSRF — consistent with the other unauthenticated auth POSTs. No-op when
+  //    there's no session (the normal signup case); enforced if a session
+  //    cookie happens to be present so it can't be forged into an existing one.
+  try {
+    await requireCsrf(request);
+  } catch {
+    return jsonError(403, "CSRF token invalid or missing.");
+  }
+
+  // 3. Per-IP rate limit (shared bucket across replicas when Redis is set).
+  const limit = await sensitiveLimiter.takeShared(`signup:${ip ?? "unknown"}`);
+  if (!limit.allowed) {
+    return jsonError(429, "Too many requests.", { retryAfterSeconds: limit.retryAfterSeconds });
+  }
+
+  // 4. Validate + enforce the password policy. Invalid input is a real 400 —
+  //    it carries no account-existence signal (the address hasn't been looked
+  //    up yet), so a precise validation error is safe and improves UX. We
+  //    return the response inline (rather than throwing) because this handler
+  //    builds its own Responses and has no outer errorResponse() catch.
+  let body;
+  try {
+    body = signupSchema.parse(await request.json());
+  } catch (err) {
+    if (err instanceof ZodError) {
+      const validation = new ValidationError("Invalid input.", {
+        fieldErrors: err.flatten().fieldErrors,
+      });
+      return Response.json(
+        { error: validation.message, details: validation.details },
+        { status: 400, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+    return jsonError(400, "Invalid request body.");
+  }
+
+  // 5. Captcha gate (same shape as login/forgot-password): enforced only when
+  //    TURNSTILE_SECRET_KEY is set, verified BEFORE the DB lookup + hashing.
+  if (env.TURNSTILE_SECRET_KEY) {
+    if (!body.captchaToken) {
+      return jsonError(400, "Captcha required.", { reason: "captcha-required" });
+    }
+    const captcha = await verifyTurnstile({
+      secret: env.TURNSTILE_SECRET_KEY,
+      token: body.captchaToken,
+      remoteIp: ip,
+    });
+    if (!captcha.ok) {
+      logger.warn({ providerReasons: captcha.reasons }, "auth.signup.captcha-failed");
+      return jsonError(400, "Captcha verification failed.", { reason: "captcha-failed" });
+    }
+  }
+
+  // 6. Email-domain allow-list. Empty list = any domain. Rejection audits the
+  //    domain only (never the full address) — PII minimisation, like OIDC's gate.
+  const domainCheck = emailDomainAllowed(body.email, env.SIGNUP_ALLOWED_EMAIL_DOMAINS);
+  if (!domainCheck.ok) {
+    await appendAudit({
+      actor: { type: "system", id: null },
+      action: "auth.signup.rejected",
+      resource: { type: "user", id: null },
+      after: { domain: domainCheck.domain, reason: "domain-not-in-allow-list" },
+      request: reqContext,
+    });
+    logger.warn({ domain: domainCheck.domain }, "auth.signup.domain-rejected");
+    return jsonError(403, "Sign-ups from that email domain are not allowed.", {
+      reason: "domain-not-allowed",
+    });
+  }
+
+  // 7. Existing-account handling — the no-enumeration core. We never reveal
+  //    whether the email is taken; both branches return the SAME GENERIC_OK.
+  const existing = await findUserByEmail(body.email);
+  if (existing) {
+    // Re-send verification ONLY for a still-unverified LOCAL account — i.e. a
+    // user who signed up but never finished. We do NOT touch:
+    //   - verified accounts (already onboarded);
+    //   - SSO-only accounts (no passwordHash — they verify via the IdP);
+    //   - disabled accounts.
+    // In all those cases we silently no-op so the response is indistinguishable
+    // from a fresh signup, and we never reset/rotate an existing credential.
+    if (
+      existing.passwordHash &&
+      existing.emailVerifiedAt === null &&
+      existing.disabledAt === null
+    ) {
+      await issueVerification(existing.id, existing.email, reqContext, "resend");
+    }
+    return ok();
+  }
+
+  // 8. Resolve the default role up-front. Boot validated it exists + is
+  //    low-privilege; if it's somehow gone now, fail closed (500) rather than
+  //    create an unroled user — and stay non-enumerating about it.
+  const defaultRole = await findRoleBySlug(env.SIGNUP_DEFAULT_ROLE);
+  if (!defaultRole) {
+    logger.error(
+      { role: env.SIGNUP_DEFAULT_ROLE },
+      "auth.signup.default-role-missing — refusing to create user without a role",
+    );
+    return jsonError(500, "Sign-up is temporarily unavailable.");
+  }
+
+  // 9. Create the unverified user + assign the default role + audit, atomically.
+  const passwordHash = await hashPassword(body.password);
+  let createdUserId: string;
+  let createdEmail: string;
+  try {
+    const created = await db.transaction(async (tx) => {
+      const row = await insertUser(
+        {
+          email: body.email,
+          name: body.name ?? null,
+          passwordHash,
+          // Unverified by construction — the login gate keeps them out until
+          // they redeem the verification link.
+          emailVerifiedAt: null,
+          // Self-service users pick their own password; no forced change.
+          mustChangePassword: false,
+        },
+        tx,
+      );
+
+      await appendAudit(
+        {
+          actor: { type: "system", id: null },
+          action: "user.create",
+          resource: { type: "user", id: row.id },
+          after: {
+            email: row.email,
+            name: row.name,
+            source: "signup",
+            initialRoleSlug: defaultRole.slug,
+          },
+          request: reqContext,
+        },
+        tx,
+      );
+
+      const assignment = await createRoleAssignment(
+        {
+          userId: row.id,
+          roleId: defaultRole.id,
+          scopeType: "global",
+          scopeId: null,
+          // No human actor — self-service. Null mirrors the bootstrap-seed grant.
+          createdBy: null,
+        },
+        tx,
+      );
+      await appendAudit(
+        {
+          actor: { type: "system", id: null },
+          action: "role.assignment.created",
+          resource: { type: "user", id: row.id },
+          after: {
+            assignmentId: assignment.id,
+            roleId: defaultRole.id,
+            roleSlug: defaultRole.slug,
+            scopeType: "global",
+            scopeId: null,
+            source: "signup",
+          },
+          request: reqContext,
+        },
+        tx,
+      );
+
+      return row;
+    });
+    createdUserId = created.id;
+    createdEmail = created.email;
+  } catch (err) {
+    // A unique-constraint race (two concurrent signups for the same address)
+    // lands here. Stay non-enumerating: return the SAME GENERIC_OK as success.
+    logger.warn(
+      { err: err instanceof Error ? err.message : "unknown" },
+      "auth.signup.insert-conflict-or-error",
+    );
+    return ok();
+  }
+
+  // 10. Send the verification link (outside the tx — email is best-effort and
+  //     must not roll back a committed user). SMTP-off falls back to the audit
+  //     log, exactly like forgot-password / send-verification.
+  await issueVerification(createdUserId, createdEmail, reqContext, "signup");
+
+  logger.info({ userId: createdUserId, role: defaultRole.slug }, "auth.signup.created");
+  return ok();
+}
+
+/**
+ * Mint a `pde_…` verification token for a user and deliver it: email when SMTP
+ * is configured, otherwise record the link in the audit log so an operator can
+ * share it out-of-band. Mirrors `/api/auth/email/send-verification`. Best-effort
+ * — failures are logged, never surfaced (keeps the response non-enumerating).
+ */
+async function issueVerification(
+  userId: string,
+  email: string,
+  reqContext: ReturnType<typeof getRequestContext>,
+  origin: "signup" | "resend",
+): Promise<void> {
+  const { token } = mintVerifyToken({ userId, email, secret: env.APP_SECRET_KEY });
+  const verifyUrl = `${env.APP_URL}/verify-email?token=${encodeURIComponent(token)}`;
+  const mail = await sendEmail({
+    to: email,
+    kind: "email-verification",
+    ...verifyEmailMessage(verifyUrl),
+  });
+
+  await appendAudit({
+    actor: { type: "system", id: null },
+    action: "auth.email.verify.sent",
+    resource: { type: "user", id: userId },
+    after: {
+      email,
+      origin,
+      // Keep the tokenised link in the audit ONLY when SMTP is off, so an
+      // operator can still share it. When emailed, the token stays out of audit.
+      ...(mail.skipped ? { url: verifyUrl } : {}),
+      delivered: mail.ok && !mail.skipped,
+    },
+    request: reqContext,
+  });
+
+  if (mail.skipped) {
+    logger.warn(
+      { userId, verifyUrl },
+      "auth.signup.verify-sent — SMTP disabled; share this URL with the user out-of-band",
+    );
+  } else if (!mail.ok) {
+    logger.error({ userId, error: mail.error }, "auth.signup.verify-send-failed");
+  }
+}

--- a/docs/03-CONFIGURATION.md
+++ b/docs/03-CONFIGURATION.md
@@ -66,10 +66,55 @@ ensures the account exists, created with "must change password on next login".
 
 ## Local authentication
 
-| Variable             | Default | Notes                                                     |
-| -------------------- | ------- | --------------------------------------------------------- |
-| `LOCAL_AUTH_ENABLED` | `true`  | Email + password sign-in. Set `false` for SSO-only.       |
-| `SIGNUP_ENABLED`     | `false` | Public self-service signup. Default: admins create users. |
+| Variable             | Default | Notes                                               |
+| -------------------- | ------- | --------------------------------------------------- |
+| `LOCAL_AUTH_ENABLED` | `true`  | Email + password sign-in. Set `false` for SSO-only. |
+
+## Self-service signup
+
+Off by default — admins create users (or users arrive via OIDC). Turn it on only
+when you want the public to register themselves. When **disabled**, both the
+`/signup` page and `POST /api/auth/signup` return **404** (the feature does not
+exist for the deployment) and no "Create an account" link is shown on the login
+page.
+
+| Variable                       | Default          | Notes                                                                                                   |
+| ------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------- |
+| `SIGNUP_ENABLED`               | `false`          | Master switch. `false` → `/signup` + the API are 404; admins create users.                              |
+| `SIGNUP_DEFAULT_ROLE`          | `read-only`      | Role (slug) every signup receives. **Must be low-privilege** — the seed step refuses to boot otherwise. |
+| `SIGNUP_ALLOWED_EMAIL_DOMAINS` | unset (no limit) | Comma-separated allow-list of email domains. Empty = any domain. Exact-domain, case-insensitive.        |
+
+**`SMTP_*` must be configured** (see [Email / SMTP](#email--smtp-optional)) for verification
+links to be **delivered**. Without SMTP the signup flow still works, but the
+verification link is only recorded in the audit log (action
+`auth.email.verify.sent`, field `after.url`) for an operator to share out-of-band
+— the same fallback the password-reset and email-change flows use.
+
+**Boot-time guard.** When `SIGNUP_ENABLED=true`, the seed step validates
+`SIGNUP_DEFAULT_ROLE` _after_ the system roles are upserted: it must resolve to an
+existing role that is **not** admin-equivalent (no `user.*`, `role.*`,
+`settings.write`, `oidc.manage`, `audit.read`, `server.*`, `team.create/delete`,
+or `token.*.all` permission, and never the `super-admin` slug). A missing or
+over-privileged value **fails the boot loudly** rather than silently turning
+public signup into an admin-account vending machine. The check is inert when
+signup is off.
+
+**End-to-end flow:**
+
+1. Visitor opens `/signup`, enters email + password (Argon2id, min 12 chars) and
+   an optional display name. Per-IP rate-limited; captcha enforced when
+   `TURNSTILE_SECRET_KEY` is set.
+2. The server validates input, enforces `SIGNUP_ALLOWED_EMAIL_DOMAINS`, then
+   creates an **unverified** user assigned exactly `SIGNUP_DEFAULT_ROLE` (one
+   audited transaction) and sends the verification link. The response is the same
+   whether or not the email already exists (**no account enumeration**) — a
+   duplicate silently re-sends verification to an unfinished signup.
+3. The user **cannot log in until verified**: while signup is enabled, any
+   unverified local account is blocked at login (`403`, `reason: email-unverified`).
+   They redeem the link at `/verify-email`, which sets `email_verified_at`.
+4. After verifying, they sign in normally and hold only the low-privilege default
+   role. MFA is **not** required at signup; a role's MFA policy can require it
+   later.
 
 ## OIDC single sign-on
 

--- a/docs/08-HARDENING.md
+++ b/docs/08-HARDENING.md
@@ -37,7 +37,12 @@ exotic — it's the handful of things worth getting right before you expose the 
 - **Require MFA where it matters.** Mark sensitive roles `requires_mfa` so holders
   must enrol TOTP. For SSO users, enforce MFA at the IdP. See [RBAC](./07-RBAC.md#mfa-required-roles).
 - **Keep `SIGNUP_ENABLED=false`** (the default) unless you intend public
-  self-service signup; create users via the admin UI or OIDC instead.
+  self-service signup; create users via the admin UI or OIDC instead. When you do
+  turn it on: keep `SIGNUP_DEFAULT_ROLE` low-privilege (the boot guard enforces
+  this — see [Self-service signup](./03-CONFIGURATION.md#self-service-signup)),
+  restrict who can register with `SIGNUP_ALLOWED_EMAIL_DOMAINS`, configure
+  `SMTP_*` so verification links are actually delivered (signups can't log in
+  until verified), and enable Turnstile to blunt automated registration.
 - **Scope OIDC sign-in** with `allowed_email_domains` (per provider) or
   `OIDC_ALLOWED_EMAIL_DOMAINS` (env) so only your org's emails auto-provision.
 - **Turn on Turnstile** (`TURNSTILE_SITE_KEY` + `TURNSTILE_SECRET_KEY`) for a

--- a/lib/audit/actions.ts
+++ b/lib/audit/actions.ts
@@ -25,6 +25,10 @@ export const AUDIT_ACTIONS = [
   "auth.token.revoked",
   "auth.oidc.linked",
   "auth.oidc.rejected_provisioning",
+  // Self-service signup (SIGNUP_ENABLED) refused before any user row is
+  // created — currently only the email-domain allow-list rejection. The
+  // successful-signup path reuses `user.create` (source: signup).
+  "auth.signup.rejected",
   "auth.password.reset.requested",
   "auth.password.reset.completed",
   "auth.password.reset.invalid",

--- a/lib/auth/signup-policy.test.ts
+++ b/lib/auth/signup-policy.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  ADMIN_EQUIVALENT_PERMISSIONS,
+  checkSignupDefaultRole,
+  isAdminEquivalentRole,
+} from "./signup-policy";
+import { DEFAULT_ROLES, SUPER_ADMIN_SLUG } from "@/lib/rbac/default-roles";
+
+function role(slug: string) {
+  const def = DEFAULT_ROLES.find((r) => r.slug === slug);
+  if (!def) throw new Error(`missing seeded role ${slug}`);
+  return { slug: def.slug, permissions: def.permissions };
+}
+
+describe("isAdminEquivalentRole", () => {
+  it("treats the read-only seeded role as low-privilege", () => {
+    expect(isAdminEquivalentRole(role("read-only"))).toBe(false);
+  });
+
+  it("treats zone-editor as low-privilege (record edits aren't admin-equivalent)", () => {
+    expect(isAdminEquivalentRole(role("zone-editor"))).toBe(false);
+  });
+
+  it("treats operator as low-privilege (zone CRUD only, no identity/settings)", () => {
+    expect(isAdminEquivalentRole(role("operator"))).toBe(false);
+  });
+
+  it("flags super-admin as admin-equivalent", () => {
+    expect(isAdminEquivalentRole(role(SUPER_ADMIN_SLUG))).toBe(true);
+  });
+
+  it("flags team-owner (holds tsig.manage + member mgmt but also team mgmt? check perms)", () => {
+    // team-owner does NOT hold any ADMIN_EQUIVALENT permission per the denylist
+    // (no user/role/settings/server/audit/team.create/team.delete/token.*.all).
+    // Confirm it is therefore treated as low-privilege — a deliberate choice so
+    // an operator could in principle use it, though read-only is the default.
+    expect(isAdminEquivalentRole(role("team-owner"))).toBe(false);
+  });
+
+  it("flags the super-admin SLUG even if its permission set were emptied", () => {
+    expect(isAdminEquivalentRole({ slug: SUPER_ADMIN_SLUG, permissions: [] })).toBe(true);
+  });
+
+  it.each(ADMIN_EQUIVALENT_PERMISSIONS)(
+    "flags a custom role holding the admin-equivalent permission %s",
+    (perm) => {
+      expect(isAdminEquivalentRole({ slug: "custom", permissions: [perm] })).toBe(true);
+    },
+  );
+
+  it("does not flag a custom role with only read + zone-create permissions", () => {
+    expect(
+      isAdminEquivalentRole({
+        slug: "custom-low",
+        permissions: ["zone.read", "zone.create", "record.update"],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("checkSignupDefaultRole", () => {
+  it("reports missing when the slug resolves to no role", () => {
+    expect(checkSignupDefaultRole(null)).toEqual({ ok: false, reason: "missing" });
+  });
+
+  it("reports admin-equivalent for super-admin", () => {
+    expect(checkSignupDefaultRole(role(SUPER_ADMIN_SLUG))).toEqual({
+      ok: false,
+      reason: "admin-equivalent",
+    });
+  });
+
+  it("accepts the read-only role", () => {
+    expect(checkSignupDefaultRole(role("read-only"))).toEqual({ ok: true });
+  });
+});

--- a/lib/auth/signup-policy.ts
+++ b/lib/auth/signup-policy.ts
@@ -1,0 +1,95 @@
+/**
+ * lib/auth/signup-policy.ts
+ *
+ * Pure policy helpers for the self-service signup flow (`SIGNUP_ENABLED`).
+ * DB-free and HTTP-free so the boot-time guard and the route can both unit-test
+ * the rules without dragging in `pg` / Next.
+ *
+ * The central rule: a self-service signup may only ever receive a LOW-PRIVILEGE
+ * role. A misconfigured `SIGNUP_DEFAULT_ROLE` pointing at an admin role would
+ * silently turn public signup into "anyone can become an admin", so we refuse to
+ * boot when the configured role carries any admin-equivalent permission.
+ */
+
+import "server-only";
+import { SUPER_ADMIN_SLUG } from "@/lib/rbac/default-roles";
+import type { Permission } from "@/lib/rbac/permissions";
+
+/**
+ * Permissions that, if held, make a role admin-equivalent for the purposes of
+ * the signup guard. These are the cross-tenant / identity / infrastructure
+ * capabilities that must never be reachable by self-registration. The list is
+ * intentionally conservative — anything that lets the holder grant themselves
+ * more power, manage other identities, change app-wide settings, or read the
+ * audit trail counts.
+ *
+ * This is a denylist (rather than "must be a subset of read-only") so an
+ * operator can safely point `SIGNUP_DEFAULT_ROLE` at a bespoke low-privilege
+ * role that, say, also grants `zone.create` — without us blocking a perfectly
+ * reasonable choice. We only block the genuinely dangerous capabilities.
+ */
+export const ADMIN_EQUIVALENT_PERMISSIONS: readonly Permission[] = [
+  // Identity management — could create/alter/disable other users.
+  "user.create",
+  "user.update",
+  "user.delete",
+  "user.disable",
+  "user.reset-password",
+  // Role management + assignment — the privilege-escalation vector.
+  "role.create",
+  "role.update",
+  "role.delete",
+  "role.assign",
+  // App-wide settings + the OIDC trust config.
+  "settings.write",
+  "oidc.manage",
+  // Audit trail visibility.
+  "audit.read",
+  // Backend (PDNS server) management.
+  "server.create",
+  "server.update",
+  "server.delete",
+  // Team lifecycle (creating/deleting teams + moving members between them).
+  "team.create",
+  "team.delete",
+  // Fleet-wide token visibility/control.
+  "token.read.all",
+  "token.delete.all",
+] as const;
+
+/**
+ * True when a role with these permissions (and slug) is too privileged to be
+ * the default for self-service signup. The super-admin slug is always refused
+ * regardless of its current permission set (defense against a future edit that
+ * empties its permissions but keeps the slug as the privileged anchor used by
+ * the last-SuperAdmin guard).
+ */
+export function isAdminEquivalentRole(role: {
+  slug: string;
+  permissions: readonly string[];
+}): boolean {
+  if (role.slug === SUPER_ADMIN_SLUG) return true;
+  const held = new Set(role.permissions);
+  return ADMIN_EQUIVALENT_PERMISSIONS.some((p) => held.has(p));
+}
+
+/**
+ * Validate a candidate `SIGNUP_DEFAULT_ROLE` against a resolved role row.
+ * Returns a structured result the caller turns into a loud boot failure.
+ *
+ *   - `null` role → the configured slug doesn't exist.
+ *   - admin-equivalent role → refused (the whole point of the guard).
+ *   - otherwise → ok.
+ */
+export type SignupDefaultRoleCheck =
+  | { ok: true }
+  | { ok: false; reason: "missing" }
+  | { ok: false; reason: "admin-equivalent" };
+
+export function checkSignupDefaultRole(
+  role: { slug: string; permissions: readonly string[] } | null,
+): SignupDefaultRoleCheck {
+  if (!role) return { ok: false, reason: "missing" };
+  if (isAdminEquivalentRole(role)) return { ok: false, reason: "admin-equivalent" };
+  return { ok: true };
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -127,6 +127,35 @@ const envSchema = z.object({
     .transform((s) => s.toLowerCase() === "true")
     .pipe(z.boolean())
     .default(false),
+  /**
+   * Role (by slug) assigned to every self-service signup. Defaults to the
+   * seeded low-privilege `read-only` role. This is the ONLY role a signup
+   * ever receives — there is no path from public signup to an admin role.
+   *
+   * The slug's existence and low-privilege nature are verified at boot by the
+   * seed step (`scripts/seed.ts`), AFTER the system roles are upserted: if the
+   * configured role is missing or holds an admin-equivalent permission, the
+   * boot fails loudly. We can't validate it here in the env schema because the
+   * check needs the DB (the role table), which isn't available at env-parse
+   * time. See `lib/auth/signup-policy.ts` for the pure low-privilege predicate.
+   */
+  SIGNUP_DEFAULT_ROLE: z.string().min(1).default("read-only"),
+  /**
+   * Comma-separated email-domain allow-list for self-service signups. Mirrors
+   * `OIDC_ALLOWED_EMAIL_DOMAINS`: empty / unset means "any domain". Matching is
+   * case-insensitive on the part after the rightmost `@`, exact-domain only
+   * (a subdomain needs its own entry). Enforced before any user row is created.
+   */
+  SIGNUP_ALLOWED_EMAIL_DOMAINS: z
+    .string()
+    .optional()
+    .transform((s) =>
+      (s ?? "")
+        .split(",")
+        .map((d) => d.trim().toLowerCase())
+        .filter((d) => d.length > 0),
+    )
+    .pipe(z.array(z.string())),
 
   // --- Bootstrap admin (run on seed if no users exist) ---
   BOOTSTRAP_ADMIN_EMAIL: z.string().email().optional(),
@@ -338,6 +367,8 @@ const ENV_KEYS = [
   "COOKIE_DOMAIN",
   "LOCAL_AUTH_ENABLED",
   "SIGNUP_ENABLED",
+  "SIGNUP_DEFAULT_ROLE",
+  "SIGNUP_ALLOWED_EMAIL_DOMAINS",
   "BOOTSTRAP_ADMIN_EMAIL",
   "BOOTSTRAP_ADMIN_PASSWORD",
   "OIDC_ENABLED",

--- a/lib/validators/password-policy.ts
+++ b/lib/validators/password-policy.ts
@@ -1,0 +1,12 @@
+/**
+ * lib/validators/password-policy.ts
+ *
+ * Client-safe password-policy constants. Deliberately has NO `server-only`
+ * import and no server dependencies, so client components (e.g. the signup /
+ * login forms) can mirror the policy for instant feedback. The authoritative
+ * enforcement still happens server-side in `lib/validators/users.ts` (which
+ * re-exports these) and `lib/auth/password.ts`.
+ */
+
+/** Minimum password length we accept anywhere local passwords are written. */
+export const MIN_PASSWORD_LENGTH = 12;

--- a/lib/validators/users.test.ts
+++ b/lib/validators/users.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { MIN_PASSWORD_LENGTH, signupSchema } from "./users";
+
+const validPassword = "a".repeat(MIN_PASSWORD_LENGTH);
+
+describe("signupSchema", () => {
+  it("accepts a valid email + policy-compliant password", () => {
+    const parsed = signupSchema.parse({ email: "user@example.com", password: validPassword });
+    expect(parsed.email).toBe("user@example.com");
+    expect(parsed.password).toBe(validPassword);
+    expect(parsed.name).toBeUndefined();
+  });
+
+  it("rejects an invalid email", () => {
+    expect(() => signupSchema.parse({ email: "not-an-email", password: validPassword })).toThrow();
+  });
+
+  it("rejects a password shorter than the policy minimum", () => {
+    const short = "a".repeat(MIN_PASSWORD_LENGTH - 1);
+    const result = signupSchema.safeParse({ email: "user@example.com", password: short });
+    expect(result.success).toBe(false);
+  });
+
+  it("trims a provided name and keeps it", () => {
+    const parsed = signupSchema.parse({
+      email: "user@example.com",
+      password: validPassword,
+      name: "  Ada Lovelace  ",
+    });
+    expect(parsed.name).toBe("Ada Lovelace");
+  });
+
+  it("normalises a whitespace-only name to undefined", () => {
+    const parsed = signupSchema.parse({
+      email: "user@example.com",
+      password: validPassword,
+      name: "   ",
+    });
+    expect(parsed.name).toBeUndefined();
+  });
+
+  it("accepts an optional captcha token", () => {
+    const parsed = signupSchema.parse({
+      email: "user@example.com",
+      password: validPassword,
+      captchaToken: "tok",
+    });
+    expect(parsed.captchaToken).toBe("tok");
+  });
+
+  it("rejects an over-long name", () => {
+    const result = signupSchema.safeParse({
+      email: "user@example.com",
+      password: validPassword,
+      name: "x".repeat(121),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/lib/validators/users.ts
+++ b/lib/validators/users.ts
@@ -6,9 +6,11 @@
 
 import "server-only";
 import { z } from "zod";
+// Re-exported from a client-safe module so client forms can mirror the policy
+// without pulling this `server-only` module into a client bundle (issue #32).
+import { MIN_PASSWORD_LENGTH } from "./password-policy";
 
-/** Minimum password length we accept anywhere local passwords are written. */
-export const MIN_PASSWORD_LENGTH = 12;
+export { MIN_PASSWORD_LENGTH };
 
 export const passwordSchema = z
   .string()

--- a/lib/validators/users.ts
+++ b/lib/validators/users.ts
@@ -66,6 +66,31 @@ export const profileNameSchema = z.object({
 });
 
 // =============================================================================
+// Self-service signup (SIGNUP_ENABLED)
+// =============================================================================
+
+export const signupSchema = z.object({
+  email: emailSchema,
+  // Reuse the app-wide password policy (Argon2id + min length) so a self-service
+  // signup can't set a weaker password than an admin-created account.
+  password: passwordSchema,
+  // Optional display name. Empty/whitespace is normalised to undefined so the
+  // user row stores NULL rather than an empty string.
+  name: z
+    .string()
+    .max(120, "Name is too long.")
+    .transform((s) => s.trim())
+    .optional()
+    .transform((s) => (s && s.length > 0 ? s : undefined)),
+  // Cloudflare Turnstile response token. Required by the route when
+  // TURNSTILE_SECRET_KEY is configured; accepted unconditionally so dev clients
+  // without the widget still validate (the route decides enforcement).
+  captchaToken: z.string().max(4096).optional(),
+});
+
+export type SignupInput = z.infer<typeof signupSchema>;
+
+// =============================================================================
 // Admin — create / update user
 // =============================================================================
 

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -34,6 +34,7 @@ import { findUserByEmail } from "@/lib/db/repositories/users";
 import { hashPassword } from "@/lib/auth/password";
 import { appendAudit } from "@/lib/audit/log";
 import { DEFAULT_ROLES } from "@/lib/rbac/default-roles";
+import { checkSignupDefaultRole } from "@/lib/auth/signup-policy";
 import { roleAssignments, users } from "@/lib/db/schema";
 
 async function seedRoles(): Promise<void> {
@@ -156,10 +157,40 @@ async function seedBootstrapAdmin(): Promise<void> {
   });
 }
 
+/**
+ * Boot-time guard for self-service signup (`SIGNUP_ENABLED`). Runs after the
+ * system roles are upserted so a default pointing at a seeded role resolves.
+ *
+ * Refuses to boot — same loud-failure contract as the env/SMTP checks — when
+ * `SIGNUP_DEFAULT_ROLE` either doesn't exist or is admin-equivalent. Without
+ * this, a typo'd or over-privileged default would turn public signup into a
+ * silent admin-account vending machine. Only enforced when signup is on; when
+ * it's off the var is inert and an operator can leave it at any value.
+ */
+async function validateSignupDefaultRole(): Promise<void> {
+  if (!env.SIGNUP_ENABLED) {
+    logger.info("seed.signup.skipped: SIGNUP_ENABLED=false");
+    return;
+  }
+  const slug = env.SIGNUP_DEFAULT_ROLE;
+  const role = await findRoleBySlug(slug);
+  const check = checkSignupDefaultRole(role);
+  if (check.ok) {
+    logger.info({ role: slug }, "seed.signup.default-role.ok");
+    return;
+  }
+  const detail =
+    check.reason === "missing"
+      ? `SIGNUP_DEFAULT_ROLE="${slug}" does not match any role. Create the role first, or point it at a seeded low-privilege role (e.g. "read-only").`
+      : `SIGNUP_DEFAULT_ROLE="${slug}" is admin-equivalent. Self-service signup must only grant a low-privilege role — pick one without user/role/settings/server/audit permissions (e.g. "read-only").`;
+  throw new Error(`seed.signup: refusing to boot — ${detail}`);
+}
+
 async function main(): Promise<void> {
   logger.info("seed.start");
   try {
     await seedRoles();
+    await validateSignupDefaultRole();
     await seedBootstrapAdmin();
     logger.info("seed.complete");
   } finally {

--- a/tests/integration/auth/signup.test.ts
+++ b/tests/integration/auth/signup.test.ts
@@ -1,0 +1,180 @@
+/**
+ * tests/integration/auth/signup.test.ts
+ *
+ * POST /api/auth/signup — public self-service signup, gated by SIGNUP_ENABLED.
+ *
+ * The shared integration stack boots with SIGNUP_ENABLED unset (signup OFF) so
+ * the existing auth suite's admin-created/unverified login flows keep working.
+ * We therefore:
+ *   - ALWAYS assert the disabled→404 / enabled→200 contract against whatever
+ *     stack is up;
+ *   - run the full happy-path / non-enumeration / allow-list / rate-limit /
+ *     verification-gate suite only when SIGNUP_INTEGRATION is set, which signals
+ *     the stack was booted with SIGNUP_ENABLED=true (SMTP unset → audit-log
+ *     fallback). Without it those cases skip (the spec's "skip when prereqs
+ *     aren't met" contract).
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { anonClient } from "../helpers/http";
+import { loginAs, uniqueEmail } from "../helpers/auth";
+import { dbQuery } from "../helpers/db";
+import { resetState } from "../helpers/reset";
+
+const STRONG_PASSWORD = "signup-passw0rd-1234";
+
+describe("POST /api/auth/signup — feature gate", () => {
+  it("returns 404 when disabled, or a uniform 200 OK when enabled", async () => {
+    const res = await anonClient().call("/api/auth/signup", {
+      method: "POST",
+      json: { email: uniqueEmail("gate"), password: STRONG_PASSWORD },
+    });
+    expect([200, 404]).toContain(res.status);
+  });
+});
+
+describe.skipIf(!process.env["SIGNUP_INTEGRATION"])(
+  "POST /api/auth/signup — full flow (requires SIGNUP_ENABLED=true)",
+  () => {
+    beforeEach(async () => {
+      await resetState({ skipPdns: true });
+    });
+
+    it("happy path: creates an UNVERIFIED user with the default role + audit + verification", async () => {
+      const email = uniqueEmail("signup-ok");
+      const res = await anonClient().call("/api/auth/signup", {
+        method: "POST",
+        json: { email, password: STRONG_PASSWORD, name: "New Person" },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: boolean; message: string };
+      expect(body.ok).toBe(true);
+
+      const users = await dbQuery<{
+        id: string;
+        email_verified_at: string | null;
+        password_hash: string | null;
+        must_change_password: boolean;
+      }>(
+        "SELECT id, email_verified_at, password_hash, must_change_password FROM users WHERE lower(email) = lower($1)",
+        [email],
+      );
+      expect(users).toHaveLength(1);
+      const user = users[0]!;
+      expect(user.email_verified_at).toBeNull(); // unverified by construction
+      expect(user.password_hash).toMatch(/^\$argon2id\$/); // Argon2id
+      expect(user.must_change_password).toBe(false); // self-chosen password
+
+      // Exactly one global role assignment, the default low-privilege role.
+      const roles = await dbQuery<{ slug: string; scope_type: string }>(
+        `SELECT r.slug, ra.scope_type FROM role_assignments ra
+           JOIN roles r ON r.id = ra.role_id WHERE ra.user_id = $1`,
+        [user.id],
+      );
+      expect(roles).toHaveLength(1);
+      expect(roles[0]!.scope_type).toBe("global");
+      expect(roles[0]!.slug).toBe(process.env["SIGNUP_DEFAULT_ROLE"] ?? "read-only");
+
+      // user.create (source: signup) + role assignment + verification-sent audit.
+      const actions = (
+        await dbQuery<{ action: string }>(
+          "SELECT action FROM audit_log WHERE resource_id = $1 ORDER BY created_at",
+          [user.id],
+        )
+      ).map((a) => a.action);
+      expect(actions).toContain("user.create");
+      expect(actions).toContain("role.assignment.created");
+      expect(actions).toContain("auth.email.verify.sent");
+    });
+
+    it("created user CANNOT log in until verified, then CAN after verification", async () => {
+      const email = uniqueEmail("signup-gate");
+      await anonClient().call("/api/auth/signup", {
+        method: "POST",
+        json: { email, password: STRONG_PASSWORD },
+      });
+
+      const blocked = await anonClient().call("/api/auth/login", {
+        method: "POST",
+        json: { email, password: STRONG_PASSWORD },
+      });
+      expect(blocked.status).toBe(403);
+      expect(((await blocked.json()) as { reason?: string }).reason).toBe("email-unverified");
+
+      await dbQuery("UPDATE users SET email_verified_at = now() WHERE lower(email) = lower($1)", [
+        email,
+      ]);
+      const client = await loginAs(email, STRONG_PASSWORD);
+      expect(client.hasCookie("pda_csrf")).toBe(true);
+    });
+
+    it("duplicate email is NON-enumerating: same status/body, no second user", async () => {
+      const email = uniqueEmail("signup-dup");
+      const first = await anonClient().call("/api/auth/signup", {
+        method: "POST",
+        json: { email, password: STRONG_PASSWORD },
+      });
+      const firstBody = (await first.json()) as Record<string, unknown>;
+
+      const second = await anonClient().call("/api/auth/signup", {
+        method: "POST",
+        json: { email, password: "totally-different-pw-99" },
+      });
+      const secondBody = (await second.json()) as Record<string, unknown>;
+
+      expect(second.status).toBe(first.status);
+      expect(secondBody).toEqual(firstBody);
+
+      const users = await dbQuery("SELECT id FROM users WHERE lower(email) = lower($1)", [email]);
+      expect(users).toHaveLength(1);
+    });
+
+    it("rejects a weak/short password with 400", async () => {
+      const res = await anonClient().call("/api/auth/signup", {
+        method: "POST",
+        json: { email: uniqueEmail("signup-weak"), password: "short" },
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rate-limits a burst of signups from one IP", async () => {
+      const client = anonClient(); // one client == one source IP
+      let saw429 = false;
+      for (let i = 0; i < 8; i++) {
+        const res = await client.call("/api/auth/signup", {
+          method: "POST",
+          json: { email: uniqueEmail(`signup-rl-${i}`), password: STRONG_PASSWORD },
+        });
+        if (res.status === 429) {
+          saw429 = true;
+          break;
+        }
+      }
+      // sensitiveLimiter is capacity 3 — a burst of 8 must trip it.
+      expect(saw429).toBe(true);
+    });
+  },
+);
+
+/**
+ * Domain allow-list rejection. Requires a stack booted with
+ * SIGNUP_ALLOWED_EMAIL_DOMAINS set to a list that EXCLUDES the test domain
+ * (signalled by SIGNUP_INTEGRATION_DOMAIN_DENY) so an out-of-list address is
+ * rejected with 403/domain-not-allowed and no user is created.
+ */
+describe.skipIf(!process.env["SIGNUP_INTEGRATION_DOMAIN_DENY"])(
+  "POST /api/auth/signup — email-domain allow-list",
+  () => {
+    it("rejects an out-of-allow-list domain with 403 and creates no user", async () => {
+      const email = `signup-denied-${Date.now()}@blocked.invalid`;
+      const res = await anonClient().call("/api/auth/signup", {
+        method: "POST",
+        json: { email, password: STRONG_PASSWORD },
+      });
+      expect(res.status).toBe(403);
+      expect(((await res.json()) as { reason?: string }).reason).toBe("domain-not-allowed");
+      const users = await dbQuery("SELECT id FROM users WHERE lower(email) = lower($1)", [email]);
+      expect(users).toHaveLength(0);
+    });
+  },
+);


### PR DESCRIPTION
## What

Implements secure public **self-service signup**, gated by the existing `SIGNUP_ENABLED` env var (until now a no-op placeholder — no page, no route, nothing read it).

## End-to-end flow

1. With `SIGNUP_ENABLED=true`, a visitor opens `/signup` (a "Create an account" link appears on the login page) and registers with email + password (Argon2id, min 12 chars) + optional name. Per-IP rate-limited; captcha enforced when `TURNSTILE_SECRET_KEY` is set.
2. The server validates input, enforces `SIGNUP_ALLOWED_EMAIL_DOMAINS`, then creates an **unverified** user assigned **exactly** the low-privilege `SIGNUP_DEFAULT_ROLE` — user insert + role assignment + both audit rows in **one transaction**.
3. A verification link is **emailed** when SMTP is configured, otherwise recorded in the audit log (`auth.email.verify.sent`, `after.url`) for out-of-band sharing — same fallback as password-reset / email-change.
4. The user **cannot log in until verified**: while signup is on, an unverified local account is blocked at login (`403`, `reason: email-unverified`). After redeeming the link at `/verify-email`, they sign in normally with only the default role.

## Security properties (all enforced)

- **Off by default**; `/signup` page and `POST /api/auth/signup` both return **404** when disabled (no UI link either).
- **Argon2id** + the app-wide password policy (reuses `lib/auth/password` + the `passwordSchema`).
- **Per-IP rate limit** via `sensitiveLimiter.takeShared` (same tier as forgot-password).
- **CSRF** handled like the other unauthenticated auth POSTs (`requireCsrf` is a no-op pre-session; can't be forged into an existing session).
- **Email verification required before login** (audit-log fallback when SMTP is unset).
- **Email-domain allow-list** (`SIGNUP_ALLOWED_EMAIL_DOMAINS`, mirrors `OIDC_ALLOWED_EMAIL_DOMAINS`); rejection audits the **domain only**, never the address.
- **Low-privilege default role, validated at boot**: `scripts/seed.ts` refuses to start when `SIGNUP_DEFAULT_ROLE` is missing or admin-equivalent (any `user.*`/`role.*`/`settings.write`/`oidc.manage`/`audit.read`/`server.*`/`team.create-delete`/`token.*.all` perm, or the `super-admin` slug).
- **No user enumeration**: identical response whether or not the email exists; a duplicate silently re-sends verification to an unfinished signup and never reveals existence or rotates a credential.
- **Audited**: `user.create` (source: signup) + `role.assignment.created`, transactional with the insert; new `auth.signup.rejected` action for domain rejections.
- **MFA not required at signup** (role policy can require it later).

## Required env / SMTP

| Var | Default | Notes |
| --- | --- | --- |
| `SIGNUP_ENABLED` | `false` | Master switch. `false` → 404. |
| `SIGNUP_DEFAULT_ROLE` | `read-only` | Role slug for new signups; boot-validated low-privilege. |
| `SIGNUP_ALLOWED_EMAIL_DOMAINS` | unset (any) | Comma-separated allow-list. |

**Configure `SMTP_*`** for verification links to be delivered; without SMTP the link is only recorded in the audit log.

## Tests

- Unit (`npm run test`, all green): `lib/auth/signup-policy.test.ts` (admin-equivalent / default-role guard), `lib/validators/users.test.ts` (signup schema).
- Integration (`tests/integration/auth/signup.test.ts`): always-on disabled→404/enabled→200 contract; full flow (happy path → unverified user + default role + audit + verification, login-blocked-until-verified, non-enumerating duplicate, weak password, rate limit) and domain-allowlist rejection run when the stack is booted with `SIGNUP_ENABLED=true` (`SIGNUP_INTEGRATION` / `SIGNUP_INTEGRATION_DOMAIN_DENY` flags) — they skip against the shared stack, which keeps signup off so the existing auth suite's unverified-login flows are unchanged.

## Docs

`docs/03-CONFIGURATION.md` (new "Self-service signup" section + var table), `docs/08-HARDENING.md`, `.env.example`.

## Gate results

`npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run test` — all pass.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)