### PR TITLE
chore(security): harden CI supply chain + resolve code-scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -74,9 +74,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -107,9 +107,9 @@ jobs:
     # on minor/major releases (+ monthly + manual), which also publishes the
     # per-version compatibility badges. See that workflow for the why.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -137,9 +137,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -172,16 +172,16 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up QEMU (for arm64 emulation)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -189,7 +189,7 @@ jobs:
 
       - name: Derive image tags + labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -199,7 +199,7 @@ jobs:
             type=sha,format=short
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           # PRs validate amd64 only (fast); main/tags publish both arches.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,21 +45,21 @@ jobs:
       matrix:
         language: [javascript-typescript, actions]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
         with:
           language: ${{ matrix.language }}
-          queries: security-extended
+          queries: security-and-quality
 
       # JS/TS is interpreted and the Actions language has nothing to compile,
       # so autobuild is a no-op here — kept for portability if a compiled
       # language is ever added.
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -29,10 +29,10 @@ jobs:
       contents: read
       pull-requests: write # post the summary comment on failure
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Dependency review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
           # MIT project — keep the dep tree to permissive/compatible licenses.

--- a/.github/workflows/pdns-compat-run.yml
+++ b/.github/workflows/pdns-compat-run.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: npm

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,7 @@ jobs:
       id-token: write # OIDC token for publish_results
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -49,13 +49,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
         with:
           sarif_file: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Node / pnpm / yarn
-node_modules/
+node_modules
 .pnpm-store/
 .yarn/cache
 .yarn/install-state.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@
 # =============================================================================
 
 # --- Stage 1: builder --------------------------------------------------------
-FROM node:24-bookworm-slim AS builder
+FROM node:24-bookworm-slim@sha256:242549cd46785b480c832479a730f4f2a20865d61ea2e404fdb2a5c3d3b73ecf AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 build-essential ca-certificates \
@@ -67,7 +67,7 @@ RUN npm run build
 # --- Stage 2: prod deps tree -------------------------------------------------
 # Separate stage so the runner gets a clean `npm ci --omit=dev` tree without
 # the devDeps that the builder needed (drizzle-kit, tsc, vitest, prettier).
-FROM node:24-bookworm-slim AS deps
+FROM node:24-bookworm-slim@sha256:242549cd46785b480c832479a730f4f2a20865d61ea2e404fdb2a5c3d3b73ecf AS deps
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 build-essential ca-certificates \
@@ -82,7 +82,7 @@ RUN --mount=type=cache,target=/root/.npm \
 
 
 # --- Stage 3: runner --------------------------------------------------------
-FROM node:24-bookworm-slim AS runner
+FROM node:24-bookworm-slim@sha256:242549cd46785b480c832479a730f4f2a20865d61ea2e404fdb2a5c3d3b73ecf AS runner
 
 WORKDIR /app
 

--- a/app/(app)/zones/[zoneId]/_components/soa-panel.tsx
+++ b/app/(app)/zones/[zoneId]/_components/soa-panel.tsx
@@ -369,7 +369,9 @@ function emailToRname(email: string): string {
   if (at === -1) {
     return addTrailingDot(trimmed);
   }
-  const local = trimmed.slice(0, at).replace(/\./g, "\\.");
+  // DNS master-file escaping: double a literal `\` before escaping `.` to `\.`,
+  // otherwise an unescaped backslash in the local-part corrupts the rname.
+  const local = trimmed.slice(0, at).replace(/\\/g, "\\\\").replace(/\./g, "\\.");
   const domain = stripTrailingDot(trimmed.slice(at + 1));
   return `${local}.${domain}.`;
 }

--- a/app/api/admin/pdns/zones/route.ts
+++ b/app/api/admin/pdns/zones/route.ts
@@ -212,7 +212,13 @@ export async function POST(request: Request): Promise<Response> {
     if (!isSecondary && normalizedNs.length > 0) {
       const primaryNs = normalizedNs[0]!;
       const responsibleEmail = input.responsibleEmail ?? `hostmaster@${lower.replace(/\.$/, "")}`;
-      const localPart = responsibleEmail.split("@")[0]!.replace(/\./g, "\\.");
+      // DNS master-file escaping for the SOA rname local-part: a literal `\`
+      // must be doubled before `.` is escaped to `\.`, else an unescaped
+      // backslash corrupts the encoding.
+      const localPart = responsibleEmail
+        .split("@")[0]!
+        .replace(/\\/g, "\\\\")
+        .replace(/\./g, "\\.");
       const domain = responsibleEmail.split("@")[1]!;
       const rname = `${localPart}.${domain.replace(/\.$/, "")}.`;
       const soa = {

--- a/components/domain/rr-editors/svcb.tsx
+++ b/components/domain/rr-editors/svcb.tsx
@@ -52,7 +52,11 @@ function serializeParam(p: SvcbParam): string {
   // whitespace (or a literal `"`). Comma is a value separator inside
   // comma-list values (alpn, ipv4hint, …) and stays unquoted.
   const needsQuote = /[\s"]/.test(p.value);
-  const v = needsQuote ? `"${p.value.replace(/"/g, '\\"')}"` : p.value;
+  // Escape `\` before `"` (RFC 9460 char-string rules): doing it the other way
+  // doubles the backslash the quote pass just inserted, and an unescaped `\`
+  // in the value would corrupt the serialized param.
+  const escaped = p.value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  const v = needsQuote ? `"${escaped}"` : p.value;
   return `${p.key}=${v}`;
 }
 

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/jadseifeddine/Documents/GitHub/PowerDNS-AuthUI/node_modules

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,6 +43,9 @@ export default defineConfig({
       "dist",
       "build",
       "coverage",
+      // Agent worktrees live here (git worktree under .claude/worktrees); their
+      // copies of the test files must not be collected into the main run.
+      ".claude/**",
       "tests/integration/**",
       "tests/e2e/**",
     ],


### PR DESCRIPTION
Resolves the remaining open **code-scanning** alerts and tightens the GitHub-native security/quality posture so the repo is strict by default. No runtime behaviour change beyond correct DNS rdata escaping.

## Supply chain (OpenSSF Scorecard — `Pinned-Dependencies`)
- **Pin every third-party GitHub Action to a full commit SHA** (with a `# vN` comment) across `ci.yml`, `codeql.yml`, `dependency-review.yml`, `pdns-compat-run.yml`, `scorecard.yml`.
- **Pin the `node:24-bookworm-slim` base image to a `sha256` digest** in all three Dockerfile stages (builder / deps / runner).

## Code quality scanning
- Switch CodeQL from `security-extended` → **`security-and-quality`** so the quality query suite runs alongside security (matches the newly-enabled *Code quality* setting on the repo).

## `js/incomplete-sanitization` (3 alerts)
Escape a literal backslash **before** escaping the following metacharacter when building DNS master-file rdata, so a `\` in user input can't corrupt the serialized value:
- SVCB/HTTPS `SvcParamValue` quoting — `components/domain/rr-editors/svcb.tsx`
- SOA responsible-mailbox RNAME encoding — `app/api/admin/pdns/zones/route.ts` + `app/(app)/zones/[zoneId]/_components/soa-panel.tsx`

## Repo hygiene
- Stop tracking the `node_modules` symlink (was a committed tree entry); ignore it via `.gitignore`.
- Exclude `.claude/**` from the vitest run so agent worktrees under `.claude/worktrees/` don't get their test files double-collected into the main run.

## Validation
`npm run validate` (lint + typecheck + format + test/coverage) green locally. Remaining CodeQL/Scorecard alerts should auto-resolve on the next scan after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)