### PR TITLE
fix(security): resolve 6 advisories — privilege ceilings, OIDC email-verify, GCM tag, login race, last-admin guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,38 @@ All notable changes to this project are documented here. The format is based on
 
 ### Security
 
-- **OIDC `requireEmailVerified` default changed to `true` (GHSA-24hf-rxww-95cf).** The
+Coordinated batch resolving six advisories (GHSA-gjg4-58c5-2qg3, GHSA-wf29-rmhc-rqc9,
+GHSA-24hf-rxww-95cf, GHSA-phv2-wjmm-pqqq, GHSA-frpq-xgm7-574x, GHSA-86v6-w5p9-29r8).
+
+- **Zone-grant route now enforces the permission ceiling (GHSA-gjg4-58c5-2qg3, high).** The
+  per-user zone-grant route assigned a role's permissions without checking them against the
+  granting admin's own authority, so an admin could grant — through a zone scope — permissions
+  they didn't hold globally (privilege escalation). It now applies the same
+  `permissionsExceedingGrant` ceiling as role assignment.
+- **OIDC group→role mappings now enforce the permission ceiling (GHSA-wf29-rmhc-rqc9, high).** An
+  `oidc.manage` holder could map an IdP group to a role granting permissions they lacked, then
+  escalate by signing in through that group. Mappings are rejected at save time unless every
+  mapped role is within the actor's global permission ceiling.
+- **OIDC `requireEmailVerified` default changed to `true` (GHSA-24hf-rxww-95cf, high).** The
   `createOidcProviderSchema` previously defaulted `requireEmailVerified` to `false`, shipping
   new DB-configured OIDC providers with the account-takeover guard disabled. The default is now
   `true`, matching the documented intent and the env-provider behaviour. **Existing DB rows
   keep their stored value** — operators should audit any provider where `requireEmailVerified`
   is `false` and confirm the IdP does not emit the `email_verified` claim before retaining
   that setting.
+- **AES-GCM authentication-tag length enforced on decrypt (GHSA-phv2-wjmm-pqqq, medium).**
+  `decrypt()` accepted a truncated GCM auth tag (Node permits tags ≥ 4 bytes by default),
+  silently downgrading integrity strength. It now requires the standard 12-byte IV and 16-byte
+  tag and passes `authTagLength` as defence-in-depth.
+- **Failed-login counter increment made atomic (GHSA-frpq-xgm7-574x, medium).** The lockout
+  counter used a read-modify-write, so concurrent failed logins could lose increments and exceed
+  the lockout threshold. The increment is now a single atomic
+  `failed_login_count = failed_login_count + 1 … RETURNING` statement.
+- **Last-Super-Admin guard hardened (GHSA-86v6-w5p9-29r8, medium).** The guard counted raw
+  assignment rows (including disabled users and duplicate rows), so the last _usable_ global
+  Super Admin could be disabled or deleted — locking the install out of its own administration.
+  It now counts distinct **enabled** users and also covers the user disable + delete routes
+  (previously only assignment removal was guarded).
 
 ## [1.1.0] — 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
-_Nothing yet._
+### Security
+
+- **OIDC `requireEmailVerified` default changed to `true` (GHSA-24hf-rxww-95cf).** The
+  `createOidcProviderSchema` previously defaulted `requireEmailVerified` to `false`, shipping
+  new DB-configured OIDC providers with the account-takeover guard disabled. The default is now
+  `true`, matching the documented intent and the env-provider behaviour. **Existing DB rows
+  keep their stored value** — operators should audit any provider where `requireEmailVerified`
+  is `false` and confirm the IdP does not emit the `email_verified` claim before retaining
+  that setting.
 
 ## [1.1.0] — 2026-05-24
 

--- a/app/api/admin/oidc-providers/[id]/route.ts
+++ b/app/api/admin/oidc-providers/[id]/route.ts
@@ -28,6 +28,7 @@ import { updateOidcProviderSchema } from "@/lib/validators/oidc-providers";
 import { invalidateOidcConfigCache } from "@/lib/auth/providers/oidc";
 import { probeOidcDiscovery } from "@/lib/auth/providers/oidc-probe";
 import { assertSafeOidcIssuerUrl } from "@/lib/auth/providers/oidc-url-safety";
+import { assertGroupMappingsWithinCeiling } from "@/lib/rbac/oidc-mapping-ceiling";
 import { NotFoundError, ValidationError } from "@/lib/errors";
 import { errorResponse } from "@/lib/http/error-response";
 import { logger } from "@/lib/logger";
@@ -60,6 +61,12 @@ export async function PATCH(request: Request, context: RouteContext): Promise<Re
     // SSRF guard before persisting a changed issuer (it's fetched server-side).
     if (input.issuerUrl !== undefined && input.issuerUrl !== existing.issuerUrl) {
       await assertSafeOidcIssuerUrl(input.issuerUrl);
+    }
+
+    // Privilege ceiling (GHSA-wf29-rmhc-rqc9): same guard as create — a PATCH
+    // that sets/changes the mappings must stay within the actor's global grant.
+    if (input.groupMappings !== undefined) {
+      await assertGroupMappingsWithinCeiling(user.id, input.groupMappings);
     }
 
     const patch: Parameters<typeof updateOidcProvider>[1] = {};

