### PR TITLE
Release 1.1.1: security advisory batch, supply-chain hardening, signup, fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -221,11 +221,13 @@ APP_PDNS_ALLOW_INSECURE_HTTP=true
 
 
 # -----------------------------------------------------------------------------
-# Redis (RESERVED — not wired up yet)
+# Redis (optional — for horizontal scale, replicas > 1)
 #
-# Validated but NOT consumed by any code today: rate limiting, the realtime SSE
-# event-bus, and reveal-once tokens are all in-process. Reserved for a future
-# HA setup. Setting it does not enable Redis or make the app multi-replica safe.
+# When set, auth rate limiting, the realtime SSE event-bus, and one-time reveal
+# tokens coordinate across replicas (sessions are already shared via Postgres).
+# Each falls back to its in-process path when REDIS_URL is unset or a command
+# fails, so single-node deployments need no Redis. See the README
+# "High availability" section and ADR-0016.
 # -----------------------------------------------------------------------------
 
 # REDIS_URL=redis://localhost:6379

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [1.1.1] — 2026-05-25
+
 ### Security
 
 Coordinated batch resolving six advisories (GHSA-gjg4-58c5-2qg3, GHSA-wf29-rmhc-rqc9,
@@ -40,6 +44,55 @@ GHSA-24hf-rxww-95cf, GHSA-phv2-wjmm-pqqq, GHSA-frpq-xgm7-574x, GHSA-86v6-w5p9-29
   Super Admin could be disabled or deleted — locking the install out of its own administration.
   It now counts distinct **enabled** users and also covers the user disable + delete routes
   (previously only assignment removal was guarded).
+- **Content-Security-Policy `script-src` tightened.** Removed `'self'` and the Cloudflare
+  Turnstile host from `script-src`; the directive is now the per-request nonce plus
+  `strict-dynamic` (with `'unsafe-eval'` only in dev), so an injected inline or remote script can
+  no longer execute by virtue of same-origin or a hard-coded allow-listed host.
+- **DNS-rebinding hardening on outbound PowerDNS requests.** The reachability guard validated the
+  backend host, but the follow-up HTTP request re-resolved DNS — a TOCTOU window a rebinding
+  record could exploit to reach a blocked address. The guard-validated IP is now pinned into the
+  request dispatcher, so the connection targets the address that actually passed the guard.
+- **Supply-chain & scanning hardening.** Every third-party GitHub Action is pinned to a full
+  commit SHA, and the container base image to a `sha256` digest; CodeQL runs the
+  `security-and-quality` query suite; and CodeQL, dependency-review, and OpenSSF Scorecard now gate
+  pushes/PRs. Also resolved three `js/incomplete-sanitization` findings — a literal backslash is
+  now escaped before the following metacharacter when building SVCB/HTTPS and SOA-mailbox rdata.
+
+### Added
+
+- **Self-service signup.** Optional `SIGNUP_ENABLED` exposes a `/signup` page and API (both 404
+  when off, the default). New accounts receive the low-privilege `SIGNUP_DEFAULT_ROLE` — a
+  boot-time guard refuses an admin-equivalent role — with an optional `SIGNUP_ALLOWED_EMAIL_DOMAINS`
+  allow-list and SMTP-backed email verification. See [Configuration](./docs/03-CONFIGURATION.md).
+- **Inline SVG brand logo.** The settings brand logo now accepts an inline `data:` SVG URI in
+  addition to an `https://` URL; inline SVG is sanitized server-side (DOMPurify) before it is
+  stored or rendered.
+- **Build provenance in the version chip.** Non-release / local builds show the short commit SHA
+  in the sidebar version chip, so a running build is unambiguously identifiable.
+
+### Fixed
+
+- **Dashboard active-session count.** The "active sessions" KPI was sampled in a way that always
+  reported 0; the sampler now counts live sessions correctly.
+- **DNS record validators.** Corrected the SRV port-range bound, accept the all-zeroes IPv6 group
+  (`::`) in AAAA, reject an unbalanced quote in CAA, and fix the TXT bare-text escape order
+  (RFC 1035 § 5.1).
+- **SQLite write path.** Writes and their audit row now commit in a single real transaction
+  (atomic), and the `backend_advisories` `first_seen_at` / `last_seen_at` defaults match the
+  Postgres schema.
+- **Cluster routing.** Probe/failure latencies no longer skew peer selection, and the round-robin
+  index is shared across the process so rotation stays even.
+- **Redis event-bus handler.** The cross-replica SSE message handler is registered exactly once,
+  so an event is no longer delivered multiple times when `REDIS_URL` is configured.
+- **SelectMenu drop-up.** The themed select menu flips upward when it would otherwise open past
+  the bottom of the viewport.
+
+### Documentation
+
+- **Installation: persist secrets in `.env`.** The setup used shell `export`s for
+  `APP_SECRET_KEY` / `APP_ENCRYPTION_KEY`, which silently change on the next shell and guarantee a
+  lockout. It now writes them once into a Compose-loaded `.env`, with explicit `down` vs `down -v`
+  guidance.
 
 ## [1.1.0] — 2026-05-24
 
@@ -194,7 +247,8 @@ First production release.
 - **Distribution** — multi-arch (`linux/amd64` + `linux/arm64`) image published to Docker Hub as
   `jseifeddine/powerdns-authadmin`, plus a one-command minimal-demo stack.
 
-[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.0.0...v1.0.1

--- a/docs/09-UPGRADING.md
+++ b/docs/09-UPGRADING.md
@@ -37,6 +37,22 @@ half-migrated schema; fix the cause and restart.
 
 ## Version-specific notes
 
+### Upgrading to 1.1.1 (from 1.1.0)
+
+A maintenance + security release — **no schema migration**, so it's a plain
+pull-and-recreate. One behavioural change to be aware of:
+
+- **OIDC `requireEmailVerified` now defaults to `true`** for newly-created
+  DB-backed providers (account-takeover hardening). **Existing provider rows keep
+  their stored value**, so nothing changes for them on upgrade — but if you have a
+  provider with `requireEmailVerified` set to `false`, audit it: confirm the IdP
+  genuinely never emits the `email_verified` claim before keeping it off. See
+  [OIDC](./05-OIDC.md).
+
+Everything else in this release (the security batch, the CSP and supply-chain
+hardening, and the opt-in additions like self-service signup) is transparent on
+upgrade — signup stays off unless you set `SIGNUP_ENABLED=true`.
+
 ### Upgrading to 1.1.0 (from 1.0.x)
 
 One schema migration applies on first boot (`0003_backend_caps_advisories_squash`).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -44,9 +44,10 @@ can jump straight into the code that owns each feature.
     - `enabled` — hides the provider from the login page when off.
     - `force_default` — `/login` auto-redirects here instead of showing the form. Escape hatch
       is `/login?force-local=1`.
-    - `require_email_verified` — default off; on, sign-in is blocked unless the IdP attests
+    - `require_email_verified` — default on; sign-in is blocked unless the IdP attests
       `email_verified: true`. Defends against account-takeover when the same email exists
-      locally and the IdP lets users set arbitrary unverified emails.
+      locally and the IdP lets users set arbitrary unverified emails. Relax it only for IdPs
+      that never emit the claim.
     - `allowed_email_domains` — per-provider override of the env-level allow-list.
   - Discovery health is operator-pollable via the **Test** button on the providers list AND
     the edit page; the result is cached on the row's `discovery_cache` field.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerdns-authadmin",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@casl/ability": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Modern, self-hosted DNS administration UI for PowerDNS — multi-team RBAC, real audit, real SSO. From-scratch rebuild of PowerDNS-Admin in Node.js + TypeScript.",
   "license": "MIT",


### PR DESCRIPTION
Release-marking PR for **v1.1.1**. Version bump + CHANGELOG/docs only — every feature and fix in this release is already merged on `main` (PRs #13–#36 since v1.1.0).

### What's in 1.1.1
- **Security:** coordinated six-advisory batch (#35 — zone-grant & OIDC-group-mapping permission ceilings, OIDC `requireEmailVerified` default → true, AES-GCM tag length, atomic failed-login counter, hardened last-Super-Admin guard); CSP `script-src` tightened to nonce + `strict-dynamic` (#29); DNS-rebinding hardening on outbound PDNS requests (#24); supply-chain hardening — all Actions pinned to SHA, base image to digest, CodeQL `security-and-quality`, Scorecard/dependency-review gating (#36/#20/#12).
- **Added:** self-service signup (`SIGNUP_ENABLED`, #33); inline SVG brand logo, sanitized server-side (#31); commit-SHA build provenance in the version chip (#15).
- **Fixed:** dashboard active-session count (#26); DNS validators — SRV/AAAA/CAA/TXT (#22/#17); SQLite real transactions + advisory default parity (#21/#23); cluster routing latency/RR-index (#19); Redis event-bus handler registered once (#18); SelectMenu drop-up (#13).
- **Docs:** installation secrets persisted in `.env` (#34); upgrade note; corrected `require_email_verified` default; `.env.example` Redis no longer "reserved".

### Release mechanics
After merge: tag `v1.1.1` on the squash commit → the docker job publishes `:1.1.1` + `:1.1`; then a GitHub release is cut. **No schema migration.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)