### PR TITLE
Release 1.1.2: security audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [1.1.2] — 2026-05-25
+
 ### Security
 
 Findings from an internal security audit. Distinct advisories are tracked privately
@@ -291,7 +295,8 @@ First production release.
 - **Distribution** — multi-arch (`linux/amd64` + `linux/arm64`) image published to Docker Hub as
   `jseifeddine/powerdns-authadmin`, plus a one-command minimal-demo stack.
 
-[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.0.1...v1.0.2

--- a/docs/09-UPGRADING.md
+++ b/docs/09-UPGRADING.md
@@ -37,6 +37,25 @@ half-migrated schema; fix the cause and restart.
 
 ## Version-specific notes
 
+### Upgrading to 1.1.2 (from 1.1.x)
+
+A security release — **no schema migration**, a plain pull-and-recreate. Two
+behavioural changes that close enforcement gaps (they may surface as a new `403`
+for accounts that were previously able to bypass a gate via the API):
+
+- **Required-MFA and forced-password-change are now enforced on the API, not just
+  in the browser.** If a user's role requires MFA, or the user is flagged "must
+  change password", their session is now refused on write routes until they
+  enroll TOTP / change their password (the enrollment, change-password, and
+  logout endpoints stay reachable). This previously only redirected the browser,
+  so a direct API caller could skip it. No action needed unless you rely on
+  required-MFA accounts driving the API without having enrolled — have them
+  enroll.
+- **Privilege ceilings are enforced on more admin paths.** Creating a user with
+  an initial role, resetting another user's password, and removing another user's
+  MFA now refuse to act beyond the actor's own global permissions. Operators using
+  only the built-in roles are unaffected.
+
 ### Upgrading to 1.1.1 (from 1.1.0)
 
 A maintenance + security release — **no schema migration**, so it's a plain

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerdns-authadmin",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@casl/ability": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "description": "Modern, self-hosted DNS administration UI for PowerDNS — multi-team RBAC, real audit, real SSO. From-scratch rebuild of PowerDNS-Admin in Node.js + TypeScript.",
   "license": "MIT",


### PR DESCRIPTION
Release-marking PR for **v1.1.2**. Version bump + CHANGELOG/UPGRADING only — all fixes are already merged on main via #42.

1.1.2 ships the internal security-audit batch: MFA/forced-password-change enforcement on API routes, privilege ceilings on user-create / password-reset / MFA-removal, OIDC outbound DNS-rebinding pinning, plus defense-in-depth hardening, the email-verification deadlock fix, and audit/test improvements.

After merge: tag `v1.1.2` (publishes `:1.1.2` + `:1.1`), publish the 4 GHSA advisories with patched=1.1.2, cut the GitHub release, and deploy. **No schema migration.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)