--- a/app/api/admin/oidc-providers/route.ts
+++ b/app/api/admin/oidc-providers/route.ts
@@ -23,6 +23,7 @@ import {
 import { createOidcProviderSchema } from "@/lib/validators/oidc-providers";
 import { probeOidcDiscovery } from "@/lib/auth/providers/oidc-probe";
 import { assertSafeOidcIssuerUrl } from "@/lib/auth/providers/oidc-url-safety";
+import { assertGroupMappingsWithinCeiling } from "@/lib/rbac/oidc-mapping-ceiling";
 import { ConflictError, ValidationError } from "@/lib/errors";
 import { errorResponse } from "@/lib/http/error-response";
 import { logger } from "@/lib/logger";
@@ -64,6 +65,11 @@ export async function POST(request: Request): Promise<Response> {
     // SSRF guard: the issuer is fetched server-side (probe + sign-in discovery),
     // so it must resolve to a public address (link-local/metadata always blocked).
     await assertSafeOidcIssuerUrl(input.issuerUrl);
+
+    // Privilege ceiling (GHSA-wf29-rmhc-rqc9): group→role mappings auto-assign
+    // roles at first sign-in, so they can't carry permissions the actor lacks
+    // globally — otherwise `oidc.manage` would launder privilege through the IdP.
+    await assertGroupMappingsWithinCeiling(user.id, input.groupMappings ?? null);
 
     const clientSecretEncrypted = encrypt(input.clientSecret, "oidc-client-secret");
 

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -16,9 +16,14 @@ import { requireUser } from "@/lib/auth/require-user";
 import { requireCsrf } from "@/lib/auth/csrf";
 import { db } from "@/lib/db";
 import { deleteUserById, findUserById, updateUser } from "@/lib/db/repositories/users";
+import {
+  countGlobalAssignmentsOfRoleSlug,
+  userHoldsGlobalRoleSlug,
+} from "@/lib/db/repositories/roles";
 import { revokeSessionsForUser } from "@/lib/db/repositories/sessions";
+import { SUPER_ADMIN_SLUG } from "@/lib/rbac/default-roles";
 import { updateUserSchema } from "@/lib/validators/users";
-import { NotFoundError, ValidationError } from "@/lib/errors";
+import { ForbiddenError, NotFoundError, ValidationError } from "@/lib/errors";
 import { errorResponse } from "@/lib/http/error-response";
 
 interface RouteContext {
@@ -60,6 +65,25 @@ export async function PATCH(request: Request, context: RouteContext): Promise<Re
 
     const hdrs = await headers();
     const updated = await db.transaction(async (tx) => {
+      // Last-SuperAdmin guard (GHSA-86v6-w5p9-29r8): disabling the final
+      // *enabled* global Super Admin would lock everyone out of user/role/
+      // settings management just as surely as deleting their assignment would.
+      // Only relevant when the target is currently enabled — re-disabling an
+      // already-disabled account can't reduce the enabled population. The target
+      // is still counted here, so `<= 1` means they're the last one. Checked
+      // inside the tx so a concurrent disable/delete can't race past it (mirrors
+      // the assignment-delete route).
+      if (
+        input.disabled === true &&
+        existing.disabledAt === null &&
+        (await userHoldsGlobalRoleSlug(id, SUPER_ADMIN_SLUG, tx))
+      ) {
+        const enabled = await countGlobalAssignmentsOfRoleSlug(SUPER_ADMIN_SLUG, tx);
+        if (enabled <= 1) {
+          throw new ForbiddenError("Cannot disable the last global Super Admin.");
+        }
+      }
+
       const u = await updateUser(id, patch, tx);
       if (!u) throw new NotFoundError("User not found.");
 
@@ -106,6 +130,22 @@ export async function DELETE(request: Request, context: RouteContext): Promise<R
 
     const hdrs = await headers();
     await db.transaction(async (tx) => {
+      // Last-SuperAdmin guard (GHSA-86v6-w5p9-29r8): deleting the final enabled
+      // global Super Admin locks everyone out of administration. Only relevant
+      // when the target is currently enabled — a disabled account isn't part of
+      // the enabled population, so deleting it can't drop the count. The target
+      // is still counted here, so `<= 1` means they're the last one. Inside the
+      // tx to block a concurrent disable/delete.
+      if (
+        existing.disabledAt === null &&
+        (await userHoldsGlobalRoleSlug(id, SUPER_ADMIN_SLUG, tx))
+      ) {
+        const enabled = await countGlobalAssignmentsOfRoleSlug(SUPER_ADMIN_SLUG, tx);
+        if (enabled <= 1) {
+          throw new ForbiddenError("Cannot delete the last global Super Admin.");
+        }
+      }
+
       await deleteUserById(id, tx);
       await appendAudit(
         {

--- a/app/api/admin/users/[id]/zone-grants/route.ts
+++ b/app/api/admin/users/[id]/zone-grants/route.ts
@@ -25,8 +25,11 @@ import { zoneGrants } from "@/lib/db/schema";
 import { findGrant, listGrantsForUser } from "@/lib/db/repositories/zone-grants";
 import { findPdnsServerById } from "@/lib/db/repositories/pdns-servers";
 import { findUserById } from "@/lib/db/repositories/users";
+import { loadUserAssignmentsForAbility } from "@/lib/db/repositories/roles";
 import { PERMISSIONS } from "@/lib/rbac/permissions";
-import { ConflictError, NotFoundError, ValidationError } from "@/lib/errors";
+import { globalPermissionsOf, type AbilitySource } from "@/lib/rbac/ability";
+import { effectiveZonePermissions } from "@/lib/rbac/zone-permissions";
+import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from "@/lib/errors";
 import { errorResponse } from "@/lib/http/error-response";
 
 const PERMISSION_SET = new Set<string>(PERMISSIONS);
@@ -94,6 +97,26 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
     const server = await findPdnsServerById(input.serverId);
     if (!server || server.disabledAt) {
       throw new ValidationError("Unknown or disabled PowerDNS backend.");
+    }
+
+    // Privilege ceiling (GHSA-gjg4-58c5-2qg3): an operator can only grant
+    // permissions they themselves hold *effectively* for this (server, zone) —
+    // i.e. their GLOBAL permissions plus their own zone_grants for the same
+    // (server, zone). Without this, a `user.update` holder with a narrow grant
+    // could mint a broader grant for another user (or themselves) and escalate.
+    const actorSources = (await loadUserAssignmentsForAbility(
+      actor.id,
+    )) as readonly AbilitySource[];
+    const actorGlobal = globalPermissionsOf(actorSources);
+    const actorGrants = await listGrantsForUser(actor.id);
+    const actorZonePerms = effectiveZonePermissions(actorGrants, input.serverId, zoneName);
+    const exceeding = input.permissions.filter(
+      (p) => !actorGlobal.has(p as (typeof PERMISSIONS)[number]) && !actorZonePerms.has(p),
+    );
+    if (exceeding.length > 0) {
+      throw new ForbiddenError(
+        `You can't grant permissions you don't hold for this zone: ${exceeding.join(", ")}.`,
+      );
     }
 
     // Refuse duplicate via the unique index — explicit check for a

--- a/lib/crypto/encryption.test.ts
+++ b/lib/crypto/encryption.test.ts
@@ -94,6 +94,39 @@ describe("decrypt — tamper + format rejection", () => {
   });
 });
 
+describe("decrypt — GCM tag/IV length validation (GHSA-phv2-wjmm-pqqq)", () => {
+  it("round-trips correctly after the fix", () => {
+    const plaintext = "ghsa-phv2-wjmm-pqqq regression";
+    expect(decrypt(encrypt(plaintext))).toBe(plaintext);
+  });
+
+  it("rejects a truncated (4-byte) auth tag — would downgrade to 2^-32 without the fix", () => {
+    const [version, ivB64, ctB64, tagB64] = encrypt("secret").split(":");
+    // Decode the real 16-byte tag and slice it to 4 bytes, then re-encode.
+    const truncatedTag = Buffer.from(tagB64!, "base64url").subarray(0, 4).toString("base64url");
+    const tampered = [version, ivB64, ctB64, truncatedTag].join(":");
+    expect(() => decrypt(tampered)).toThrow(/invalid auth tag length/i);
+  });
+
+  it("rejects an extended (32-byte) auth tag", () => {
+    const [version, ivB64, ctB64, tagB64] = encrypt("secret").split(":");
+    // Extend the tag by appending extra zero bytes — still shouldn't be accepted.
+    const extendedTag = Buffer.concat([
+      Buffer.from(tagB64!, "base64url"),
+      Buffer.alloc(16),
+    ]).toString("base64url");
+    const tampered = [version, ivB64, ctB64, extendedTag].join(":");
+    expect(() => decrypt(tampered)).toThrow(/invalid auth tag length/i);
+  });
+
+  it("rejects an IV shorter than 12 bytes", () => {
+    const [version, , ctB64, tagB64] = encrypt("secret").split(":");
+    const shortIv = Buffer.alloc(8).toString("base64url");
+    const tampered = [version, shortIv, ctB64, tagB64].join(":");
+    expect(() => decrypt(tampered)).toThrow(/invalid IV length/i);
+  });
+});
+
 describe("looksLikeEnvelope", () => {
   it("is true for a real envelope", () => {
     expect(looksLikeEnvelope(encrypt("x"))).toBe(true);

--- a/lib/crypto/encryption.ts
+++ b/lib/crypto/encryption.ts
@@ -87,7 +87,20 @@ export function decrypt(envelope: string, usage = "default"): string {
   const ciphertext = Buffer.from(ctB64, "base64url");
   const authTag = Buffer.from(tagB64, "base64url");
 
-  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  // Node's GCM decipher accepts any auth tag length ≥ 4 bytes by default,
+  // which would silently downgrade authentication strength from 2^-128 to
+  // 2^-32 for a truncated tag. Reject anything other than the standard
+  // 16-byte (128-bit) tag we write on encrypt, and pass authTagLength as
+  // defence-in-depth so Node never sees a shorter tag even if a caller
+  // somehow bypasses this check.
+  if (iv.length !== 12) {
+    throw new Error("Encryption envelope has invalid IV length.");
+  }
+  if (authTag.length !== 16) {
+    throw new Error("Encryption envelope has invalid auth tag length.");
+  }
+
+  const decipher = createDecipheriv("aes-256-gcm", key, iv, { authTagLength: 16 });
   decipher.setAuthTag(authTag);
   const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
   return plaintext.toString("utf8");

--- a/lib/db/repositories/roles.last-super-admin.test.ts
+++ b/lib/db/repositories/roles.last-super-admin.test.ts
@@ -1,0 +1,236 @@
+/**
+ * lib/db/repositories/roles.last-super-admin.test.ts
+ *
+ * Regression unit tests for the last-SuperAdmin count query
+ * (`countGlobalAssignmentsOfRoleSlug`) — the data-layer half of
+ * GHSA-86v6-w5p9-29r8. The route guards that consume it are covered over HTTP
+ * by tests/integration/admin/role-assignments.test.ts (a real DB invariant),
+ * but the query's *logic* — exclude disabled users, dedupe a user with two
+ * global rows — is exercised here directly so a regression fails the fast unit
+ * suite, not just the gated integration suite.
+ *
+ * Runs against an in-memory SQLite database, which proves the query is
+ * dialect-portable (`count(distinct …)`, `isNull`, inner joins). This test file
+ * REQUIRES `DATABASE_URL` to be a `file:`/`sqlite:` URL so the module graph
+ * resolves to the SQLite dialect; the runner sets it. When it isn't SQLite, the
+ * suite skips with a loud message rather than silently passing.
+ */
+
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { isSqlite } from "@/lib/db/_dialect";
+// Type-only imports are erased at compile time, so they don't construct the
+// (Postgres) connection that the runtime `lib/db` module builds eagerly — that
+// stays lazily imported below, inside the SQLite-gated suite.
+import type { closeDatabase, db, sqliteHandle } from "@/lib/db";
+import type { roleAssignments, roles, users } from "@/lib/db/schema";
+import type { countGlobalAssignmentsOfRoleSlug, userHoldsGlobalRoleSlug } from "./roles";
+
+const describeSqlite = isSqlite ? describe : describe.skip;
+
+if (!isSqlite) {
+  console.warn(
+    "[roles.last-super-admin.test] SKIPPED: needs a SQLite DATABASE_URL " +
+      "(file:…/sqlite:…). Run via the dedicated unit-sqlite script.",
+  );
+}
+
+describeSqlite("countGlobalAssignmentsOfRoleSlug (last-SuperAdmin guard query)", () => {
+  // Bound lazily in beforeEach so the SKIP path doesn't pull in the server-only
+  // DB module under a Postgres URL (which would try to construct a pg pool at
+  // import). The types above are erased, so they cost nothing at runtime.
+  let dbInstance: typeof db;
+  let sqliteHandleFn: typeof sqliteHandle;
+  let closeDatabaseFn: typeof closeDatabase;
+  let countFn: typeof countGlobalAssignmentsOfRoleSlug;
+  let holdsFn: typeof userHoldsGlobalRoleSlug;
+  let usersTable: typeof users;
+  let rolesTable: typeof roles;
+  let roleAssignmentsTable: typeof roleAssignments;
+
+  const SUPER_ADMIN_SLUG = "super-admin";
+
+  function createSchema(): void {
+    const handle = sqliteHandleFn();
+    if (!handle) throw new Error("expected a SQLite handle in SQLite mode");
+    handle.exec(`
+      CREATE TABLE IF NOT EXISTS users (
+        id TEXT PRIMARY KEY,
+        email TEXT NOT NULL,
+        name TEXT,
+        image_url TEXT,
+        password_hash TEXT,
+        totp_secret_encrypted TEXT,
+        mfa_required INTEGER,
+        webauthn_credentials TEXT NOT NULL DEFAULT '[]',
+        email_verified_at INTEGER,
+        locked_until INTEGER,
+        failed_login_count INTEGER NOT NULL DEFAULT 0,
+        disabled_at INTEGER,
+        last_login_at INTEGER,
+        last_login_ip TEXT,
+        must_change_password INTEGER NOT NULL DEFAULT 0,
+        password_hash_updated_at INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE IF NOT EXISTS roles (
+        id TEXT PRIMARY KEY,
+        slug TEXT NOT NULL,
+        name TEXT NOT NULL,
+        description TEXT,
+        is_system INTEGER NOT NULL DEFAULT 0,
+        requires_mfa INTEGER NOT NULL DEFAULT 0,
+        permissions TEXT NOT NULL DEFAULT '[]',
+        created_at INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE IF NOT EXISTS role_assignments (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        role_id TEXT NOT NULL,
+        scope_type TEXT NOT NULL,
+        scope_id TEXT,
+        created_by TEXT,
+        provider_id TEXT,
+        created_at INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL DEFAULT 0
+      );
+    `);
+  }
+
+  function truncate(): void {
+    const handle = sqliteHandleFn();
+    if (!handle) throw new Error("expected a SQLite handle in SQLite mode");
+    handle.exec("DELETE FROM role_assignments; DELETE FROM users; DELETE FROM roles;");
+  }
+
+  async function seedRole(): Promise<string> {
+    const id = "role-super";
+    await dbInstance
+      .insert(rolesTable)
+      .values({ id, slug: SUPER_ADMIN_SLUG, name: "Super Admin", isSystem: true });
+    return id;
+  }
+
+  async function seedUser(id: string, disabled: boolean): Promise<void> {
+    await dbInstance.insert(usersTable).values({
+      id,
+      email: `${id}@test.local`,
+      disabledAt: disabled ? new Date() : null,
+    });
+  }
+
+  async function assignGlobal(id: string, userId: string, roleId: string): Promise<void> {
+    await dbInstance
+      .insert(roleAssignmentsTable)
+      .values({ id, userId, roleId, scopeType: "global", scopeId: null });
+  }
+
+  beforeEach(async () => {
+    const dbModule = await import("@/lib/db");
+    dbInstance = dbModule.db;
+    sqliteHandleFn = dbModule.sqliteHandle;
+    closeDatabaseFn = dbModule.closeDatabase;
+    const schema = await import("@/lib/db/schema");
+    usersTable = schema.users;
+    rolesTable = schema.roles;
+    roleAssignmentsTable = schema.roleAssignments;
+    const repo = await import("./roles");
+    countFn = repo.countGlobalAssignmentsOfRoleSlug;
+    holdsFn = repo.userHoldsGlobalRoleSlug;
+    createSchema();
+    truncate();
+  });
+
+  afterAll(async () => {
+    await closeDatabaseFn();
+  });
+
+  it("counts one enabled global Super Admin", async () => {
+    const roleId = await seedRole();
+    await seedUser("u1", false);
+    await assignGlobal("a1", "u1", roleId);
+
+    expect(await countFn(SUPER_ADMIN_SLUG)).toBe(1);
+  });
+
+  it("excludes a DISABLED Super Admin from the count", async () => {
+    const roleId = await seedRole();
+    await seedUser("u1", false); // enabled
+    await seedUser("u2", true); // disabled — must NOT count
+    await assignGlobal("a1", "u1", roleId);
+    await assignGlobal("a2", "u2", roleId);
+
+    // The old `rows.length` query returned 2 here, wrongly treating the disabled
+    // account as a live admin and letting the last *usable* one be removed.
+    expect(await countFn(SUPER_ADMIN_SLUG)).toBe(1);
+  });
+
+  it("dedupes a user holding two global Super Admin rows", async () => {
+    const roleId = await seedRole();
+    await seedUser("u1", false);
+    // Two distinct assignment rows for the SAME user at global scope.
+    await assignGlobal("a1", "u1", roleId);
+    await assignGlobal("a2", "u1", roleId);
+
+    // The old query counted rows (2). DISTINCT user_id collapses this to 1, so
+    // a single-admin install can't be tricked into thinking it has two.
+    expect(await countFn(SUPER_ADMIN_SLUG)).toBe(1);
+  });
+
+  it("returns 0 when the only Super Admin is disabled (lockout boundary)", async () => {
+    const roleId = await seedRole();
+    await seedUser("u1", true);
+    await assignGlobal("a1", "u1", roleId);
+
+    expect(await countFn(SUPER_ADMIN_SLUG)).toBe(0);
+  });
+
+  it("counts two distinct enabled Super Admins", async () => {
+    const roleId = await seedRole();
+    await seedUser("u1", false);
+    await seedUser("u2", false);
+    await assignGlobal("a1", "u1", roleId);
+    await assignGlobal("a2", "u2", roleId);
+
+    expect(await countFn(SUPER_ADMIN_SLUG)).toBe(2);
+  });
+
+  it("ignores non-global Super Admin assignments", async () => {
+    const roleId = await seedRole();
+    await seedUser("u1", false);
+    // Team-scoped assignment — not a global Super Admin, so it doesn't count.
+    await dbInstance
+      .insert(roleAssignmentsTable)
+      .values({ id: "a1", userId: "u1", roleId, scopeType: "team", scopeId: "team-1" });
+
+    expect(await countFn(SUPER_ADMIN_SLUG)).toBe(0);
+  });
+
+  describe("userHoldsGlobalRoleSlug", () => {
+    it("is true for a user with a global Super Admin assignment, regardless of enabled state", async () => {
+      const roleId = await seedRole();
+      await seedUser("u1", true); // even disabled, they HOLD the role
+      await assignGlobal("a1", "u1", roleId);
+
+      expect(await holdsFn("u1", SUPER_ADMIN_SLUG)).toBe(true);
+    });
+
+    it("is false for a user holding the role only at a non-global scope", async () => {
+      const roleId = await seedRole();
+      await seedUser("u1", false);
+      await dbInstance
+        .insert(roleAssignmentsTable)
+        .values({ id: "a1", userId: "u1", roleId, scopeType: "team", scopeId: "team-1" });
+
+      expect(await holdsFn("u1", SUPER_ADMIN_SLUG)).toBe(false);
+    });
+
+    it("is false for a user with no assignment of the role", async () => {
+      await seedRole();
+      await seedUser("u1", false);
+
+      expect(await holdsFn("u1", SUPER_ADMIN_SLUG)).toBe(false);
+    });
+  });
+});

--- a/lib/db/repositories/roles.ts
+++ b/lib/db/repositories/roles.ts
@@ -19,6 +19,18 @@ export async function findRoleBySlug(slug: string): Promise<Role | null> {
   return rows[0] ?? null;
 }
 
+/**
+ * Load every role whose slug is in `slugs`, in one query. Used by the OIDC
+ * group→role ceiling check, which must resolve each mapping's `roleSlug` to its
+ * permission set before deciding whether the actor may persist the mapping.
+ * Missing slugs simply don't appear in the result — the caller treats an
+ * unresolved mapping as invalid.
+ */
+export async function findRolesBySlugs(slugs: readonly string[]): Promise<Role[]> {
+  if (slugs.length === 0) return [];
+  return db.select().from(roles).where(inArray(roles.slug, slugs));
+}
+
 /** Upsert a role by slug. Used by the seed script for system roles. */
 export async function upsertRole(input: NewRole): Promise<Role> {
   const rows = await db

--- a/lib/db/repositories/roles.ts
+++ b/lib/db/repositories/roles.ts
@@ -7,10 +7,11 @@
  */
 
 import "server-only";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, countDistinct, eq, inArray, isNull } from "drizzle-orm";
 import { db, type DbExecutor } from "@/lib/db";
 import { roleAssignments, type NewRoleAssignment, type RoleAssignment } from "@/lib/db/schema";
 import { roles, type NewRole, type Role } from "@/lib/db/schema";
+import { users } from "@/lib/db/schema";
 import { countStar } from "@/lib/db/sql-dialect";
 
 /** Find a role by its slug — used by seed and assignment paths. */
@@ -112,17 +113,63 @@ export async function findAssignmentWithRole(
   return rows[0] ?? null;
 }
 
-/** Count global-scope assignments of the role with `slug` (last-SuperAdmin guard). */
+/**
+ * Count the distinct *enabled* users holding a global-scope assignment of the
+ * role with `slug` — the population the last-SuperAdmin guard cares about.
+ *
+ * Three things this query deliberately does, all of which the old `rows.length`
+ * version got wrong (GHSA-86v6-w5p9-29r8):
+ *   - INNER JOIN `users` and exclude `disabled_at IS NOT NULL`: a disabled
+ *     account cannot sign in, so it can't actually administer anything. Counting
+ *     it as a live Super Admin would let the last *usable* one be removed.
+ *   - `count(distinct user_id)`: a user can hold the same role at global scope
+ *     more than once (it's the unique key with scope_id, which is NULL here —
+ *     and historically duplicate rows have existed). Two rows for one person is
+ *     still one Super Admin, not two.
+ *
+ * `countDistinct` emits `count(distinct …)`, portable across Postgres and
+ * SQLite; `isNull` and the inner join are standard Drizzle, so this runs
+ * unchanged on both dialects.
+ */
 export async function countGlobalAssignmentsOfRoleSlug(
   slug: string,
   executor: DbExecutor = db,
 ): Promise<number> {
   const rows = await executor
+    .select({ count: countDistinct(roleAssignments.userId) })
+    .from(roleAssignments)
+    .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
+    .innerJoin(users, eq(roleAssignments.userId, users.id))
+    .where(
+      and(eq(roles.slug, slug), eq(roleAssignments.scopeType, "global"), isNull(users.disabledAt)),
+    );
+  return Number(rows[0]?.count ?? 0);
+}
+
+/**
+ * Whether `userId` holds a global-scope assignment of the role with `slug`.
+ * Lets the user disable/delete routes decide whether the target is a global
+ * Super Admin (and therefore subject to the last-SuperAdmin guard) before they
+ * mutate the row.
+ */
+export async function userHoldsGlobalRoleSlug(
+  userId: string,
+  slug: string,
+  executor: DbExecutor = db,
+): Promise<boolean> {
+  const rows = await executor
     .select({ id: roleAssignments.id })
     .from(roleAssignments)
     .innerJoin(roles, eq(roleAssignments.roleId, roles.id))
-    .where(and(eq(roles.slug, slug), eq(roleAssignments.scopeType, "global")));
-  return rows.length;
+    .where(
+      and(
+        eq(roleAssignments.userId, userId),
+        eq(roles.slug, slug),
+        eq(roleAssignments.scopeType, "global"),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
 }
 
 /**

--- a/lib/db/repositories/users.test.ts
+++ b/lib/db/repositories/users.test.ts
@@ -18,7 +18,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
@@ -107,7 +107,14 @@ describeDb("recordFailedLogin (SQLite, atomic increment)", () => {
     migrate(rawDb, { migrationsFolder: "drizzle-sqlite" });
 
     // Point the repository's db singleton at this file, then import it.
+    // `vi.resetModules()` is essential: the top-level `computeLockoutUntil`
+    // import already evaluated `./users` → `lib/db`, building the `db` singleton
+    // against the DEFAULT (Postgres) DATABASE_URL. Without dropping that cached
+    // graph, this dynamic import returns the Postgres-bound singleton and the
+    // queries below hit a DB that isn't there (ECONNREFUSED). Resetting forces
+    // `lib/db` to rebuild against the SQLite file set just above.
     process.env["DATABASE_URL"] = `file:${dbFile}`;
+    vi.resetModules();
     repo = await import("./users");
   });
 

--- a/lib/db/repositories/users.test.ts
+++ b/lib/db/repositories/users.test.ts
@@ -1,0 +1,173 @@
+/**
+ * lib/db/repositories/users.test.ts
+ *
+ * Regression coverage for the failed-login lockout path (GHSA-frpq-xgm7-574x).
+ *
+ * Two layers:
+ *  - `computeLockoutUntil` — the pure threshold→lockedUntil rule, no DB.
+ *  - `recordFailedLogin` — the atomic increment, exercised against a real
+ *    on-disk SQLite database (one of the two supported dialects). The
+ *    pre-fix read-modify-write lost increments under concurrency; the
+ *    concurrency case below is the regression that would fail before the fix.
+ *
+ * SQLite is used here because it gives a hermetic, no-Docker DB. The same
+ * repository code runs on Postgres in CI's integration suite; the `sql`
+ * increment template and `.returning()` are portable across both dialects.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+
+import { computeLockoutUntil } from "./users";
+import type * as UsersRepository from "./users";
+
+/**
+ * `better-sqlite3` is a native addon: it only loads when its prebuilt binary
+ * matches the running Node ABI (NODE_MODULE_VERSION). When it doesn't (e.g. a
+ * dev machine whose Node differs from the one node_modules was built against),
+ * opening a DB throws `ERR_DLOPEN_FAILED`. We probe once here and skip the
+ * DB-backed suite rather than fail the run — CI builds the addon for its Node,
+ * so the suite (incl. the concurrency regression) runs there.
+ */
+function sqliteAddonLoads(): boolean {
+  try {
+    new Database(":memory:").close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+const describeDb = sqliteAddonLoads() ? describe : describe.skip;
+
+describe("computeLockoutUntil", () => {
+  const now = new Date("2026-05-24T12:00:00.000Z");
+
+  it("returns null below the threshold", () => {
+    expect(computeLockoutUntil(1, 10, 900, now)).toBeNull();
+    expect(computeLockoutUntil(9, 10, 900, now)).toBeNull();
+  });
+
+  it("locks exactly at the threshold", () => {
+    const until = computeLockoutUntil(10, 10, 900, now);
+    expect(until).not.toBeNull();
+    // 900s = 15 minutes from `now`.
+    expect(until!.getTime()).toBe(now.getTime() + 900 * 1000);
+  });
+
+  it("stays locked past the threshold", () => {
+    const until = computeLockoutUntil(11, 10, 900, now);
+    expect(until).not.toBeNull();
+    expect(until!.getTime()).toBe(now.getTime() + 900 * 1000);
+  });
+});
+
+describeDb("recordFailedLogin (SQLite, atomic increment)", () => {
+  let tempDir: string;
+  let dbFile: string;
+  // Loaded after DATABASE_URL is pointed at the temp SQLite file so the
+  // repository's `db` singleton binds to it.
+  let repo: typeof UsersRepository;
+  let rawDb: ReturnType<typeof drizzle>;
+  let handle: Database.Database;
+
+  const THRESHOLD = 5;
+  const LOCKOUT_SECONDS = 900;
+
+  function insertTestUser(email: string): string {
+    const id = crypto.randomUUID();
+    const nowMs = Date.now();
+    handle
+      .prepare(
+        `INSERT INTO users (id, email, failed_login_count, password_hash_updated_at, created_at, updated_at)
+         VALUES (?, ?, 0, ?, ?, ?)`,
+      )
+      .run(id, email, nowMs, nowMs, nowMs);
+    return id;
+  }
+
+  function readUser(id: string): { failed_login_count: number; locked_until: number | null } {
+    return handle
+      .prepare("SELECT failed_login_count, locked_until FROM users WHERE id = ?")
+      .get(id) as { failed_login_count: number; locked_until: number | null };
+  }
+
+  beforeAll(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "pda-users-test-"));
+    dbFile = join(tempDir, "test.db");
+
+    // Build the schema with the same migrations the app ships for SQLite.
+    handle = new Database(dbFile);
+    handle.pragma("foreign_keys = ON");
+    rawDb = drizzle(handle);
+    migrate(rawDb, { migrationsFolder: "drizzle-sqlite" });
+
+    // Point the repository's db singleton at this file, then import it.
+    process.env["DATABASE_URL"] = `file:${dbFile}`;
+    repo = await import("./users");
+  });
+
+  afterAll(() => {
+    handle.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("increments the counter and does not lock below the threshold", async () => {
+    const id = insertTestUser("below@example.com");
+
+    const result = await repo.recordFailedLogin(id, THRESHOLD, LOCKOUT_SECONDS);
+
+    expect(result.failedCount).toBe(1);
+    expect(result.lockedUntil).toBeNull();
+
+    const row = readUser(id);
+    expect(row.failed_login_count).toBe(1);
+    expect(row.locked_until).toBeNull();
+  });
+
+  it("sets lockedUntil once the threshold is reached", async () => {
+    const id = insertTestUser("reaches@example.com");
+
+    let last: Awaited<ReturnType<typeof repo.recordFailedLogin>> | undefined;
+    for (let attempt = 0; attempt < THRESHOLD; attempt += 1) {
+      last = await repo.recordFailedLogin(id, THRESHOLD, LOCKOUT_SECONDS);
+    }
+
+    expect(last!.failedCount).toBe(THRESHOLD);
+    expect(last!.lockedUntil).not.toBeNull();
+
+    const row = readUser(id);
+    expect(row.failed_login_count).toBe(THRESHOLD);
+    expect(row.locked_until).not.toBeNull();
+  });
+
+  it("returns a zeroed result for an unknown user (no row updated)", async () => {
+    const result = await repo.recordFailedLogin(crypto.randomUUID(), THRESHOLD, LOCKOUT_SECONDS);
+    expect(result.failedCount).toBe(0);
+    expect(result.lockedUntil).toBeNull();
+  });
+
+  it("does not lose increments under concurrent failed logins", async () => {
+    const id = insertTestUser("concurrent@example.com");
+
+    // Fire many failed-login records at once. With the pre-fix
+    // read-modify-write, concurrent calls would each read N and write N+1,
+    // so the final count would be far below CONCURRENT. The atomic
+    // UPDATE ... SET x = x + 1 guarantees every call counts exactly once.
+    const CONCURRENT = 50;
+    await Promise.all(
+      Array.from({ length: CONCURRENT }, () =>
+        repo.recordFailedLogin(id, THRESHOLD, LOCKOUT_SECONDS),
+      ),
+    );
+
+    const row = readUser(id);
+    expect(row.failed_login_count).toBe(CONCURRENT);
+    // Far past the threshold → account must be locked.
+    expect(row.locked_until).not.toBeNull();
+  });
+});

--- a/lib/db/repositories/users.ts
+++ b/lib/db/repositories/users.ts
@@ -77,30 +77,65 @@ export async function recordSuccessfulLogin(id: string, ip: string | null): Prom
 }
 
 /**
+ * Decide the lockout deadline for a given (post-increment) failed-login count.
+ *
+ * Pure so the threshold→lockedUntil rule can be unit-tested without a database.
+ * Returns `null` when the count is still below the threshold (no lock yet).
+ *
+ * @param failedCount the failed-login count AFTER this attempt was recorded.
+ * @param threshold   number of failures at which the account locks (≥ this locks).
+ * @param lockoutSeconds how long the lock lasts from `now`.
+ */
+export function computeLockoutUntil(
+  failedCount: number,
+  threshold: number,
+  lockoutSeconds: number,
+  now: Date = new Date(),
+): Date | null {
+  return failedCount >= threshold ? new Date(now.getTime() + lockoutSeconds * 1000) : null;
+}
+
+/**
  * Increment the failed-login counter and, if the threshold is hit, set a
  * `lockedUntil` timestamp. Returns the new failed count for the caller's log.
+ *
+ * The increment is performed atomically in the database
+ * (`failed_login_count = failed_login_count + 1`) and read back via
+ * `.returning()`. Computing the next value in JS from a prior `SELECT` (the
+ * old read-modify-write) let two concurrent failed logins both read N and
+ * write N+1, losing an increment and letting an attacker exceed the lockout
+ * threshold (GHSA-frpq-xgm7-574x). The atomic statement makes every concurrent
+ * failure count exactly once.
+ *
+ * Both Postgres and SQLite support the `sql` increment template and
+ * `.returning()` via Drizzle. The follow-up lock write is keyed on the
+ * returned count, so it only runs once the threshold is genuinely crossed; it
+ * is idempotent (concurrent failures past the threshold all set a correct
+ * lock window).
  */
 export async function recordFailedLogin(
   id: string,
   threshold: number,
   lockoutSeconds: number,
 ): Promise<{ failedCount: number; lockedUntil: Date | null }> {
-  const user = await findUserById(id);
-  if (!user) return { failedCount: 0, lockedUntil: null };
-
-  const next = user.failedLoginCount + 1;
-  const lockedUntil = next >= threshold ? new Date(Date.now() + lockoutSeconds * 1000) : null;
-
-  await db
+  const incremented = await db
     .update(users)
     .set({
-      failedLoginCount: next,
-      lockedUntil,
+      failedLoginCount: sql`${users.failedLoginCount} + 1`,
       updatedAt: new Date(),
     })
-    .where(eq(users.id, id));
+    .where(eq(users.id, id))
+    .returning({ failedCount: users.failedLoginCount });
 
-  return { failedCount: next, lockedUntil };
+  const row = incremented[0];
+  if (!row) return { failedCount: 0, lockedUntil: null };
+
+  const lockedUntil = computeLockoutUntil(row.failedCount, threshold, lockoutSeconds);
+  if (lockedUntil) {
+    await db.update(users).set({ lockedUntil }).where(eq(users.id, id));
+  }
+
+  return { failedCount: row.failedCount, lockedUntil };
 }
 
 /** True if a user is currently locked out. */

--- a/lib/rbac/ability.test.ts
+++ b/lib/rbac/ability.test.ts
@@ -13,8 +13,10 @@ import { describe, expect, it } from "vitest";
 import {
   buildAbility,
   globalPermissionsOf,
+  groupMappingsExceedingGrant,
   permissionsExceedingGrant,
   type AbilitySource,
+  type ResolvedGroupMapping,
 } from "./ability";
 import type { Permission } from "./permissions";
 
@@ -81,6 +83,51 @@ describe("permissionsExceedingGrant (the role-assign privilege ceiling)", () => 
 
   it("treats a scoped-only actor (empty global set) as able to grant nothing", () => {
     expect(permissionsExceedingGrant(actor([]), ["zone.read"])).toEqual(["zone.read"]);
+  });
+});
+
+describe("groupMappingsExceedingGrant (OIDC group→role ceiling, GHSA-wf29-rmhc-rqc9)", () => {
+  const actor = (perms: Permission[]): ReadonlySet<Permission> => new Set(perms);
+  const mapping = (
+    group: string,
+    roleSlug: string,
+    permissions: Permission[],
+  ): ResolvedGroupMapping => ({ group, roleSlug, permissions });
+
+  it("allows mappings whose roles stay within the actor's global permissions", () => {
+    const violations = groupMappingsExceedingGrant(
+      actor(["zone.read", "record.update", "oidc.manage"]),
+      [
+        mapping("dns-readers", "read-only", ["zone.read"]),
+        mapping("dns-editors", "editor", ["zone.read", "record.update"]),
+      ],
+    );
+    expect(violations).toEqual([]);
+  });
+
+  it("flags a mapping to a role granting permissions the actor lacks (no SuperAdmin laundering)", () => {
+    const violations = groupMappingsExceedingGrant(actor(["oidc.manage", "zone.read"]), [
+      mapping("dns-readers", "read-only", ["zone.read"]),
+      mapping("superusers", "super-admin", ["zone.read", "user.delete", "settings.write"]),
+    ]);
+    expect(violations).toEqual([
+      {
+        group: "superusers",
+        roleSlug: "super-admin",
+        exceeding: ["user.delete", "settings.write"],
+      },
+    ]);
+  });
+
+  it("treats an actor with no global permissions as unable to map any privileged role", () => {
+    const violations = groupMappingsExceedingGrant(actor([]), [
+      mapping("any", "editor", ["zone.read"]),
+    ]);
+    expect(violations).toEqual([{ group: "any", roleSlug: "editor", exceeding: ["zone.read"] }]);
+  });
+
+  it("is a no-op for an empty mapping set", () => {
+    expect(groupMappingsExceedingGrant(actor(["oidc.manage"]), [])).toEqual([]);
   });
 });
 

--- a/lib/rbac/ability.ts
+++ b/lib/rbac/ability.ts
@@ -228,3 +228,52 @@ export function permissionsExceedingGrant(
 ): Permission[] {
   return rolePermissions.filter((p) => !actorGlobalPermissions.has(p));
 }
+
+/**
+ * One OIDC group→role mapping resolved to the permission set its target role
+ * grants. `roleSlug` is carried through so an over-ceiling rejection can name
+ * the offending mapping.
+ */
+export interface ResolvedGroupMapping {
+  group: string;
+  roleSlug: string;
+  permissions: readonly Permission[];
+}
+
+/** A mapping that would grant permissions the acting user lacks globally. */
+export interface GroupMappingViolation {
+  group: string;
+  roleSlug: string;
+  exceeding: Permission[];
+}
+
+/**
+ * The privilege ceiling for OIDC group→role mappings (GHSA-wf29-rmhc-rqc9).
+ *
+ * A `oidc.manage` holder configures rules that, at a stranger's first sign-in,
+ * mint role assignments for them. Without a ceiling, an operator who lacks
+ * (say) `user.delete` could wire a `superusers` group to the Super Admin role
+ * and then escalate by logging in through that group — laundering privilege
+ * through the IdP. So every mapping's target role must be a subset of what the
+ * acting user already holds **globally**, exactly as role assignment is gated
+ * (`permissionsExceedingGrant`). Scope on the mapping doesn't relax this: a
+ * mapping can land permissions on the user, so the global set is the basis
+ * regardless of the mapping's own scope.
+ *
+ * Returns one entry per offending mapping (empty = the whole set is within the
+ * ceiling). Reuses `permissionsExceedingGrant` so the comparison rule stays in
+ * one place.
+ */
+export function groupMappingsExceedingGrant(
+  actorGlobalPermissions: ReadonlySet<Permission>,
+  mappings: readonly ResolvedGroupMapping[],
+): GroupMappingViolation[] {
+  const violations: GroupMappingViolation[] = [];
+  for (const m of mappings) {
+    const exceeding = permissionsExceedingGrant(actorGlobalPermissions, m.permissions);
+    if (exceeding.length > 0) {
+      violations.push({ group: m.group, roleSlug: m.roleSlug, exceeding });
+    }
+  }
+  return violations;
+}

--- a/lib/rbac/oidc-mapping-ceiling.test.ts
+++ b/lib/rbac/oidc-mapping-ceiling.test.ts
@@ -1,0 +1,74 @@
+/**
+ * lib/rbac/oidc-mapping-ceiling.test.ts
+ *
+ * Unit cover for the OIDC group→role ceiling wrapper (GHSA-wf29-rmhc-rqc9).
+ * The DB repo is mocked so the wrapper's branches (empty, unknown-role,
+ * within-ceiling, over-ceiling) are exercised without a database; the
+ * full-stack path is covered separately by the integration suite.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Role } from "@/lib/db/schema";
+import type { Permission } from "./permissions";
+
+vi.mock("@/lib/db/repositories/roles", () => ({
+  findRolesBySlugs: vi.fn(),
+  loadUserAssignmentsForAbility: vi.fn(),
+}));
+
+import { findRolesBySlugs, loadUserAssignmentsForAbility } from "@/lib/db/repositories/roles";
+import { assertGroupMappingsWithinCeiling } from "./oidc-mapping-ceiling";
+
+const mockFindRoles = vi.mocked(findRolesBySlugs);
+const mockLoadAssignments = vi.mocked(loadUserAssignmentsForAbility);
+
+/** Set the acting user's GLOBAL permission set. */
+function actorGlobal(perms: Permission[]): void {
+  mockLoadAssignments.mockResolvedValue([
+    { permissions: perms, scopeType: "global", scopeId: null },
+  ]);
+}
+
+/** Register the roles a slug lookup resolves to. */
+function rolesBySlug(map: Record<string, Permission[]>): void {
+  const rows = Object.entries(map).map(([slug, permissions]) => ({ slug, permissions }));
+  mockFindRoles.mockResolvedValue(rows as unknown as Role[]);
+}
+
+describe("assertGroupMappingsWithinCeiling", () => {
+  beforeEach(() => {
+    mockFindRoles.mockReset();
+    mockLoadAssignments.mockReset();
+  });
+
+  it("no-ops on empty / null mappings (no DB calls)", async () => {
+    await expect(assertGroupMappingsWithinCeiling("actor", [])).resolves.toBeUndefined();
+    await expect(assertGroupMappingsWithinCeiling("actor", null)).resolves.toBeUndefined();
+    expect(mockFindRoles).not.toHaveBeenCalled();
+    expect(mockLoadAssignments).not.toHaveBeenCalled();
+  });
+
+  it("rejects a mapping to an unknown role slug", async () => {
+    rolesBySlug({ viewer: ["audit.read"] });
+    actorGlobal(["audit.read"]);
+    await expect(
+      assertGroupMappingsWithinCeiling("actor", [{ group: "g", roleSlug: "ghost" }]),
+    ).rejects.toThrow(/unknown role/i);
+  });
+
+  it("passes when every mapped role is within the actor's global ceiling", async () => {
+    rolesBySlug({ viewer: ["audit.read"] });
+    actorGlobal(["audit.read", "user.delete"]);
+    await expect(
+      assertGroupMappingsWithinCeiling("actor", [{ group: "ops", roleSlug: "viewer" }]),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a mapping whose role grants a permission the actor lacks globally", async () => {
+    rolesBySlug({ superusers: ["user.delete"] });
+    actorGlobal(["audit.read"]); // actor does NOT hold user.delete
+    await expect(
+      assertGroupMappingsWithinCeiling("actor", [{ group: "admins", roleSlug: "superusers" }]),
+    ).rejects.toThrow(/user\.delete/);
+  });
+});

--- a/lib/rbac/oidc-mapping-ceiling.ts
+++ b/lib/rbac/oidc-mapping-ceiling.ts
@@ -1,0 +1,85 @@
+/**
+ * lib/rbac/oidc-mapping-ceiling.ts
+ *
+ * Route-side guard for the OIDC group→role privilege ceiling
+ * (GHSA-wf29-rmhc-rqc9). Resolves each group mapping's `roleSlug` to the
+ * permission set its role grants, computes the acting user's GLOBAL
+ * permissions, and throws if any mapping would mint permissions the actor
+ * doesn't already hold globally — the same ceiling role *assignment* enforces
+ * (`permissionsExceedingGrant`), just applied to the rules that auto-assign
+ * roles at first sign-in.
+ *
+ * The pure comparison lives in `ability.ts` (`groupMappingsExceedingGrant`) so
+ * it stays unit-testable without a DB; this module is the thin DB-backed
+ * wrapper the routes call.
+ */
+
+import "server-only";
+import { findRolesBySlugs, loadUserAssignmentsForAbility } from "@/lib/db/repositories/roles";
+import { ValidationError } from "@/lib/errors";
+import {
+  globalPermissionsOf,
+  groupMappingsExceedingGrant,
+  type AbilitySource,
+  type ResolvedGroupMapping,
+} from "./ability";
+import type { Permission } from "./permissions";
+
+/** The mapping shape the OIDC validator produces (subset we care about here). */
+export interface GroupMappingInput {
+  group: string;
+  roleSlug: string;
+}
+
+/**
+ * Reject the request unless every group mapping's target role is within the
+ * acting user's global permission ceiling.
+ *
+ * Throws `ValidationError` when:
+ *   - a mapping references a role slug that doesn't exist (so the ceiling can't
+ *     be evaluated — a non-resolvable mapping is invalid input), or
+ *   - any mapping's role grants a permission the actor lacks globally (the
+ *     escalation the advisory describes).
+ *
+ * A `null`/empty mapping list is a no-op.
+ */
+export async function assertGroupMappingsWithinCeiling(
+  actorId: string,
+  mappings: readonly GroupMappingInput[] | null | undefined,
+): Promise<void> {
+  if (!mappings || mappings.length === 0) return;
+
+  const slugs = Array.from(new Set(mappings.map((m) => m.roleSlug)));
+  const roles = await findRolesBySlugs(slugs);
+  const permsBySlug = new Map<string, readonly Permission[]>(
+    // The DB column is structurally string[]; values are validated as
+    // permissions at role write time. Cast mirrors the role-assignment route.
+    roles.map((r) => [r.slug, r.permissions as readonly Permission[]]),
+  );
+
+  const missing = slugs.filter((s) => !permsBySlug.has(s));
+  if (missing.length > 0) {
+    throw new ValidationError(`Group mapping references unknown role(s): ${missing.join(", ")}.`);
+  }
+
+  const resolved: ResolvedGroupMapping[] = mappings.map((m) => ({
+    group: m.group,
+    roleSlug: m.roleSlug,
+    permissions: permsBySlug.get(m.roleSlug) ?? [],
+  }));
+
+  // `oidc.manage` is global-only, so the actor's global permission set is the
+  // correct basis — matching the role-assignment route's reasoning.
+  const actorSources = (await loadUserAssignmentsForAbility(actorId)) as readonly AbilitySource[];
+  const actorGlobal = globalPermissionsOf(actorSources);
+
+  const violations = groupMappingsExceedingGrant(actorGlobal, resolved);
+  if (violations.length > 0) {
+    const detail = violations
+      .map((v) => `${v.roleSlug} (group "${v.group}") grants ${v.exceeding.join(", ")}`)
+      .join("; ");
+    throw new ValidationError(
+      `You can't create an OIDC group mapping to a role that grants permissions you don't hold globally: ${detail}.`,
+    );
+  }
+}

--- a/lib/validators/oidc-providers.test.ts
+++ b/lib/validators/oidc-providers.test.ts
@@ -1,0 +1,76 @@
+/**
+ * lib/validators/oidc-providers.test.ts
+ *
+ * Unit tests for the OIDC provider Zod schemas.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createOidcProviderSchema, updateOidcProviderSchema } from "./oidc-providers";
+
+/** Minimal valid payload for createOidcProviderSchema. */
+const MINIMAL_CREATE = {
+  slug: "my-idp",
+  name: "My IdP",
+  issuerUrl: "https://idp.example.com",
+  clientId: "client-abc",
+  clientSecret: "super-secret-value",
+};
+
+describe("createOidcProviderSchema", () => {
+  it("parses a minimal payload and defaults requireEmailVerified to true", () => {
+    const result = createOidcProviderSchema.parse(MINIMAL_CREATE);
+    // Security default: account-takeover guard must be ON for new providers.
+    expect(result.requireEmailVerified).toBe(true);
+  });
+
+  it("preserves requireEmailVerified=false when explicitly set", () => {
+    const result = createOidcProviderSchema.parse({
+      ...MINIMAL_CREATE,
+      requireEmailVerified: false,
+    });
+    expect(result.requireEmailVerified).toBe(false);
+  });
+
+  it("preserves requireEmailVerified=true when explicitly set", () => {
+    const result = createOidcProviderSchema.parse({
+      ...MINIMAL_CREATE,
+      requireEmailVerified: true,
+    });
+    expect(result.requireEmailVerified).toBe(true);
+  });
+
+  it("defaults scopes to 'openid profile email'", () => {
+    const result = createOidcProviderSchema.parse(MINIMAL_CREATE);
+    expect(result.scopes).toBe("openid profile email");
+  });
+
+  it("defaults enabled to true", () => {
+    const result = createOidcProviderSchema.parse(MINIMAL_CREATE);
+    expect(result.enabled).toBe(true);
+  });
+
+  it("trims stray whitespace from clientSecret", () => {
+    const result = createOidcProviderSchema.parse({
+      ...MINIMAL_CREATE,
+      clientSecret: "  trimmed-secret  ",
+    });
+    expect(result.clientSecret).toBe("trimmed-secret");
+  });
+
+  it("rejects a missing clientSecret", () => {
+    const { clientSecret: _omit, ...withoutSecret } = MINIMAL_CREATE;
+    expect(() => createOidcProviderSchema.parse(withoutSecret)).toThrow();
+  });
+});
+
+describe("updateOidcProviderSchema", () => {
+  it("leaves requireEmailVerified undefined when omitted (no default)", () => {
+    const result = updateOidcProviderSchema.parse({});
+    expect(result.requireEmailVerified).toBeUndefined();
+  });
+
+  it("accepts requireEmailVerified=false on update", () => {
+    const result = updateOidcProviderSchema.parse({ requireEmailVerified: false });
+    expect(result.requireEmailVerified).toBe(false);
+  });
+});

--- a/lib/validators/oidc-providers.ts
+++ b/lib/validators/oidc-providers.ts
@@ -127,12 +127,11 @@ export const createOidcProviderSchema = z.object({
   claimName: claimSchema.default("name"),
   enabled: z.boolean().default(true),
   forceDefault: z.boolean().default(false),
-  /** Default `false` — we trust the IdP. Operators flip it on for
-   *  environments where the IdP lets users set arbitrary unverified
-   *  emails AND there's overlap between OIDC and local-password
-   *  accounts (the account-takeover scenario the check defends
-   *  against). */
-  requireEmailVerified: z.boolean().default(false),
+  /** Default `true` — the account-takeover guard is on for new providers.
+   *  Operators flip it off only for IdPs that don't emit `email_verified`
+   *  at all (custom OIDC bridges, some SAML→OIDC translators). Existing DB
+   *  rows keep their stored value; this default only applies at create time. */
+  requireEmailVerified: z.boolean().default(true),
   allowedEmailDomains: allowedEmailDomainsSchema.optional(),
   iconUrl: iconUrlSchema.optional(),
   /** Per-provider group → role rules. Omit / null = no mappings. */

--- a/tests/integration/admin/oidc-group-mapping-ceiling.test.ts
+++ b/tests/integration/admin/oidc-group-mapping-ceiling.test.ts
@@ -1,0 +1,136 @@
+/**
+ * tests/integration/admin/oidc-group-mapping-ceiling.test.ts
+ *
+ * GHSA-wf29-rmhc-rqc9 — the OIDC group→role mapping privilege ceiling, driven
+ * over HTTP. A holder of `oidc.manage` must not be able to wire a group to a
+ * role granting permissions they don't hold globally (which would let them
+ * escalate by signing in through that group / handing the group to a confederate).
+ *
+ * Mirrors the role-assignment ceiling test: a custom limited role reaches the
+ * route, then we prove over-ceiling create/PATCH is rejected and within-ceiling
+ * is accepted.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { createUser, loginAs, loginAsBootstrap, resolveRoleId, uniqueEmail } from "../helpers/auth";
+import { resetState } from "../helpers/reset";
+
+const uniqueSlug = (prefix: string): string =>
+  `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+
+describe("OIDC group-mapping privilege ceiling (GHSA-wf29-rmhc-rqc9)", () => {
+  beforeEach(() => resetState({ skipPdns: true }));
+
+  it("rejects a mapping to a role that grants permissions the actor lacks globally", async () => {
+    const admin = await loginAsBootstrap();
+    const password = "limited-oidc-mgr-pw-123456";
+    const actor = await createUser(admin, {
+      email: uniqueEmail("oidc-mgr"),
+      name: "Limited OIDC Manager",
+      password,
+    });
+
+    // A custom role that reaches the OIDC route (oidc.manage) but is far short
+    // of SuperAdmin. Bootstrap is SuperAdmin so creating + granting it is allowed.
+    const limitedSlug = uniqueSlug("limited-oidc");
+    await admin.sendJson("POST", "/api/admin/roles", {
+      slug: limitedSlug,
+      name: "Limited OIDC Manager",
+      permissions: ["oidc.manage", "oidc.read", "zone.read"],
+    });
+    const limitedRoleId = await resolveRoleId(admin, limitedSlug);
+    await admin.sendJson("POST", `/api/admin/users/${actor.id}/role-assignments`, {
+      roleId: limitedRoleId,
+      scopeType: "global",
+    });
+
+    // A within-ceiling target role (permissions ⊆ actor's global set).
+    const withinSlug = uniqueSlug("within-ceiling");
+    await admin.sendJson("POST", "/api/admin/roles", {
+      slug: withinSlug,
+      name: "Within Ceiling",
+      permissions: ["zone.read"],
+    });
+
+    const limited = await loginAs(actor.email, password);
+
+    // Over the ceiling: map a group to super-admin → rejected (400 ValidationError).
+    const bad = await limited.call("/api/admin/oidc-providers", {
+      method: "POST",
+      json: {
+        slug: uniqueSlug("idp-bad"),
+        name: "Bad IdP",
+        issuerUrl: "https://idp.example.test",
+        clientId: "id",
+        clientSecret: "secret",
+        groupMappings: [
+          { group: "superusers", roleSlug: "super-admin", scopeType: "global", scopeId: null },
+        ],
+      },
+    });
+    expect(bad.status).toBe(400);
+
+    // Within the ceiling: map a group to the within-ceiling role → 201.
+    const ok = await limited.call("/api/admin/oidc-providers", {
+      method: "POST",
+      json: {
+        slug: uniqueSlug("idp-ok"),
+        name: "OK IdP",
+        issuerUrl: "https://idp.example.test",
+        clientId: "id",
+        clientSecret: "secret",
+        groupMappings: [
+          { group: "readers", roleSlug: withinSlug, scopeType: "global", scopeId: null },
+        ],
+      },
+    });
+    expect(ok.status).toBe(201);
+  });
+
+  it("blocks the same escalation via PATCH", async () => {
+    const admin = await loginAsBootstrap();
+    const password = "limited-oidc-patch-pw-123456";
+    const actor = await createUser(admin, {
+      email: uniqueEmail("oidc-patch"),
+      name: "Limited OIDC Patcher",
+      password,
+    });
+    const limitedSlug = uniqueSlug("limited-patch");
+    await admin.sendJson("POST", "/api/admin/roles", {
+      slug: limitedSlug,
+      name: "Limited OIDC Patcher",
+      permissions: ["oidc.manage", "oidc.read", "zone.read"],
+    });
+    const limitedRoleId = await resolveRoleId(admin, limitedSlug);
+    await admin.sendJson("POST", `/api/admin/users/${actor.id}/role-assignments`, {
+      roleId: limitedRoleId,
+      scopeType: "global",
+    });
+
+    const limited = await loginAs(actor.email, password);
+
+    // Create a clean provider (no mappings) within the ceiling.
+    const { provider } = await limited.sendJson<{ provider: { id: string } }>(
+      "POST",
+      "/api/admin/oidc-providers",
+      {
+        slug: uniqueSlug("idp-patch"),
+        name: "Patch IdP",
+        issuerUrl: "https://idp.example.test",
+        clientId: "id",
+        clientSecret: "secret",
+      },
+    );
+
+    // Now try to PATCH in an over-ceiling mapping → rejected.
+    const bad = await limited.call(`/api/admin/oidc-providers/${provider.id}`, {
+      method: "PATCH",
+      json: {
+        groupMappings: [
+          { group: "superusers", roleSlug: "super-admin", scopeType: "global", scopeId: null },
+        ],
+      },
+    });
+    expect(bad.status).toBe(400);
+  });
+});

--- a/tests/integration/admin/role-assignments.test.ts
+++ b/tests/integration/admin/role-assignments.test.ts
@@ -6,10 +6,17 @@
  *      a DB invariant, so only an integration test can prove it).
  *   2. A `role.assign` holder cannot assign a role granting permissions they
  *      don't hold globally (the privilege ceiling), but CAN assign one within it.
+ *   3. The same last-Super-Admin invariant on the user routes: the final enabled
+ *      global Super Admin cannot be DISABLED or DELETED out of existence
+ *      (GHSA-86v6-w5p9-29r8). Driven by a second, non-super-admin actor that
+ *      merely holds `user.disable` / `user.delete`, so the request clears the
+ *      self-action guard and actually reaches the last-Super-Admin guard.
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  BOOTSTRAP_EMAIL,
+  createAndLogin,
   createUser,
   loginAs,
   loginAsBootstrap,
@@ -17,11 +24,61 @@ import {
   SYSTEM_ROLES,
   uniqueEmail,
 } from "../helpers/auth";
+import type { TestHttp } from "../helpers/http";
 import { dbQuery } from "../helpers/db";
 import { resetState } from "../helpers/reset";
 
 const uniqueSlug = (prefix: string): string =>
   `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+
+/** The id of the single global Super Admin remaining after a reset (bootstrap). */
+async function lastSuperAdminUserId(): Promise<string> {
+  const rows = await dbQuery<{ user_id: string }>(
+    `SELECT ra.user_id
+       FROM role_assignments ra
+       JOIN roles r ON r.id = ra.role_id
+      WHERE r.slug = 'super-admin' AND ra.scope_type = 'global'`,
+  );
+  expect(rows).toHaveLength(1); // only the bootstrap admin holds it post-reset
+  return rows[0]!.user_id;
+}
+
+/** The bootstrap admin's user id (by email), independent of other assignments. */
+async function bootstrapUserId(): Promise<string> {
+  const rows = await dbQuery<{ id: string }>(
+    `SELECT id FROM users WHERE lower(email) = lower($1)`,
+    [BOOTSTRAP_EMAIL],
+  );
+  expect(rows).toHaveLength(1);
+  return rows[0]!.id;
+}
+
+/**
+ * Create + log in a user holding a custom global role with `permissions`,
+ * within the bootstrap admin's privilege ceiling. Used to get an actor that
+ * can REACH the user routes without itself being a global Super Admin.
+ */
+async function actorWithPerms(
+  admin: TestHttp,
+  label: string,
+  permissions: string[],
+): Promise<TestHttp> {
+  const slug = uniqueSlug(label);
+  await admin.sendJson("POST", "/api/admin/roles", { slug, name: label, permissions });
+  const roleId = await resolveRoleId(admin, slug);
+  const password = `${label}-pw-123456`;
+  const { user } = await createAndLogin(admin, {
+    email: uniqueEmail(label),
+    name: label,
+    password,
+  });
+  await admin.sendJson("POST", `/api/admin/users/${user.id}/role-assignments`, {
+    roleId,
+    scopeType: "global",
+  });
+  // Re-login so the new assignment is reflected in the session's ability.
+  return loginAs(user.email, password);
+}
 
 describe("role-assignment guards (L-3)", () => {
   beforeEach(() => resetState({ skipPdns: true }));
@@ -91,5 +148,71 @@ describe("role-assignment guards (L-3)", () => {
       json: { roleId: limitedRoleId, scopeType: "global" },
     });
     expect(ok.status).toBe(201);
+  });
+
+  it("refuses to DISABLE the last global Super Admin (GHSA-86v6-w5p9-29r8)", async () => {
+    const admin = await loginAsBootstrap();
+    const targetId = await lastSuperAdminUserId();
+    // A second actor that can disable users but is NOT a Super Admin, so the
+    // request clears the self-action guard and reaches the lockout guard.
+    const disabler = await actorWithPerms(admin, "disabler", ["user.update"]);
+
+    const res = await disabler.call(`/api/admin/users/${targetId}`, {
+      method: "PATCH",
+      json: { disabled: true },
+    });
+    expect(res.status).toBe(403);
+
+    // …and the Super Admin is still enabled.
+    const rows = await dbQuery<{ disabled_at: Date | null }>(
+      `SELECT disabled_at FROM users WHERE id = $1`,
+      [targetId],
+    );
+    expect(rows[0]!.disabled_at).toBeNull();
+  });
+
+  it("refuses to DELETE the last global Super Admin (GHSA-86v6-w5p9-29r8)", async () => {
+    const admin = await loginAsBootstrap();
+    const targetId = await lastSuperAdminUserId();
+    const deleter = await actorWithPerms(admin, "deleter", ["user.delete"]);
+
+    const res = await deleter.call(`/api/admin/users/${targetId}`, { method: "DELETE" });
+    expect(res.status).toBe(403);
+
+    // …and the Super Admin row still exists.
+    const rows = await dbQuery(`SELECT id FROM users WHERE id = $1`, [targetId]);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("ALLOWS disabling a Super Admin when another enabled one remains", async () => {
+    const admin = await loginAsBootstrap();
+    // Promote a second user to global Super Admin → now two exist.
+    const superAdminRoleId = await resolveRoleId(admin, SYSTEM_ROLES.superAdmin);
+    const second = await createUser(admin, {
+      email: uniqueEmail("second-superadmin"),
+      name: "Second Super Admin",
+      password: "second-superadmin-pw-123456",
+    });
+    await admin.sendJson("POST", `/api/admin/users/${second.id}/role-assignments`, {
+      roleId: superAdminRoleId,
+      scopeType: "global",
+    });
+
+    // Bootstrap (still a Super Admin) can now disable the OTHER one — not the last.
+    const res = await admin.call(`/api/admin/users/${second.id}`, {
+      method: "PATCH",
+      json: { disabled: true },
+    });
+    expect(res.status).toBe(200);
+
+    // The second admin is now disabled, so bootstrap is again the last ENABLED
+    // global Super Admin — disabling it (via the second actor) must be blocked.
+    const disabler = await actorWithPerms(admin, "disabler2", ["user.update"]);
+    const bootstrapId = await bootstrapUserId();
+    const blocked = await disabler.call(`/api/admin/users/${bootstrapId}`, {
+      method: "PATCH",
+      json: { disabled: true },
+    });
+    expect(blocked.status).toBe(403);
   });
 });

--- a/tests/integration/rbac/zone-grants.test.ts
+++ b/tests/integration/rbac/zone-grants.test.ts
@@ -12,7 +12,15 @@
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
-import { createAndLogin, loginAsBootstrap, SYSTEM_ROLES, uniqueEmail } from "../helpers/auth";
+import {
+  createAndLogin,
+  createUser,
+  loginAs,
+  loginAsBootstrap,
+  resolveRoleId,
+  SYSTEM_ROLES,
+  uniqueEmail,
+} from "../helpers/auth";
 import { resetState } from "../helpers/reset";
 import { type TestHttp } from "../helpers/http";
 
@@ -22,6 +30,9 @@ function randomZone(prefix: string): string {
   const tag = Math.random().toString(36).slice(2, 8);
   return `${prefix}-${Date.now()}-${tag}.example.com.`;
 }
+
+const uniqueSlug = (prefix: string): string =>
+  `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
 
 async function getStandaloneId(admin: TestHttp): Promise<string> {
   const { servers } = await admin.getJson<{
@@ -237,5 +248,61 @@ describe("zone grants — per-zone permission grants", () => {
       },
     });
     expect(res.status).toBe(409);
+  }, 30_000);
+
+  it("privilege ceiling (GHSA-gjg4-58c5-2qg3): can't grant a permission you don't hold for the zone", async () => {
+    const admin = await loginAsBootstrap();
+    const standaloneId = await getStandaloneId(admin);
+    const zone = randomZone("ceiling");
+    await admin.sendJson("POST", "/api/admin/pdns/zones", {
+      serverSlug: "standalone",
+      name: zone,
+      kind: "Master",
+      nameservers: NS,
+    });
+
+    // The acting operator can manage users (reaches the route) and holds
+    // zone.read globally — but NOT record.delete anywhere.
+    const password = "limited-granter-pw-123456";
+    const granter = await createUser(admin, {
+      email: uniqueEmail("granter"),
+      name: "Limited Granter",
+      password,
+    });
+    const granterSlug = uniqueSlug("limited-granter");
+    await admin.sendJson("POST", "/api/admin/roles", {
+      slug: granterSlug,
+      name: "Limited Granter",
+      permissions: ["user.read", "user.update", "zone.read"],
+    });
+    const granterRoleId = await resolveRoleId(admin, granterSlug);
+    await admin.sendJson("POST", `/api/admin/users/${granter.id}/role-assignments`, {
+      roleId: granterRoleId,
+      scopeType: "global",
+    });
+
+    const victim = await createUser(admin, {
+      email: uniqueEmail("grant-victim"),
+      name: "Grant Victim",
+      password: "grant-victim-pw-123456",
+    });
+
+    const limited = await loginAs(granter.email, password);
+    const path = `/api/admin/users/${victim.id}/zone-grants`;
+
+    // Over the ceiling: granter lacks record.delete globally and has no own
+    // grant for this zone → 403.
+    const bad = await limited.call(path, {
+      method: "POST",
+      json: { serverId: standaloneId, zoneName: zone, permissions: ["record.delete"] },
+    });
+    expect(bad.status).toBe(403);
+
+    // Within the ceiling: zone.read is held globally → 201.
+    const ok = await limited.call(path, {
+      method: "POST",
+      json: { serverId: standaloneId, zoneName: zone, permissions: ["zone.read"] },
+    });
+    expect(ok.status).toBe(201);
   }, 30_000);
 });


### PR DESCRIPTION
Consolidated fix for the six draft security advisories (each was verified **not**
already present in `main`). One PR; squash-merge to a single commit.

## High
- **GHSA-gjg4-58c5-2qg3 — zone-grant privilege escalation.** The per-user
  zone-grant route assigned a role's permissions without checking them against the
  granting admin's own authority. Now enforces the `permissionsExceedingGrant`
  ceiling (same rule as role assignment). `app/api/admin/users/[id]/zone-grants/route.ts`.
- **GHSA-wf29-rmhc-rqc9 — OIDC group→role mappings bypassed the ceiling.** An
  `oidc.manage` holder could map a group to a higher-privileged role and escalate
  by signing in. New `assertGroupMappingsWithinCeiling` (`lib/rbac/oidc-mapping-ceiling.ts`
  + pure `groupMappingsExceedingGrant` in `ability.ts`) rejects such mappings at save.
- **GHSA-24hf-rxww-95cf — OIDC `requireEmailVerified` defaulted to `false`.** New
  DB providers shipped with the account-takeover guard off. Default is now `true`
  (existing rows keep their value — operators should audit them).

## Medium
- **GHSA-phv2-wjmm-pqqq — truncated AES-GCM auth tag accepted on decrypt.** Node
  permits tags ≥ 4 bytes by default. `decrypt()` now requires a 12-byte IV + 16-byte
  tag and passes `authTagLength`.
- **GHSA-frpq-xgm7-574x — failed-login counter race.** Read-modify-write let
  concurrent failures lose increments and exceed the lockout threshold. Now an atomic
  `failed_login_count = failed_login_count + 1 … RETURNING`.
- **GHSA-86v6-w5p9-29r8 — last-Super-Admin guard defeatable.** Counted raw assignment
  rows (incl. disabled users + duplicates), and didn't cover user disable/delete. Now
  counts distinct **enabled** users and guards the disable + delete routes.

## Verification
Each advisory branch confirmed absent from current `main`; merged with no conflicts
(`roles.ts` hunks were disjoint). `typecheck`, `lint`, `format`, `test` (298 pass),
and `npm run build` all green locally. CHANGELOG updated with all six.