### PR TITLE
ci(release): sign images + attach SBOM/signed checksums (Scorecard Signed-Releases)

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -1,0 +1,93 @@
+# =============================================================================
+# Sign release — supply-chain provenance for published releases.
+#
+# Runs when a GitHub release is published (so the release + the :X.Y.Z image
+# already exist). It:
+#   1. cosign-signs the published multi-arch image (keyless / Sigstore) — a
+#      verifiable signature attached to the image in GHCR.
+#   2. generates an SPDX SBOM of the image,
+#   3. writes a checksums file over the attached artifacts and cosign sign-blobs
+#      it into a Sigstore bundle,
+#   4. uploads the SBOM + checksums + signature bundle as release assets.
+#
+# The release assets (the *.sigstore.json bundle) are what OpenSSF Scorecard's
+# Signed-Releases check looks for; the image signature is the real supply-chain
+# win (verify with: cosign verify ghcr.io/...@<digest>).
+#
+# All actions are pinned to a commit SHA. Verify a signature:
+#   cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:<version> \
+#     --certificate-identity-regexp '^https://github.com/PowerDNS-AuthAdmin/' \
+#     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+# =============================================================================
+
+name: Sign release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write # upload release assets
+      packages: write # cosign writes the image signature to GHCR
+      id-token: write # cosign keyless (Fulcio OIDC)
+    env:
+      IMAGE: ghcr.io/powerdns-authadmin/powerdns-authadmin
+      TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image digest for the release tag
+        id: digest
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"                       # v1.2.3 -> 1.2.3 (the published image tag)
+          digest="$(docker buildx imagetools inspect "${IMAGE}:${version}" --format '{{ .Manifest.Digest }}')"
+          echo "ref=${IMAGE}@${digest}" >> "$GITHUB_OUTPUT"
+          echo "Resolved ${IMAGE}:${version} -> ${digest}"
+
+      - name: Sign the image (keyless)
+        run: cosign sign --yes "${{ steps.digest.outputs.ref }}"
+
+      - name: Generate SBOM (SPDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ steps.digest.outputs.ref }}
+          format: spdx-json
+          output-file: powerdns-authadmin.sbom.spdx.json
+
+      - name: Build + sign checksums
+        run: |
+          set -euo pipefail
+          echo "${{ steps.digest.outputs.ref }}" > image-digest.txt
+          sha256sum powerdns-authadmin.sbom.spdx.json image-digest.txt > checksums.txt
+          cosign sign-blob --yes --bundle checksums.txt.sigstore.json checksums.txt
+
+      - name: Upload signed assets to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$TAG" \
+            powerdns-authadmin.sbom.spdx.json \
+            image-digest.txt \
+            checksums.txt \
+            checksums.txt.sigstore.json \
+            --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ All notable changes to this project are documented here. The format is based on
   DynDNS request/auth, and every RR-type content validator — running in the unit suite as
   `*.fuzz.test.ts`. Hardens the hand-rolled parsers (which have shipped real bugs) and
   satisfies the OpenSSF Scorecard Fuzzing check.
+- **Signed releases + image provenance.** A `release-sign` workflow (on release publish)
+  cosign-signs the published multi-arch image (keyless / Sigstore) and attaches an SPDX SBOM
+  plus a signed checksums bundle (`*.sigstore.json`) to the GitHub release. Verify the image
+  with `cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:<version>` (see
+  [Hardening → verifying the image](./docs/08-HARDENING.md)). (OpenSSF Scorecard: Signed-Releases.)
 
 ## [1.1.3] — 2026-05-26
 

--- a/docs/08-HARDENING.md
+++ b/docs/08-HARDENING.md
@@ -74,6 +74,20 @@ exotic — it's the handful of things worth getting right before you expose the 
 - **Watch the audit log.** Every write is recorded with redacted before/after
   snapshots — it's your forensic trail.
 
+## Verify the image signature
+
+Each published release is cosign-signed (keyless / Sigstore) by the release
+workflow. Verify before deploying:
+
+```sh
+cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:1.1.3 \
+  --certificate-identity-regexp '^https://github.com/PowerDNS-AuthAdmin/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+The GitHub release also carries an SPDX SBOM and a signed `checksums.txt`
+(`checksums.txt.sigstore.json`) for the attached artifacts.
+
 ---
 
 [← Docs index](./README.md)


### PR DESCRIPTION
Adds verifiable release/image provenance and raises the OpenSSF Scorecard **Signed-Releases** check. Milestone: **v1.1.4**.

### What it does (`.github/workflows/release-sign.yml`, on `release: published`)
1. **cosign-signs the published multi-arch image** (keyless / Sigstore) — the real supply-chain win:
   ```sh
   cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:<version> \
     --certificate-identity-regexp '^https://github.com/PowerDNS-AuthAdmin/' \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com
   ```
2. **Generates an SPDX SBOM** of the image and uploads it to the release.
3. **Signs a `checksums.txt`** (`cosign sign-blob` → `checksums.txt.sigstore.json`) and uploads it — this `*.sigstore.json` release asset is what Scorecard's Signed-Releases check scans for.

### Notes
- All actions SHA-pinned; top-level perms `read-only`, job perms minimal (`contents/packages/id-token: write` only where needed) — keeps Token-Permissions / Dangerous-Workflow / Pinned-Dependencies green.
- Triggered on `release: published` (so the release + `:X.Y.Z` image already exist), decoupled from the build/push job.
- **Validated on the next release (v1.1.4)** — release-asset signing can only be exercised on a real published release. The image-digest resolution + uploads run there first.
- Scorecard's Signed-Releases averages the **last 5 releases**, so it ramps as signed releases accumulate (1/5 after v1.1.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)