### PR TITLE
Cluster zone grants (#40) + Next 16 proxy migration (#41) + Node 24 CI action bumps (#44) + docs overhaul

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -2,10 +2,16 @@
 # locally before pushing. With these set, `act -j static-checks -W .github/workflows/ci.yml`
 # works with no extra flags (and no interactive image prompt).
 #
-# Runner image: the "medium" catthehacker image — enough to run our JS-action
-# jobs (static-checks, test, audit). CodeQL, the Docker build/publish, Scorecard,
-# and dependency-review need GitHub-hosted runners and are NOT validated by act.
+# Runner image: the "medium" catthehacker image (multi-arch) — enough to run our
+# JS-action jobs (static-checks, test, audit). CodeQL, the Docker build/publish,
+# Scorecard, and dependency-review need GitHub-hosted runners and are NOT run here.
 -P ubuntu-latest=catthehacker/ubuntu:act-latest
-# Pin the container arch so Apple-silicon hosts don't prompt / misbehave; a no-op
-# cost on amd64 Linux.
---container-architecture linux/amd64
+# No --container-architecture: act uses the HOST-native arch (arm64 on Apple
+# silicon, amd64 on Linux). Forcing linux/amd64 on Apple silicon runs under QEMU,
+# which makes loopback-networking unit tests time out — native arch runs them fine.
+#
+# Default to the CI workflow, so `act -j static-checks` / `act -j test` need no
+# other flags. (act only honours one -j, so the full local gate is wrapped as
+# `npm run ci:local`. integration-test + docker need a real runner / nested
+# Docker — run `npm run test:integration` natively instead.)
+-W .github/workflows/ci.yml

--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,11 @@
+# act (https://github.com/nektos/act) defaults for this repo — run GitHub Actions
+# locally before pushing. With these set, `act -j static-checks -W .github/workflows/ci.yml`
+# works with no extra flags (and no interactive image prompt).
+#
+# Runner image: the "medium" catthehacker image — enough to run our JS-action
+# jobs (static-checks, test, audit). CodeQL, the Docker build/publish, Scorecard,
+# and dependency-review need GitHub-hosted runners and are NOT validated by act.
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+# Pin the container arch so Apple-silicon hosts don't prompt / misbehave; a no-op
+# cost on amd64 Linux.
+--container-architecture linux/amd64

--- a/.env.example
+++ b/.env.example
@@ -238,7 +238,7 @@ APP_PDNS_ALLOW_INSECURE_HTTP=true
 # -----------------------------------------------------------------------------
 
 # OTEL_EXPORTER_OTLP_ENDPOINT=
-# Expose GET /metrics (Prometheus). Default false.
+# Expose GET /metrics (Prometheus). Default true; set false to disable.
 # METRICS_ENABLED=true
 # Optional bearer token gating /metrics (≥16 chars). Unset = open (rely on
 # network ACLs). Generate with: openssl rand -hex 32

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -74,9 +74,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -107,9 +107,9 @@ jobs:
     # on minor/major releases (+ monthly + manual), which also publishes the
     # per-version compatibility badges. See that workflow for the why.
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -137,9 +137,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -172,16 +172,16 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up QEMU (for arm64 emulation)
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -189,7 +189,7 @@ jobs:
 
       - name: Derive image tags + labels
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -199,7 +199,7 @@ jobs:
             type=sha,format=short
 
       - name: Build and push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           # PRs validate amd64 only (fast); main/tags publish both arches.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,10 +45,10 @@ jobs:
       matrix:
         language: [javascript-typescript, actions]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           language: ${{ matrix.language }}
           queries: security-and-quality
@@ -57,9 +57,9 @@ jobs:
       # so autobuild is a no-op here — kept for portability if a compiled
       # language is ever added.
       - name: Autobuild
-        uses: github/codeql-action/autobuild@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
+        uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -29,10 +29,10 @@ jobs:
       contents: read
       pull-requests: write # post the summary comment on failure
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Dependency review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           fail-on-severity: high
           # MIT project — keep the dep tree to permissive/compatible licenses.

--- a/.github/workflows/pdns-compat-run.yml
+++ b/.github/workflows/pdns-compat-run.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: npm

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,7 @@ jobs:
       id-token: write # OIDC token for publish_results
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -49,13 +49,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,31 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **Per-zone grants now work on multi-primary clusters.** A `zone_grant` is keyed to one
+  backend, but a cluster zone's reads/writes resolve a rotating peer (`choosePeer`), so a grant
+  issued on one peer intermittently returned 403 when another peer was chosen. Grants are now
+  expanded across cluster peers on the authorization path, so a grant on any peer authorizes the
+  zone on every peer of that cluster. (#40)
+
+### Changed
+
+- **`middleware.ts` → `proxy.ts`.** Adopted the Next 16 `proxy` file convention (the `middleware`
+  convention is deprecated); the per-request CSP nonce + security headers are unchanged. (#41)
+- **CI GitHub Actions re-pinned to Node 24-compatible releases** (still pinned by commit SHA),
+  ahead of GitHub's deprecation of the Node 20 action runtime. (#44)
+
+### Documentation
+
+- **Installation guide rewritten** to four bulletproof, copy-paste steps (pick a database → create
+  `.env` → write `docker-compose.yml` → start), plus a docs-wide accuracy sweep (bootstrap-admin
+  semantics, lockout default, metrics route/default, provisioning order, dev-setup flow) verified
+  against the code.
+- **`act` documented as the pre-push local-CI standard** (a committed `.actrc` pins the runner
+  image); it runs the JS-action jobs locally, while CodeQL / Docker / Scorecard remain on GitHub CI.
+- README: added a GHCR pulls badge and a "PowerDNS Auth tested versions" header over the
+  compatibility badges.
 
 ## [1.1.2] — 2026-05-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,9 +53,10 @@ npm run db:generate              # after a schema change → new migration (also
 npm run db:migrate               # apply pending migrations
 ```
 
-Run CI locally before pushing with [`act`](https://github.com/nektos/act) — e.g.
-`act -j static-checks -W .github/workflows/ci.yml --container-architecture linux/amd64` (covers
-the `static-checks`/`test`/`audit` jobs; CodeQL/Docker/Scorecard still need real CI).
+Pre-push gate: `npm run test` (unit suite, native) + `act -j static-checks -W .github/workflows/ci.yml`
+([act](https://github.com/nektos/act) runs CI lint+typecheck+format — incl. `eslint .` without the
+local OOM; `.actrc` pins the image + arch). Run unit tests natively, not under `act` (network-touching
+tests can time out in its emulated container). CodeQL/Docker/Scorecard still need real CI.
 
 ## Project layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,31 +27,35 @@ Licensed under **MIT**.
 
 ## How to run things
 
-### Containerized (recommended)
+### Containerized demo (quickest)
 
 ```sh
-cp .env.example .env
-openssl rand -base64 32   # → APP_SECRET_KEY in .env
-openssl rand -base64 32   # → APP_ENCRYPTION_KEY in .env
-docker compose up -d --build
-#   app  at http://localhost:3000
-#   pdns at http://localhost:8081/api/v1   (X-API-Key: changeme)
+docker compose up -d   # demo stack (app + PDNS); reads throwaway secrets from .env.example
+#   app  at http://localhost:3000          (login: admin@example.com / change-me-now)
+#   pdns at http://localhost:8081/api/v1   (X-API-Key: demo-pdns-api-key)
 ```
+
+For a real install (your own `.env` + compose, SQLite or Postgres) see
+[`docs/02-INSTALLATION.md`](./docs/02-INSTALLATION.md).
 
 ### Local dev with HMR
 
 ```sh
 nvm use                          # Node 24 from .nvmrc
 npm ci                           # exact-pin install
-cp .env.example .env.local       # fill in APP_SECRET_KEY + APP_ENCRYPTION_KEY
-docker compose up -d             # Postgres + Redis + sandbox PDNS
+cp .env.example .env.local       # set APP_SECRET_KEY + APP_ENCRYPTION_KEY; DATABASE_URL=file:./dev.db
+docker compose up -d pdns        # a local PowerDNS to develop against (SQLite app runs on host)
 
 npm run dev                      # http://localhost:3000
 npm run validate                 # the CI gate — lint + typecheck + format + test
-npm run db:generate              # after a schema change → produces a new migration
+npm run test:integration         # integration suite (builds + boots the stack in Docker)
+npm run db:generate              # after a schema change → new migration (also db:generate:sqlite)
 npm run db:migrate               # apply pending migrations
-npm run db:studio                # browse the DB via Drizzle Studio
 ```
+
+Run CI locally before pushing with [`act`](https://github.com/nektos/act) — e.g.
+`act -j static-checks -W .github/workflows/ci.yml --container-architecture linux/amd64` (covers
+the `static-checks`/`test`/`audit` jobs; CodeQL/Docker/Scorecard still need real CI).
 
 ## Project layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ lib/                  domain code, three-layer architecture enforced via ESLint
   logger.ts           Pino structured logging
   client-ip.ts        proxy-aware client IP
 
-middleware.ts         per-request CSP nonce + security headers
+proxy.ts              per-request CSP nonce + security headers (Next 16 proxy convention)
 docker/               entrypoint that runs migrations then boots the server
 drizzle/              generated PG migrations
 drizzle-sqlite/       generated SQLite migrations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,10 +53,10 @@ npm run db:generate              # after a schema change → new migration (also
 npm run db:migrate               # apply pending migrations
 ```
 
-Pre-push gate: `npm run test` (unit suite, native) + `act -j static-checks -W .github/workflows/ci.yml`
-([act](https://github.com/nektos/act) runs CI lint+typecheck+format — incl. `eslint .` without the
-local OOM; `.actrc` pins the image + arch). Run unit tests natively, not under `act` (network-touching
-tests can time out in its emulated container). CodeQL/Docker/Scorecard still need real CI.
+Pre-push gate: `npm run ci:local` (= `act -j static-checks && act -j test` — [act](https://github.com/nektos/act)
+runs the CI lint/typecheck/format + unit-test jobs locally, incl. `eslint .` without the local OOM;
+the committed `.actrc` pins the runner image + workflow + host-native arch). Run
+`npm run test:integration` natively (act can't nest docker-compose). CodeQL/Docker/Scorecard still need real CI.
 
 ## Project layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,20 +176,20 @@ Two layers, run independently:
 
 ### Before you push (run CI locally)
 
-Standard pre-push gate — fix anything that fails before pushing:
+Standard pre-push gate — run CI locally with **[`act`](https://github.com/nektos/act)** and fix
+anything that fails. The committed `.actrc` pins the runner image + the CI workflow and uses your
+host-native arch, so the commands are flag-free:
 
 ```sh
-npm run test                              # unit suite (native — fast, reliable)
-act -j static-checks -W .github/workflows/ci.yml   # CI lint + typecheck + format
-npm run test:integration                  # only if you touched routes / repos / auth
+npm run ci:local            # the gate: act runs the CI lint + typecheck + format + unit-test jobs
+npm run test:integration    # only if you touched routes / repos / auth
 ```
 
-- **Run the unit suite natively** with `npm run test`, not under `act` — a couple of
-  network-touching tests can time out in `act`'s emulated container (e.g. on Apple Silicon).
-- **[`act`](https://github.com/nektos/act)** runs the CI lint + typecheck + format job in Docker;
-  use it for lint especially — it runs `eslint .` without the host-memory limit you can hit with
-  `npm run lint` directly. The committed `.actrc` pins the runner image + arch (no flags needed;
-  first run pulls the ~1 GB image).
+- `npm run ci:local` is `act -j static-checks && act -j test`; run a single job with `act -j test`
+  if you prefer. `act` runs `eslint .` without the host-memory limit you can hit with
+  `npm run lint` directly (first run pulls the ~1 GB runner image).
+- Run the integration suite **natively, not under `act`** — that job nests docker-compose, which
+  `act` can't run.
 - `act` does **not** replace GitHub-hosted CodeQL, the Docker build/publish, Scorecard, or
   dependency-review — those need GitHub runners/tokens and remain the authority on the PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,25 @@ Two layers, run independently:
   log, anything that handles money or secrets. Don't write tests to inflate the percentage.
 - **Every bug fix ships a test that fails before the fix.** No exceptions.
 
+### Before you push (run CI locally)
+
+Standard pre-push gate, in order — fix anything that fails before pushing:
+
+1. `npm run validate` — lint + typecheck + format check + unit tests.
+2. `npm run test:integration` — if you touched routes, repositories, or auth.
+3. **[`act`](https://github.com/nektos/act)** — run the GitHub Actions jobs in Docker to catch
+   CI failures locally:
+
+   ```sh
+   act -j static-checks -W .github/workflows/ci.yml --container-architecture linux/amd64
+   act -j test          -W .github/workflows/ci.yml --container-architecture linux/amd64
+   ```
+
+   `act` covers the JS-action jobs (`static-checks`, `test`, `audit`) and runs `eslint .` without
+   the host-memory limits you can hit locally. It does **not** replace GitHub-hosted CodeQL, the
+   Docker build/publish, Scorecard, or dependency-review — those need GitHub runners/tokens and
+   remain the authority on the PR.
+
 ### Running the integration suite
 
 `npm run test:integration` is one command. It:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,9 @@
 4. **Trunk-based.** Short-lived branches, squash-merge to `main`, no long-running feature branches.
 5. **Conventional Commits** for PR titles: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, `test:`,
    `perf:`, `build:`, `ci:`. The PR body is the changelog entry — write it for humans.
+6. **Milestones track releases.** Every issue and PR targeting a release is tagged with that
+   release's milestone (e.g. `v1.1.3`). The milestone is closed when that version ships — its
+   issues/PRs are the release's scope and map to the `CHANGELOG` section.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,22 +176,22 @@ Two layers, run independently:
 
 ### Before you push (run CI locally)
 
-Standard pre-push gate, in order — fix anything that fails before pushing:
+Standard pre-push gate — fix anything that fails before pushing:
 
-1. `npm run validate` — lint + typecheck + format check + unit tests.
-2. `npm run test:integration` — if you touched routes, repositories, or auth.
-3. **[`act`](https://github.com/nektos/act)** — run the GitHub Actions jobs in Docker to catch
-   CI failures locally:
+```sh
+npm run test                              # unit suite (native — fast, reliable)
+act -j static-checks -W .github/workflows/ci.yml   # CI lint + typecheck + format
+npm run test:integration                  # only if you touched routes / repos / auth
+```
 
-   ```sh
-   act -j static-checks -W .github/workflows/ci.yml --container-architecture linux/amd64
-   act -j test          -W .github/workflows/ci.yml --container-architecture linux/amd64
-   ```
-
-   `act` covers the JS-action jobs (`static-checks`, `test`, `audit`) and runs `eslint .` without
-   the host-memory limits you can hit locally. It does **not** replace GitHub-hosted CodeQL, the
-   Docker build/publish, Scorecard, or dependency-review — those need GitHub runners/tokens and
-   remain the authority on the PR.
+- **Run the unit suite natively** with `npm run test`, not under `act` — a couple of
+  network-touching tests can time out in `act`'s emulated container (e.g. on Apple Silicon).
+- **[`act`](https://github.com/nektos/act)** runs the CI lint + typecheck + format job in Docker;
+  use it for lint especially — it runs `eslint .` without the host-memory limit you can hit with
+  `npm run lint` directly. The committed `.actrc` pins the runner image + arch (no flags needed;
+  first run pulls the ~1 GB image).
+- `act` does **not** replace GitHub-hosted CodeQL, the Docker build/publish, Scorecard, or
+  dependency-review — those need GitHub runners/tokens and remain the authority on the PR.
 
 ### Running the integration suite
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [![Container: GHCR](https://img.shields.io/badge/ghcr.io-powerdns--authadmin-2496ED?logo=docker&logoColor=white)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/pkgs/container/powerdns-authadmin)
 [![GHCR version](https://ghcr-badge.egpl.dev/powerdns-authadmin/powerdns-authadmin/latest_tag?ignore=latest,edge&label=ghcr.io&color=%232ea44f)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/pkgs/container/powerdns-authadmin)
 [![GHCR image size](https://ghcr-badge.egpl.dev/powerdns-authadmin/powerdns-authadmin/size?tag=latest&label=image%20size&color=%232ea44f)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/pkgs/container/powerdns-authadmin)
+[![GHCR pulls](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fghcr-badge.elias.eu.org%2Fapi%2Fpowerdns-authadmin%2Fpowerdns-authadmin&query=%24.downloadCount&label=ghcr%20pulls&logo=docker&logoColor=white&color=2496ED)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/pkgs/container/powerdns-authadmin)
 [![License: MIT](https://img.shields.io/github/license/PowerDNS-AuthAdmin/powerdns-authadmin)](./LICENSE)
 
 [![Node.js 24](https://img.shields.io/badge/Node.js-24-339933?logo=node.js&logoColor=white)](.nvmrc)

--- a/README.md
+++ b/README.md
@@ -363,9 +363,10 @@ Full guides live in **[`docs/`](./docs/)** — start at the
 
 ## Status
 
-**v1.0.0 — first production release.** Deploy on SQLite or Postgres with the published image; see
-[Run it](#run-it). The roadmap is tracked in GitHub issues — contributions welcome, read
-[`CONTRIBUTING.md`](./CONTRIBUTING.md) first.
+**Production-ready.** Deploy on SQLite or Postgres with the published image; see
+[Run it](#run-it). Released versions and changes are in
+[`CHANGELOG.md`](./CHANGELOG.md); the roadmap is tracked in GitHub issues —
+contributions welcome, read [`CONTRIBUTING.md`](./CONTRIBUTING.md) first.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -23,17 +23,19 @@
 [![Next.js 16](https://img.shields.io/badge/Next.js-16-000000?logo=next.js)](https://nextjs.org)
 [![TypeScript strict](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)](tsconfig.json)
 
-[![PowerDNS 4.6](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-46.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-46.yml)
-[![PowerDNS 4.7](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-47.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-47.yml)
-[![PowerDNS 4.8](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-48.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-48.yml)
-[![PowerDNS 4.9](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-49.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-49.yml)
-[![PowerDNS 5.0](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-50.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-50.yml)
-
 PowerDNS-AuthAdmin manages one or many PowerDNS Authoritative backends from a single web app. It
 ships with a permissive RBAC engine, OIDC single sign-on with group→role mapping, transactional
 zone editing, NOTIFY-aware sync probes for cluster + primary/secondary topologies, an append-only
 audit log, scoped API tokens, and a YAML-driven first-boot provisioning system that brings up a
 ready-to-use install without a single click.
+
+**PowerDNS Auth version compatibility tests:**
+
+[![PowerDNS 4.6](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-46.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-46.yml)
+[![PowerDNS 4.7](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-47.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-47.yml)
+[![PowerDNS 4.8](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-48.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-48.yml)
+[![PowerDNS 4.9](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-49.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-49.yml)
+[![PowerDNS 5.0](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-50.yml/badge.svg)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/pdns-compat-50.yml)
 
 ## At a glance
 

--- a/app/api/admin/users/[id]/zone-grants/route.ts
+++ b/app/api/admin/users/[id]/zone-grants/route.ts
@@ -22,13 +22,17 @@ import { requireUser } from "@/lib/auth/require-user";
 import { requireCsrf } from "@/lib/auth/csrf";
 import { db } from "@/lib/db";
 import { zoneGrants } from "@/lib/db/schema";
-import { findGrant, listGrantsForUser } from "@/lib/db/repositories/zone-grants";
+import {
+  findGrant,
+  listGrantsForUser,
+  mapServersToClusterPeers,
+} from "@/lib/db/repositories/zone-grants";
 import { findPdnsServerById } from "@/lib/db/repositories/pdns-servers";
 import { findUserById } from "@/lib/db/repositories/users";
 import { loadUserAssignmentsForAbility } from "@/lib/db/repositories/roles";
 import { PERMISSIONS } from "@/lib/rbac/permissions";
 import { globalPermissionsOf, type AbilitySource } from "@/lib/rbac/ability";
-import { effectiveZonePermissions } from "@/lib/rbac/zone-permissions";
+import { effectiveZonePermissions, expandGrantsAcrossClusters } from "@/lib/rbac/zone-permissions";
 import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from "@/lib/errors";
 import { errorResponse } from "@/lib/http/error-response";
 
@@ -109,7 +113,14 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
     )) as readonly AbilitySource[];
     const actorGlobal = globalPermissionsOf(actorSources);
     const actorGrants = await listGrantsForUser(actor.id);
-    const actorZonePerms = effectiveZonePermissions(actorGrants, input.serverId, zoneName);
+    // Expand across cluster peers so an actor's grant on a sibling peer counts
+    // toward the ceiling for this (cluster) zone (see get-current-user).
+    const actorPeers = actorGrants.length
+      ? await mapServersToClusterPeers(actorGrants.map((g) => g.serverId))
+      : new Map<string, string[]>();
+    const actorEffectiveGrants =
+      actorPeers.size === 0 ? actorGrants : expandGrantsAcrossClusters(actorGrants, actorPeers);
+    const actorZonePerms = effectiveZonePermissions(actorEffectiveGrants, input.serverId, zoneName);
     const exceeding = input.permissions.filter(
       (p) => !actorGlobal.has(p as (typeof PERMISSIONS)[number]) && !actorZonePerms.has(p),
     );

--- a/app/api/csp-report/route.ts
+++ b/app/api/csp-report/route.ts
@@ -31,7 +31,7 @@
  *     arbitrarily large log line.
  *
  * Wired into CSP via the `report-uri` + `report-to` directives in
- * `middleware.ts`.
+ * `proxy.ts`.
  */
 
 import { logger } from "@/lib/logger";

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -55,7 +55,7 @@ export const viewport: Viewport = {
 const THEME_INIT_SCRIPT = `(function(){try{var k="pda-theme",t=localStorage.getItem(k)||"system",d=t==="dark"||(t==="system"&&matchMedia("(prefers-color-scheme: dark)").matches);document.documentElement.classList.toggle("dark",d);}catch(e){}})();`;
 
 export default async function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
-  // CSP nonce is set per request in middleware.ts; thread it onto the inline
+  // CSP nonce is set per request in proxy.ts; thread it onto the inline
   // theme-init script so it isn't blocked by the strict policy.
   const nonce = (await headers()).get("x-nonce") ?? undefined;
 

--- a/app/nic/update/route.ts
+++ b/app/nic/update/route.ts
@@ -30,7 +30,7 @@ import {
 } from "@/lib/db/repositories/api-tokens";
 import { findUserByEmail } from "@/lib/db/repositories/users";
 import { loadUserAssignmentsForAbility } from "@/lib/db/repositories/roles";
-import { listGrantsForUser } from "@/lib/db/repositories/zone-grants";
+import { listGrantsForUser, mapServersToClusterPeers } from "@/lib/db/repositories/zone-grants";
 import { listActivePdnsServers } from "@/lib/db/repositories/pdns-servers";
 import { appendAudit } from "@/lib/audit/log";
 import { getClientIp, getRequestContext } from "@/lib/client-ip";
@@ -48,7 +48,7 @@ import {
   type NarrowableAssignment,
 } from "@/lib/auth/token-scope-narrowing";
 import { globalPermissionsOf } from "@/lib/rbac/ability";
-import { hasZonePermissionViaGrant } from "@/lib/rbac/zone-permissions";
+import { expandGrantsAcrossClusters, hasZonePermissionViaGrant } from "@/lib/rbac/zone-permissions";
 import { getBackendGateway } from "@/lib/realtime/backend-gateway";
 import { replaceRRset, zonePatchBody } from "@/lib/pdns/rrsets";
 import { redact } from "@/lib/errors/redact";
@@ -118,7 +118,7 @@ export async function GET(request: Request): Promise<Response> {
   );
   const globalPermissions = globalPermissionsOf(narrowed);
   const rawGrants = await listGrantsForUser(user.id);
-  const zoneGrants =
+  const narrowedGrants =
     tokenRow.scopes.length === 0
       ? rawGrants
       : rawGrants
@@ -127,6 +127,16 @@ export async function GET(request: Request): Promise<Response> {
             permissions: g.permissions.filter((p) => tokenRow.scopes.includes(p)),
           }))
           .filter((g) => g.permissions.length > 0);
+  // Expand across cluster peers so a grant on one peer authorizes the zone on
+  // the rotating peer this DynDNS update resolves to (see get-current-user).
+  const clusterPeers =
+    narrowedGrants.length > 0
+      ? await mapServersToClusterPeers(narrowedGrants.map((g) => g.serverId))
+      : new Map<string, string[]>();
+  const zoneGrants =
+    clusterPeers.size === 0
+      ? narrowedGrants
+      : expandGrantsAcrossClusters(narrowedGrants, clusterPeers);
 
   // ── Source IP — use the explicit param when given, else derive ──────────
   const sourceIp = myip ?? getClientIp(hdrs);

--- a/docs/01-QUICKSTART.md
+++ b/docs/01-QUICKSTART.md
@@ -17,7 +17,7 @@ cd powerdns-authadmin
 docker compose up -d
 ```
 
-The first run builds the app image (a few minutes); later runs start instantly.
+The first run pulls the app + PowerDNS images; subsequent runs start instantly.
 When the containers report healthy:
 
 - **App** → http://localhost:3000

--- a/docs/02-INSTALLATION.md
+++ b/docs/02-INSTALLATION.md
@@ -1,57 +1,82 @@
 # Installation
 
-Run PowerDNS-AuthAdmin in production. The app ships as a single image —
+Run PowerDNS-AuthAdmin in production with Docker Compose. The app is one image —
 [`ghcr.io/powerdns-authadmin/powerdns-authadmin`](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/pkgs/container/powerdns-authadmin) —
-that runs on **SQLite** or **Postgres**. Migrations and the system-role seed run
-automatically on boot, so a fresh container comes up ready to use.
+and runs on **SQLite** or **Postgres**. Database migrations and the first-run
+admin seed happen automatically on boot, so the container comes up ready to use.
 
-- **SQLite** — single instance: homelab, evaluation, small teams. One file, no
-  separate database service.
-- **Postgres** — multi-instance, write-concurrent, the production default for
-  teams. Boots are serialised by an advisory lock so multiple replicas are safe.
-  For replicas > 1 also set `REDIS_URL` (cross-replica rate limiting, reveal
-  tokens, and live updates) — see [High availability](../README.md#high-availability-replicas--1).
+Four steps: **pick a database → create `.env` → write `docker-compose.yml` → start.**
 
-Switching dialects later is a fresh install — the two schema histories don't
-share migrations. Pick one up front.
+---
 
-## 1. Generate secrets and create your `.env`
+## Before you start
 
-Two secrets are **required** and must be unique per deployment. **Generate them
-once, store them in a `.env` file next to your `docker-compose.yml`, and never
-change them.** Docker Compose auto-loads `.env`, so the exact same values are
-reused on every `up`, `down`, and restart — there are no shell `export`s to
-remember (and nothing to silently regenerate).
+- **Docker** with the Compose plugin — `docker compose version` must be **v2+**.
+- A directory to hold your two files (`.env` + `docker-compose.yml`). Everything
+  below runs from inside it:
 
-> ⚠️ **Generate these once; never regenerate them on an existing install.**
-> Rotating `APP_ENCRYPTION_KEY` makes every stored PowerDNS API key, OIDC client
-> secret, and TOTP/MFA secret undecryptable; changing `APP_SECRET_KEY` logs
-> everyone out and voids outstanding verification/reset tokens. Re-running the
-> generator on a running deployment is the most common way to lock yourself out
-> — keep the `.env` backed up instead.
+  ```sh
+  mkdir powerdns-authadmin && cd powerdns-authadmin
+  ```
+
+### Which database?
+
+|              | **SQLite**                                     | **Postgres**                                                                                    |
+| ------------ | ---------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Use when     | one instance — homelab, evaluation, small team | multiple instances, or you want a managed DB                                                    |
+| Storage      | one file in a Docker volume                    | a `postgres` service (or your own DB)                                                           |
+| Replicas > 1 | ❌                                             | ✅ (also set `REDIS_URL` — see [High availability](../README.md#high-availability-replicas--1)) |
+
+> The two database backends do **not** share a migration history — switching
+> later is a fresh install. Pick one now.
+
+---
+
+## 1. Create `.env` (secrets)
+
+Two secrets are **required** and must be unique to your deployment. This command
+generates them, picks a bootstrap admin password, and writes `.env`. **Run it
+once.**
 
 ```sh
-# Run ONCE, in your deployment directory. Writes freshly-generated keys into
-# .env. Do NOT re-run this on an existing install (see the warning above).
-cat > .env <<EOF
-APP_SECRET_KEY=$(openssl rand -base64 32)
-APP_ENCRYPTION_KEY=$(openssl rand -base64 32)
-BOOTSTRAP_ADMIN_PASSWORD=a-strong-password
-# Option B (Postgres) also needs a database password:
-POSTGRES_PASSWORD=a-strong-db-password
-EOF
+{
+  echo "APP_SECRET_KEY=$(openssl rand -base64 32)"
+  echo "APP_ENCRYPTION_KEY=$(openssl rand -base64 32)"
+  echo "APP_URL=https://dns.example.com"
+  echo "BOOTSTRAP_ADMIN_EMAIL=admin@example.com"
+  echo "BOOTSTRAP_ADMIN_PASSWORD=$(openssl rand -base64 18)"
+  # Postgres only — delete this line if you chose SQLite:
+  echo "POSTGRES_PASSWORD=$(openssl rand -base64 18)"
+} > .env
 chmod 600 .env
 ```
 
-| Secret               | Used for                                            | Constraint                    |
-| -------------------- | --------------------------------------------------- | ----------------------------- |
-| `APP_SECRET_KEY`     | Signing sessions, CSRF tokens, API-token HMACs      | ≥ 32 chars                    |
-| `APP_ENCRYPTION_KEY` | Encrypting PowerDNS API keys + OIDC secrets at rest | base64 decoding to ≥ 32 bytes |
+Then edit `.env`: set **`APP_URL`** to your real public URL and
+**`BOOTSTRAP_ADMIN_EMAIL`** to your address. Note the generated
+`BOOTSTRAP_ADMIN_PASSWORD` — you'll use it for the first login (and change it
+immediately).
 
-The app refuses to start if either is missing, too short, or an obvious
-placeholder (`changeme`, `secret`, …).
+| Variable                              | Purpose                                                      | Constraint                     |
+| ------------------------------------- | ------------------------------------------------------------ | ------------------------------ |
+| `APP_SECRET_KEY`                      | Signs sessions, CSRF tokens, API-token HMACs                 | ≥ 32 characters                |
+| `APP_ENCRYPTION_KEY`                  | Encrypts stored PowerDNS API keys, OIDC secrets, MFA secrets | base64 decoding to ≥ 32 bytes  |
+| `APP_URL`                             | Public, browser-visible URL (no trailing slash)              | e.g. `https://dns.example.com` |
+| `BOOTSTRAP_ADMIN_EMAIL` / `_PASSWORD` | The first admin account (set together)                       | password ≥ 12 chars            |
 
-## 2. Deploy
+> ⚠️ **Generate the two keys once and never change them.** Rotating
+> `APP_ENCRYPTION_KEY` makes every stored PowerDNS API key, OIDC secret, and MFA
+> secret undecryptable; changing `APP_SECRET_KEY` logs everyone out. Back up
+> `.env` — don't regenerate it. (The app refuses to start if either key is
+> missing, too short, or a placeholder like `changeme`.)
+
+Compose loads `.env` automatically, so the same values are reused on every `up`,
+`down`, and restart — there are no shell `export`s to remember.
+
+---
+
+## 2. Write `docker-compose.yml`
+
+Pick the block matching your database choice.
 
 ### Option A — SQLite
 
@@ -63,29 +88,17 @@ services:
     restart: unless-stopped
     ports: ["3000:3000"]
     environment:
-      APP_URL: https://dns.example.com
+      APP_URL: ${APP_URL}
       DATABASE_URL: file:/data/powerdns_authadmin.db
       APP_SECRET_KEY: ${APP_SECRET_KEY}
       APP_ENCRYPTION_KEY: ${APP_ENCRYPTION_KEY}
-      BOOTSTRAP_ADMIN_EMAIL: admin@example.com
-      BOOTSTRAP_ADMIN_PASSWORD: ${BOOTSTRAP_ADMIN_PASSWORD} # ≥12 chars
+      BOOTSTRAP_ADMIN_EMAIL: ${BOOTSTRAP_ADMIN_EMAIL}
+      BOOTSTRAP_ADMIN_PASSWORD: ${BOOTSTRAP_ADMIN_PASSWORD}
     volumes:
       - app-data:/data
 volumes:
   app-data:
 ```
-
-With the `.env` from [step 1](#1-generate-secrets-and-create-your-env) in the
-same directory (Compose loads it automatically for `${...}` interpolation), edit
-`APP_URL`/`BOOTSTRAP_ADMIN_EMAIL` in the compose file, then start the stack:
-
-```sh
-docker compose up -d
-```
-
-> Later, `docker compose down` then `up -d` **reuses the same `.env`** — your
-> data and encrypted secrets stay valid because the keys never changed. (Use
-> `docker compose down -v` only to start over: it **deletes the data volume**.)
 
 ### Option B — Postgres
 
@@ -99,11 +112,11 @@ services:
     depends_on:
       postgres: { condition: service_healthy }
     environment:
-      APP_URL: https://dns.example.com
+      APP_URL: ${APP_URL}
       DATABASE_URL: postgres://pdns:${POSTGRES_PASSWORD}@postgres:5432/powerdns_authadmin
       APP_SECRET_KEY: ${APP_SECRET_KEY}
       APP_ENCRYPTION_KEY: ${APP_ENCRYPTION_KEY}
-      BOOTSTRAP_ADMIN_EMAIL: admin@example.com
+      BOOTSTRAP_ADMIN_EMAIL: ${BOOTSTRAP_ADMIN_EMAIL}
       BOOTSTRAP_ADMIN_PASSWORD: ${BOOTSTRAP_ADMIN_PASSWORD}
   postgres:
     image: postgres:16-alpine
@@ -122,39 +135,49 @@ volumes:
   pg-data:
 ```
 
-Start it the same way — the `.env` from
-[step 1](#1-generate-secrets-and-create-your-env) supplies `APP_SECRET_KEY`,
-`APP_ENCRYPTION_KEY`, `POSTGRES_PASSWORD`, and `BOOTSTRAP_ADMIN_PASSWORD`:
+> **Production tip:** pin a version (`:1.1.2`) instead of `:latest` so deploys
+> are deterministic. See [Upgrading](./09-UPGRADING.md).
+
+---
+
+## 3. Start
 
 ```sh
 docker compose up -d
+docker compose logs -f app   # watch migrations + seed run, then "Ready"
 ```
 
-## 3. First login
+Later, `docker compose down` then `up -d` reuses the same `.env` and data.
+`docker compose down -v` **deletes the data volume** — only use it to start over.
+
+---
+
+## 4. First login
 
 Open `APP_URL`, sign in as `BOOTSTRAP_ADMIN_EMAIL` with the bootstrap password,
-and set a new password when prompted (the bootstrap admin is created with
-"must change password on next login"). Then add your PowerDNS backend(s) under
-**Admin → PowerDNS servers** — see [Connecting PowerDNS backends](./04-BACKENDS.md) —
-or define them in a [provisioning file](./06-PROVISIONING.md).
+and set a new password when prompted (the bootstrap admin is flagged
+"must change password"). Then add your PowerDNS backend(s) under **Admin →
+PowerDNS servers** ([Connecting backends](./04-BACKENDS.md)) — or define them in
+a [provisioning file](./06-PROVISIONING.md).
 
-> The bootstrap admin only seeds when both `BOOTSTRAP_ADMIN_EMAIL` and
-> `BOOTSTRAP_ADMIN_PASSWORD` are set (together — setting one without the other is
-> a startup error). It's idempotent: it ensures the account exists but won't
-> clobber an existing one.
+The bootstrap admin seeds only when **both** `BOOTSTRAP_ADMIN_EMAIL` and
+`BOOTSTRAP_ADMIN_PASSWORD` are set. It's idempotent — keyed on the email, it
+ensures that account exists and never clobbers an existing one.
 
-## Running behind a reverse proxy
+---
+
+## Reference
+
+### Behind a reverse proxy
 
 Terminate TLS at your proxy (nginx, Caddy, Traefik, a cloud LB) and forward to
 the app's port 3000. Two things matter:
 
-1. **`APP_URL` must be the public, browser-visible URL** (`https://dns.example.com`,
-   no trailing slash). It's used to build OIDC redirect URIs, email links, and
-   CSP origin checks — a wrong value breaks SSO and cookies.
-2. **The proxy must set `X-Forwarded-For` / `X-Real-IP`** to the real client IP.
-   The app always trusts these headers for IP attribution (audit log, rate
-   limiting) — there is no `TRUST_PROXY` toggle — so your proxy must _overwrite_
-   any client-supplied value, never append to it.
+1. **`APP_URL` is the public URL** — it builds OIDC redirect URIs, email links,
+   and cookie/CSP origins. A wrong value breaks SSO and cookies.
+2. **The proxy must set `X-Forwarded-For` / `X-Real-IP`** to the real client IP
+   (and _overwrite_ any client-supplied value, never append). The app always
+   trusts these for audit + rate limiting — there is no `TRUST_PROXY` toggle.
 
 Minimal Caddy example:
 
@@ -164,10 +187,10 @@ dns.example.com {
 }
 ```
 
-## Secrets from files (Docker / Kubernetes)
+### Secrets from files (Docker / Kubernetes secrets)
 
-Every variable also accepts a `_FILE` suffix: point it at a file whose contents
-are the value. Ideal for Docker secrets and Kubernetes `Secret` volumes.
+Every variable also accepts a `_FILE` suffix pointing at a file whose contents
+are the value:
 
 ```yaml
 environment:
@@ -180,60 +203,47 @@ secrets:
 
 If both `FOO` and `FOO_FILE` are set, the inline value wins and a warning is logged.
 
-## What happens on boot
+### What happens on boot
 
-The container entrypoint runs four stages, and **any failure aborts the boot** —
-a broken migration or malformed provisioning file produces a refused start, not a
-silently degraded run:
+The entrypoint runs four stages; **any failure aborts the boot** (a broken
+migration or bad provisioning file gives a refused start, not a degraded run):
 
-1. **Migrations** — apply pending schema changes. Opt out: `MIGRATE_ON_BOOT=false`.
-2. **Seed** — create the five system roles and (if configured) the bootstrap
-   admin. Opt out: `SEED_ON_BOOT=false`.
-3. **Provisioning** — apply `PROVISIONING_FILE` once. Opt out: `PROVISION_ON_BOOT=false`
-   or leave `PROVISIONING_FILE` unset. See [Provisioning](./06-PROVISIONING.md).
-4. **Start** the Next.js server.
+1. **Migrate** — apply pending schema changes. Opt out: `MIGRATE_ON_BOOT=false`.
+2. **Seed** — create the five system roles and (if configured) the bootstrap admin. Opt out: `SEED_ON_BOOT=false`.
+3. **Provision** — apply `PROVISIONING_FILE` once, if set. Opt out: `PROVISION_ON_BOOT=false`. See [Provisioning](./06-PROVISIONING.md).
+4. **Start** the server.
 
-To run migrations as a separate CI/CD step instead of on boot, set
-`MIGRATE_ON_BOOT=false` and run `npm run db:migrate` (with `DATABASE_URL` set)
-before starting the app.
+To run migrations as a separate CI/CD step, set `MIGRATE_ON_BOOT=false` and run
+`npm run db:migrate` (with `DATABASE_URL` set) before starting the app.
 
-## Health checks
-
-Wire these into your orchestrator:
+### Health checks
 
 | Endpoint       | Meaning                                                 | Use for                     |
 | -------------- | ------------------------------------------------------- | --------------------------- |
 | `GET /healthz` | Process is alive                                        | Liveness probe              |
 | `GET /readyz`  | DB reachable **and** migrations at the expected version | Readiness probe / LB gating |
 
-`/readyz` deliberately fails while migrations are mid-flight, so a rolling deploy
-won't send traffic to a replica that isn't ready.
+`/readyz` fails while migrations are mid-flight, so a rolling deploy won't send
+traffic to a replica that isn't ready.
 
-## Backups
+### Backups
 
-- **SQLite:** the database is a single file at the path in `DATABASE_URL`
-  (e.g. `/data/powerdns_authadmin.db` inside the `app-data` volume). Back up the
-  volume, or copy the file while the app is stopped (or use `sqlite3 … ".backup"`
-  for a hot copy). Losing `APP_ENCRYPTION_KEY` makes the backup's stored API keys
-  unreadable — back up the key alongside the data.
-- **Postgres:** standard `pg_dump` / `pg_restore` or volume snapshots.
+- **SQLite** — back up the `app-data` volume (the DB is a single file at the
+  `DATABASE_URL` path). Back up `APP_ENCRYPTION_KEY` alongside it, or the stored
+  secrets are unreadable.
+- **Postgres** — `pg_dump` / `pg_restore` or volume snapshots:
 
-```sh
-# Postgres logical backup
-docker compose exec postgres pg_dump -U pdns powerdns_authadmin > backup.sql
-```
+  ```sh
+  docker compose exec postgres pg_dump -U pdns powerdns_authadmin > backup.sql
+  ```
 
-## Upgrading
-
-Pull a newer image tag and recreate the container — migrations run automatically.
-**Back up first**, and read [Upgrading](./09-UPGRADING.md) for version pinning and
-rollback caveats.
+---
 
 ## Next steps
 
-- [Configuration reference](./03-CONFIGURATION.md) — every environment variable.
+- [Configuration](./03-CONFIGURATION.md) — every environment variable.
 - [Connecting PowerDNS backends](./04-BACKENDS.md).
-- [Hardening & best practices](./08-HARDENING.md).
+- [Hardening](./08-HARDENING.md) and [Upgrading](./09-UPGRADING.md).
 
 ---
 

--- a/docs/06-PROVISIONING.md
+++ b/docs/06-PROVISIONING.md
@@ -15,7 +15,7 @@ keys.
 1. On boot, if `PROVISIONING_FILE` points at a YAML file **and** the
    `settings.provisioned_at` row is absent, the app applies the file.
 2. Blocks are processed **in order**: `settings → roles → teams → zone_templates
-→ clusters → pdns_servers → demo_zones → oidc`. References resolve by slug, so
+→ clusters → pdns_servers → oidc → demo_zones`. References resolve by slug, so
    an `oidc` group mapping can point at a role defined earlier in the same file.
 3. On success it writes `settings.provisioned_at = <timestamp>`. **Subsequent
    boots skip the file** — from then on the admin UI is the source of truth.

--- a/docs/08-HARDENING.md
+++ b/docs/08-HARDENING.md
@@ -21,7 +21,7 @@ exotic — it's the handful of things worth getting right before you expose the 
 
 - **Terminate TLS at a reverse proxy** and forward to port 3000. Set `APP_URL` to
   the public `https://` URL (no trailing slash) — it drives OIDC redirects,
-  cookies, and CSP. See [Installation → reverse proxy](./02-INSTALLATION.md#running-behind-a-reverse-proxy).
+  cookies, and CSP. See [Installation → reverse proxy](./02-INSTALLATION.md#behind-a-reverse-proxy).
 - **Ensure the proxy overwrites `X-Forwarded-For`/`X-Real-IP`** with the real
   client IP (the app trusts these for audit + rate limiting; there's no
   `TRUST_PROXY` toggle).
@@ -48,7 +48,8 @@ exotic — it's the handful of things worth getting right before you expose the 
 - **Turn on Turnstile** (`TURNSTILE_SITE_KEY` + `TURNSTILE_SECRET_KEY`) for a
   public-facing login to blunt credential-stuffing.
 - **Tune the lockout policy** (`login_lockout_threshold` / `login_lockout_seconds`
-  settings) to taste — defaults are 5 attempts → 15-minute lockout.
+  settings) to taste — defaults are 10 failed attempts → 15-minute account
+  lockout. (Separately, a per-IP rate limiter throttles login bursts.)
 
 ## Least privilege
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -19,7 +19,8 @@ can jump straight into the code that owns each feature.
   `app/(auth)/login/`.
 - **How.**
   - Bootstrap the first admin via `BOOTSTRAP_ADMIN_EMAIL` + `BOOTSTRAP_ADMIN_PASSWORD` env (see
-    `.env.example`). The seed script creates the row only when the `users` table is empty.
+    `.env.example`). The seed is idempotent — keyed on the email, it ensures that account exists
+    and never clobbers an existing one.
   - Add more users from `/admin/users` (gated on `user.create`). The admin can issue a
     one-time temporary password that forces the user to change on first login.
   - Lockout policy is operator-tunable: `login_lockout_threshold` (1–100 attempts) and
@@ -384,7 +385,7 @@ can jump straight into the code that owns each feature.
   - **Metrics.** Prometheus `/metrics` (optional bearer-token gate via `METRICS_TOKEN`).
   - **Health.** `/healthz` (liveness) + `/readyz` (readiness — fails on DB unreachable or
     pending migrations).
-- **Where.** `lib/logger.ts`, `app/api/metrics/`, `app/healthz/`, `app/readyz/`.
+- **Where.** `lib/logger.ts`, `app/metrics/`, `app/healthz/`, `app/readyz/`.
 
 ---
 

--- a/docs/adr/0006-csp-nonce.md
+++ b/docs/adr/0006-csp-nonce.md
@@ -21,7 +21,8 @@ The options are:
 
 ## Decision
 
-We use option 3: a **per-request nonce** generated in `middleware.ts`, propagated to Next.js'
+We use option 3: a **per-request nonce** generated in `proxy.ts` (the Next 16 proxy convention —
+formerly `middleware.ts`), propagated to Next.js'
 inline scripts via the `x-nonce` request header, with `'strict-dynamic'` so we don't have to list
 every chunk URL.
 
@@ -36,12 +37,12 @@ every chunk URL.
 
 ## Trade-offs (the honest part)
 
-- **Every response goes through middleware.** This is a tiny per-request cost (~1ms for nonce
+- **Every response goes through the proxy.** This is a tiny per-request cost (~1ms for nonce
   generation), but it does mean CDN cacheability is reduced. Acceptable for an admin app; would
   be reconsidered for a public-facing site.
-- **`crypto.getRandomValues` works in the Edge runtime,** which is where Next middleware runs.
-  If we ever move middleware to Node runtime we need to verify the nonce generator still uses a
-  CSPRNG.
+- **`crypto.getRandomValues` works in both the Edge and Node runtimes,** so the nonce generator
+  is correct wherever the proxy runs. `crypto.randomUUID()` (request id) and `btoa` are likewise
+  available in both.
 - **CSS still uses `'unsafe-inline'`** for style-src because Tailwind injects critical CSS at
   render time. Not load-bearing for security since style injection has a much smaller attack
   surface than script injection.
@@ -57,6 +58,6 @@ every chunk URL.
 
 ## References
 
-- `middleware.ts` (the implementation)
+- `proxy.ts` (the implementation; renamed from `middleware.ts` in the Next 16 upgrade)
 - [Next.js CSP guide](https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy)
 - [MDN: CSP nonce-source](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -47,33 +47,31 @@ Health endpoints to confirm everything's wired:
 
 ## Before opening a PR
 
-```sh
-# One command runs lint, typecheck, format check, and unit tests.
-npm run validate
-```
-
-Run the integration suite too if you touched routes, repositories, or auth — it
-builds + boots the stack in Docker:
+Run this gate and fix anything that fails:
 
 ```sh
-npm run test:integration
+npm run test                              # unit suite (native — fast, reliable)
+act -j static-checks -W .github/workflows/ci.yml   # CI lint + typecheck + format
+npm run test:integration                  # only if you touched routes / repos / auth
 ```
 
-**Run the CI workflow locally with [`act`](https://github.com/nektos/act)** to
-catch failures before they hit GitHub. It runs the GitHub Actions jobs in Docker:
+Why this split:
 
-```sh
-act -j static-checks -W .github/workflows/ci.yml --container-architecture linux/amd64
-act -j test          -W .github/workflows/ci.yml --container-architecture linux/amd64
-```
+- **`npm run test`** runs the unit suite natively. Run it here rather than under
+  `act` — a couple of network-touching tests can time out under `act`'s emulated
+  container (e.g. on Apple Silicon).
+- **`act -j static-checks`** ([act](https://github.com/nektos/act)) runs the CI
+  lint + typecheck + format-check job in Docker. Use it for lint especially: it
+  runs `eslint .` without the host-memory limit you can hit with `npm run lint`
+  directly. The committed `.actrc` pins the runner image + arch, so no flags are
+  needed (first run pulls the ~1 GB image).
+- **`npm run test:integration`** builds + boots the stack in Docker for the HTTP
+  integration suite.
 
-`act` reliably runs the **JS-action jobs** (`static-checks`, `test`, `audit`) —
-and runs `eslint .` without the host-memory limits you can hit locally. It does
-**not** stand in for GitHub-hosted CodeQL, the Docker build/publish, Scorecard,
-or dependency-review (those need GitHub runners / tokens), so those remain the
-authority on the PR. First run pulls the runner image (~1 GB).
-
-If any of these fail locally, CI will too. Fix before pushing.
+`act` does **not** stand in for GitHub-hosted CodeQL, the Docker build/publish,
+Scorecard, or dependency-review (those need GitHub runners / tokens) — they
+remain the authority on the PR. If the gate above passes, CI's JS-action jobs
+will too.
 
 ## Commonly-needed commands
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -47,31 +47,28 @@ Health endpoints to confirm everything's wired:
 
 ## Before opening a PR
 
-Run this gate and fix anything that fails:
+Run CI locally with [`act`](https://github.com/nektos/act) and fix anything that
+fails. The committed `.actrc` pins the runner image + the CI workflow and uses
+your host-native arch, so the commands are flag-free:
 
 ```sh
-npm run test                              # unit suite (native — fast, reliable)
-act -j static-checks -W .github/workflows/ci.yml   # CI lint + typecheck + format
-npm run test:integration                  # only if you touched routes / repos / auth
+npm run ci:local            # the gate: act runs the CI lint + typecheck + format + unit-test jobs
+npm run test:integration    # only if you touched routes / repos / auth
 ```
 
-Why this split:
+`npm run ci:local` is just `act -j static-checks && act -j test`; run a single
+job directly with `act -j static-checks` or `act -j test` if you prefer.
 
-- **`npm run test`** runs the unit suite natively. Run it here rather than under
-  `act` — a couple of network-touching tests can time out under `act`'s emulated
-  container (e.g. on Apple Silicon).
-- **`act -j static-checks`** ([act](https://github.com/nektos/act)) runs the CI
-  lint + typecheck + format-check job in Docker. Use it for lint especially: it
-  runs `eslint .` without the host-memory limit you can hit with `npm run lint`
-  directly. The committed `.actrc` pins the runner image + arch, so no flags are
-  needed (first run pulls the ~1 GB image).
-- **`npm run test:integration`** builds + boots the stack in Docker for the HTTP
-  integration suite.
+- `act` runs `eslint .` without the host-memory limit you can hit with
+  `npm run lint` directly. First run pulls the ~1 GB runner image.
+- For a fast inner loop, `npm run test` / `npm run typecheck` run natively too.
+- `npm run test:integration` boots the stack in Docker for the HTTP integration
+  suite — run it **natively, not under `act`** (the job nests docker-compose,
+  which act can't do; it publishes ports to the host, not into act's container).
 
 `act` does **not** stand in for GitHub-hosted CodeQL, the Docker build/publish,
 Scorecard, or dependency-review (those need GitHub runners / tokens) — they
-remain the authority on the PR. If the gate above passes, CI's JS-action jobs
-will too.
+remain the authority on the PR.
 
 ## Commonly-needed commands
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -7,29 +7,33 @@ be safe to copy-paste.
 
 - **Node.js 24 LTS.** The `.nvmrc` pins the major version; `nvm use` picks it up.
 - **npm 10+.** Ships with Node 24.
-- **Docker** with Compose v2. Needed for Postgres + Redis + the sandbox PowerDNS stack.
+- **Docker** with Compose v2 — runs a local PowerDNS backend to develop against.
 
 ## One-time setup
 
 ```sh
 git clone https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin
-cd PowerDNS-AuthAdmin
+cd powerdns-authadmin
 
 nvm use            # reads .nvmrc
 npm ci             # exact-pin install
 
 cp .env.example .env.local
-# Generate the two required secrets — paste them into .env.local under
-# APP_SECRET_KEY and APP_ENCRYPTION_KEY:
-openssl rand -base64 32
-openssl rand -base64 32
 ```
+
+Then edit `.env.local`:
+
+- Set `APP_SECRET_KEY` and `APP_ENCRYPTION_KEY` (generate each with `openssl rand -base64 32`).
+- Point `DATABASE_URL` at a local SQLite file the dev server can write — e.g.
+  `DATABASE_URL=file:./dev.db` (the shipped default `file:/data/...` is the in-container path).
+
+Redis is optional in dev — everything falls back to an in-process path when `REDIS_URL` is unset.
 
 ## Daily loop
 
 ```sh
-# Start dependencies (Postgres + Redis + sandbox PDNS)
-docker compose up -d
+# A local PowerDNS to talk to (just the pdns service from the demo stack)
+docker compose up -d pdns
 
 # Dev server with hot reload — migrations run on app boot (ADR 0011)
 npm run dev        # → http://localhost:3000
@@ -38,7 +42,7 @@ npm run dev        # → http://localhost:3000
 Health endpoints to confirm everything's wired:
 
 - `GET /healthz` — `{"status":"ok",...}` 200.
-- `GET /readyz` — `{"status":"ok","checks":{"database":"ok"}}` 200 when Postgres is reachable,
+- `GET /readyz` — `{"status":"ok","checks":{"database":"ok"}}` 200 when the database is reachable,
   503 otherwise.
 
 ## Before opening a PR
@@ -48,7 +52,28 @@ Health endpoints to confirm everything's wired:
 npm run validate
 ```
 
-If any of those fail locally, CI will too. Fix before pushing.
+Run the integration suite too if you touched routes, repositories, or auth — it
+builds + boots the stack in Docker:
+
+```sh
+npm run test:integration
+```
+
+**Run the CI workflow locally with [`act`](https://github.com/nektos/act)** to
+catch failures before they hit GitHub. It runs the GitHub Actions jobs in Docker:
+
+```sh
+act -j static-checks -W .github/workflows/ci.yml --container-architecture linux/amd64
+act -j test          -W .github/workflows/ci.yml --container-architecture linux/amd64
+```
+
+`act` reliably runs the **JS-action jobs** (`static-checks`, `test`, `audit`) —
+and runs `eslint .` without the host-memory limits you can hit locally. It does
+**not** stand in for GitHub-hosted CodeQL, the Docker build/publish, Scorecard,
+or dependency-review (those need GitHub runners / tokens), so those remain the
+authority on the PR. First run pulls the runner image (~1 GB).
+
+If any of these fail locally, CI will too. Fix before pushing.
 
 ## Commonly-needed commands
 
@@ -77,14 +102,14 @@ If any of those fail locally, CI will too. Fix before pushing.
 You're missing a required environment variable. The error message lists exactly which ones.
 Check `.env.local` against `.env.example`.
 
-### Database connection refused
+### PowerDNS backend unreachable
 
 ```sh
 docker compose ps
-docker compose logs postgres
+docker compose logs pdns
 ```
 
-Confirm `postgres` shows `(healthy)`. If not, `docker compose up -d --force-recreate postgres`.
+Confirm `pdns` shows `(healthy)`. If not, `docker compose up -d --force-recreate pdns`.
 
 ### "Cannot find module 'server-only'"
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -222,7 +222,7 @@ export default tseslint.config(
       "app/**/sitemap.ts",
       "app/**/robots.ts",
       "app/**/manifest.ts",
-      "middleware.ts",
+      "proxy.ts",
       "instrumentation.ts",
       "next.config.ts",
       "drizzle.config.ts",
@@ -255,7 +255,7 @@ export default tseslint.config(
   // no-img-element, no-html-link-for-pages, no-sync-scripts, etc. Also
   // satisfies the existing `@next/next/no-img-element` disable directives.
   {
-    files: ["app/**/*.{ts,tsx}", "components/**/*.{ts,tsx}", "middleware.ts", "instrumentation.ts"],
+    files: ["app/**/*.{ts,tsx}", "components/**/*.{ts,tsx}", "proxy.ts", "instrumentation.ts"],
     plugins: { "@next/next": nextPlugin },
     rules: {
       ...nextPlugin.configs.recommended.rules,

--- a/lib/auth/get-current-user.ts
+++ b/lib/auth/get-current-user.ts
@@ -20,7 +20,8 @@ import {
 } from "@/lib/db/repositories/api-tokens";
 import { findUserById } from "@/lib/db/repositories/users";
 import { loadUserAssignmentsForAbility } from "@/lib/db/repositories/roles";
-import { listGrantsForUser } from "@/lib/db/repositories/zone-grants";
+import { listGrantsForUser, mapServersToClusterPeers } from "@/lib/db/repositories/zone-grants";
+import { expandGrantsAcrossClusters } from "@/lib/rbac/zone-permissions";
 import type { User } from "@/lib/db/schema";
 import type { ZoneGrant } from "@/lib/db/schema";
 import {
@@ -68,6 +69,23 @@ export interface AuthenticatedRequest {
  * decrypts cleanly but points at a deleted user — that's an inconsistency,
  * not "anonymous").
  */
+/**
+ * Expand a user's zone grants across cluster peers (see
+ * `expandGrantsAcrossClusters`): a grant on one peer of a multi-primary cluster
+ * authorizes the zone on every peer, since the request path picks a rotating
+ * peer. Applied on the authz path only; the admin display path keeps the raw
+ * rows. No DB round-trip for the common case (a user with no grants, or none on
+ * a clustered backend).
+ */
+async function expandClusterGrants<T extends { serverId: string }>(
+  grants: readonly T[],
+): Promise<T[]> {
+  if (grants.length === 0) return [...grants];
+  const peers = await mapServersToClusterPeers(grants.map((g) => g.serverId));
+  if (peers.size === 0) return [...grants];
+  return expandGrantsAcrossClusters(grants, peers);
+}
+
 export async function getCurrentUser(): Promise<AuthenticatedRequest | null> {
   // --- Session cookie path -------------------------------------------------
   const session = await readSession();
@@ -91,7 +109,7 @@ export async function getCurrentUser(): Promise<AuthenticatedRequest | null> {
       user,
       ability,
       globalPermissions: globalPermissionsOf(sources),
-      zoneGrants,
+      zoneGrants: await expandClusterGrants(zoneGrants),
       source: "session",
     };
   }
@@ -186,7 +204,7 @@ async function resolvePresentedToken(
     user,
     ability,
     globalPermissions: globalPermissionsOf(sources),
-    zoneGrants,
+    zoneGrants: await expandClusterGrants(zoneGrants),
     source: "token",
   };
 }

--- a/lib/client-ip.ts
+++ b/lib/client-ip.ts
@@ -55,7 +55,7 @@ function isPlausibleIp(s: string): boolean {
 }
 
 /**
- * Request-ID set by `middleware.ts`. Returns null only when middleware
+ * Request-ID set by `proxy.ts`. Returns null only when the proxy
  * didn't run (e.g. /_next/static paths that the matcher skips — those
  * never hit audit-writing routes, so the null is fine in practice).
  */

--- a/lib/db/repositories/zone-grants.ts
+++ b/lib/db/repositories/zone-grants.ts
@@ -10,9 +10,9 @@
  */
 
 import "server-only";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray, isNotNull } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { zoneGrants, type ZoneGrant } from "@/lib/db/schema";
+import { zoneGrants, pdnsServers, type ZoneGrant } from "@/lib/db/schema";
 
 /**
  * Every zone grant the given user has, across all backends. Used by
@@ -55,4 +55,53 @@ export async function findGrant(input: {
     )
     .limit(1);
   return rows[0] ?? null;
+}
+
+/**
+ * For each of the given server ids that belongs to a cluster, the full set of
+ * server ids in that cluster (including itself). Servers not in a cluster
+ * (standalone primaries, primary+secondaries groups) are omitted — callers
+ * treat an absent key as "just this server".
+ *
+ * Feeds `expandGrantsAcrossClusters` (lib/rbac/zone-permissions): a zone grant
+ * issued on one peer of a multi-primary cluster must authorize the zone on every
+ * peer, because the request path resolves a rotating peer via `choosePeer`.
+ *
+ * Two small dialect-neutral queries instead of a self-join (the repo's `db` is
+ * the shared pg/sqlite handle; a self-join needs dialect-specific aliasing).
+ */
+export async function mapServersToClusterPeers(
+  serverIds: readonly string[],
+): Promise<Map<string, string[]>> {
+  const result = new Map<string, string[]>();
+  if (serverIds.length === 0) return result;
+
+  // Which of the requested servers are in a cluster, and which cluster?
+  const inputRows = await db
+    .select({ id: pdnsServers.id, clusterId: pdnsServers.clusterId })
+    .from(pdnsServers)
+    .where(inArray(pdnsServers.id, [...serverIds]));
+  const clusterIds = [
+    ...new Set(inputRows.map((r) => r.clusterId).filter((c): c is string => c !== null)),
+  ];
+  if (clusterIds.length === 0) return result;
+
+  // Every server in those clusters.
+  const peerRows = await db
+    .select({ id: pdnsServers.id, clusterId: pdnsServers.clusterId })
+    .from(pdnsServers)
+    .where(and(inArray(pdnsServers.clusterId, clusterIds), isNotNull(pdnsServers.clusterId)));
+  const peersByCluster = new Map<string, string[]>();
+  for (const r of peerRows) {
+    if (r.clusterId === null) continue;
+    const arr = peersByCluster.get(r.clusterId) ?? [];
+    arr.push(r.id);
+    peersByCluster.set(r.clusterId, arr);
+  }
+
+  for (const r of inputRows) {
+    if (r.clusterId === null) continue;
+    result.set(r.id, peersByCluster.get(r.clusterId) ?? [r.id]);
+  }
+  return result;
 }

--- a/lib/rbac/zone-permissions.test.ts
+++ b/lib/rbac/zone-permissions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   canActOnZone,
   effectiveZonePermissions,
+  expandGrantsAcrossClusters,
   hasZonePermissionViaGrant,
   type ZoneGrantInput,
 } from "./zone-permissions";
@@ -142,5 +143,61 @@ describe("canActOnZone", () => {
         permission: "record.update",
       }),
     ).toBe(false);
+  });
+});
+
+describe("expandGrantsAcrossClusters", () => {
+  const clusterGrant: ZoneGrantInput[] = [
+    { serverId: "peer-1", zoneName: "example.com.", permissions: ["record.update"] },
+  ];
+
+  it("emits a copy of a cluster grant for every peer (preserving zone + permissions)", () => {
+    const peers = new Map<string, readonly string[]>([["peer-1", ["peer-1", "peer-2", "peer-3"]]]);
+    const out = expandGrantsAcrossClusters(clusterGrant, peers);
+    expect(out.map((g) => g.serverId).sort()).toEqual(["peer-1", "peer-2", "peer-3"]);
+    for (const g of out) {
+      expect(g.zoneName).toBe("example.com.");
+      expect(g.permissions).toEqual(["record.update"]);
+    }
+  });
+
+  it("makes a cluster grant authorize the zone on a sibling peer (the #40 fix)", () => {
+    const peers = new Map<string, readonly string[]>([["peer-1", ["peer-1", "peer-2"]]]);
+    const expanded = expandGrantsAcrossClusters(clusterGrant, peers);
+    // The request resolved peer-2 via choosePeer; the grant was issued on peer-1.
+    expect(hasZonePermissionViaGrant(expanded, "peer-2", "example.com.", "record.update")).toBe(
+      true,
+    );
+    // Without expansion the raw grant would NOT match peer-2.
+    expect(hasZonePermissionViaGrant(clusterGrant, "peer-2", "example.com.", "record.update")).toBe(
+      false,
+    );
+  });
+
+  it("leaves a standalone grant (server absent from the map) untouched", () => {
+    const out = expandGrantsAcrossClusters(clusterGrant, new Map());
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe(clusterGrant[0]); // same reference, no copy
+  });
+
+  it("does not cross cluster boundaries", () => {
+    const twoClusters: ZoneGrantInput[] = [
+      { serverId: "a1", zoneName: "z.", permissions: ["zone.read"] },
+      { serverId: "b1", zoneName: "z.", permissions: ["zone.delete"] },
+    ];
+    const peers = new Map<string, readonly string[]>([
+      ["a1", ["a1", "a2"]],
+      ["b1", ["b1", "b2"]],
+    ]);
+    const out = expandGrantsAcrossClusters(twoClusters, peers);
+    // a-cluster peers only carry zone.read; b-cluster peers only zone.delete.
+    expect(hasZonePermissionViaGrant(out, "a2", "z.", "zone.read")).toBe(true);
+    expect(hasZonePermissionViaGrant(out, "a2", "z.", "zone.delete")).toBe(false);
+    expect(hasZonePermissionViaGrant(out, "b2", "z.", "zone.delete")).toBe(true);
+    expect(hasZonePermissionViaGrant(out, "b2", "z.", "zone.read")).toBe(false);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(expandGrantsAcrossClusters([], new Map())).toEqual([]);
   });
 });

--- a/lib/rbac/zone-permissions.ts
+++ b/lib/rbac/zone-permissions.ts
@@ -105,3 +105,42 @@ export function canActOnZone(input: {
   if (input.hasGlobalPermission) return true;
   return hasZonePermissionViaGrant(input.grants, input.serverId, input.zoneName, input.permission);
 }
+
+/**
+ * Expand a user's grants across cluster peers so a grant issued on one peer of
+ * a multi-primary cluster authorizes the zone on EVERY peer of that cluster.
+ *
+ * Grants are keyed to a single `serverId`, but a cluster zone's reads/writes
+ * resolve a peer per request via `choosePeer` (round-robin / lowest-latency), so
+ * a grant on peer A would intermittently 403 when peer B is chosen. We close
+ * that by emitting, for each grant whose server belongs to a cluster, a copy of
+ * the grant for every peer id in the same cluster — leaving the exact-`serverId`
+ * matchers (`canActOnZone` et al.) and all their call sites untouched.
+ *
+ * `equivalentServerIds` maps a grant's `serverId` to every server id in its
+ * cluster (built by `mapServersToClusterPeers`). A server absent from the map
+ * (standalone, or not in a cluster) keeps its single grant verbatim.
+ *
+ * This is applied only on the AUTHZ path (`getCurrentUser`, the DynDNS token
+ * path, the grant-ceiling check) — never on the admin DISPLAY path, where the
+ * operator should see the real stored row, not synthetic per-peer copies.
+ *
+ * Pure: storage I/O (the cluster lookup) happens in the repo; this just maps.
+ */
+export function expandGrantsAcrossClusters<T extends { serverId: string }>(
+  grants: readonly T[],
+  equivalentServerIds: ReadonlyMap<string, readonly string[]>,
+): T[] {
+  const out: T[] = [];
+  for (const g of grants) {
+    const peers = equivalentServerIds.get(g.serverId);
+    if (!peers || peers.length === 0) {
+      out.push(g);
+      continue;
+    }
+    for (const peerId of peers) {
+      out.push(peerId === g.serverId ? g : { ...g, serverId: peerId });
+    }
+  }
+  return out;
+}

--- a/lib/security/csp.ts
+++ b/lib/security/csp.ts
@@ -2,7 +2,7 @@
  * lib/security/csp.ts
  *
  * Builds the Content-Security-Policy header value. Pure (no request/runtime
- * deps) so it can be unit-tested in isolation; `middleware.ts` calls it with a
+ * deps) so it can be unit-tested in isolation; `proxy.ts` calls it with a
  * fresh per-request nonce. See ADR-0006 for the nonce + `'strict-dynamic'`
  * rationale.
  *

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "db:seed": "NODE_OPTIONS=--conditions=react-server tsx scripts/seed.ts",
     "provision": "NODE_OPTIONS=--conditions=react-server tsx scripts/provision.ts",
     "audit:strict": "npm audit --audit-level=high --omit=dev",
-    "validate": "npm run lint && npm run typecheck && npm run format:check && npm run test"
+    "validate": "npm run lint && npm run typecheck && npm run format:check && npm run test",
+    "ci:local": "act -j static-checks && act -j test"
   },
   "dependencies": {
     "@casl/ability": "7.0.0",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,10 +1,11 @@
 /**
- * middleware.ts
+ * proxy.ts
  *
- * Next.js Edge middleware that runs on every request. It applies the security
- * headers — most importantly a per-request CSP nonce — generates and propagates
- * a request id for log + audit correlation, and forwards the nonce and request
- * pathname to server components via request headers.
+ * Next.js Proxy — the Next 16 successor to the `middleware` file convention —
+ * runs on every request. It applies the security headers — most importantly a
+ * per-request CSP nonce — generates and propagates a request id for log + audit
+ * correlation, and forwards the nonce and request pathname to server components
+ * via request headers.
  *
  * Why a per-request nonce instead of static CSP: Next.js streams inline scripts
  * for hydration data. A static `script-src 'self'` CSP would block them; the only
@@ -35,12 +36,13 @@ function isPlausibleRequestId(value: string): boolean {
 }
 
 /**
- * The middleware itself.
+ * The proxy itself.
  *
- * `export default` is required by Next.js — this is one of the small set of files
- * exempt from our "no default exports" rule (see eslint.config.mjs).
+ * Next 16 accepts the proxy as a default export or a named `proxy` export; we
+ * use the default export, one of the small set of files exempt from our
+ * "no default exports" rule (see eslint.config.mjs).
  */
-export default function middleware(request: NextRequest): NextResponse {
+export default function proxy(request: NextRequest): NextResponse {
   const isDev = process.env.NODE_ENV === "development";
   const turnstileEnabled = Boolean(process.env["TURNSTILE_SITE_KEY"]);
   const nonce = generateNonce();
@@ -127,7 +129,7 @@ export default function middleware(request: NextRequest): NextResponse {
   return response;
 }
 
-// Skip the middleware for static assets and Next's internal routes.
+// Skip the proxy for static assets and Next's internal routes.
 export const config = {
   matcher: [
     /*
@@ -137,7 +139,7 @@ export const config = {
      *   favicon.ico      — static asset
      *   robots.txt       — static
      *   sitemap.xml      — static
-     * Health endpoints DO run through the middleware — we want their responses to
+     * Health endpoints DO run through the proxy — we want their responses to
      * carry the security headers too.
      */
     "/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)",


### PR DESCRIPTION
Closes #40. Closes #41. Closes #44. Milestone: **v1.1.3**.

One branch, validated locally before pushing.

## #40 — cluster-aware zone grants (fix)
A `zone_grant` is keyed to one backend, but a cluster zone resolves a rotating peer (`choosePeer`), so a grant on one peer intermittently 403'd. Grants are now **expanded across cluster peers on the authorization path** (`expandGrantsAcrossClusters` + `mapServersToClusterPeers`), wired into every authz path (`get-current-user` session+token, `nic/update`, the grant-create ceiling). +5 unit tests; integration suite (live cluster peers) passes.

## #41 — `middleware.ts` → `proxy.ts` (Next 16)
Adopted the Next 16 `proxy` file convention (the `middleware` convention is deprecated — the build warning is gone). CSP nonce + security headers unchanged. Updated eslint exemptions, CLAUDE.md, ADR-0006, and references.

## #44 — Node 24 GitHub Actions (chore)
Re-pinned every third-party Action to its latest **Node 24-compatible** release (still SHA-pinned with `# vN`), ahead of GitHub's Node 20 runtime deprecation (forced 2026-06-02): checkout v6, setup-node v6, upload-artifact v7, dependency-review v5, docker/* v7/v4/v6/v4/v4, codeql v4.

## Local CI with `act` (new convention)
`act` is now the documented pre-push gate, runnable flag-free:

```sh
npm run ci:local          # = act -j static-checks && act -j test  (CI lint/typecheck/format + unit suite)
npm run test:integration  # native — only if you touched routes / repos / auth
```

- A committed **`.actrc`** pins the runner image + the CI workflow and uses the **host-native arch** (forcing `linux/amd64` on Apple silicon ran under QEMU and timed out a loopback unit test).
- `act` runs `eslint .` without the host-memory limit you can hit with `npm run lint` directly.
- `act` does **not** run `integration-test` (nests docker-compose) or stand in for GitHub-hosted **CodeQL / Docker build+publish / Scorecard / dependency-review** — those remain the authority on the PR.

## Docs overhaul
INSTALLATION rewritten to four bulletproof steps; docs-wide accuracy sweep verified against code (bootstrap-admin semantics, lockout default 10, metrics route/default, provisioning order, dev-setup flow, QUICKSTART pull-not-build). README: GHCR pulls badge + "PowerDNS Auth tested versions" header.

After merge: cut **v1.1.3** (CHANGELOG/docs/version) and deploy. No schema migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)