### PR TITLE
Release 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [1.1.3] — 2026-05-26
+
 ### Fixed
 
 - **Per-zone grants now work on multi-primary clusters.** A `zone_grant` is keyed to one
@@ -319,7 +323,8 @@ First production release.
 - **Distribution** — multi-arch (`linux/amd64` + `linux/arm64`) image published to Docker Hub as
   `jseifeddine/powerdns-authadmin`, plus a one-command minimal-demo stack.
 
-[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.2...HEAD
+[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.3...HEAD
+[1.1.3]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.0.2...v1.1.0

--- a/docs/09-UPGRADING.md
+++ b/docs/09-UPGRADING.md
@@ -37,6 +37,14 @@ half-migrated schema; fix the cause and restart.
 
 ## Version-specific notes
 
+### Upgrading to 1.1.3 (from 1.1.x)
+
+A maintenance release — **no schema migration**, a plain pull-and-recreate, and
+nothing operator-facing to change. It fixes per-zone grants on multi-primary
+clusters (a grant on one peer now authorizes the zone on every peer), renames the
+internal request middleware to the Next 16 `proxy` convention (transparent), and
+re-pins the CI GitHub Actions to Node 24 (CI-only).
+
 ### Upgrading to 1.1.2 (from 1.1.x)
 
 A security release — **no schema migration**, a plain pull-and-recreate. Two

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerdns-authadmin",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@casl/ability": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "description": "Modern, self-hosted DNS administration UI for PowerDNS — multi-team RBAC, real audit, real SSO. From-scratch rebuild of PowerDNS-Admin in Node.js + TypeScript.",
   "license": "MIT",


### PR DESCRIPTION
Release-marking PR for **v1.1.3**. Version bump + CHANGELOG/UPGRADING only — all changes are already merged on main via #45 (closes #40/#41/#44).

1.1.3 ships: cluster-aware zone grants (#40), the Next 16 `middleware`→`proxy` migration (#41), Node 24-compatible CI action pins (#44), a docs overhaul (bulletproof INSTALLATION + accuracy sweep), and `act`-based local CI (`npm run ci:local`).

After merge: tag `v1.1.3` (publishes `:1.1.3` + `:1.1`), GitHub release, close milestone v1.1.3, deploy. **No schema migration.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)