### PR TITLE
chore: fix stale CODEOWNERS path (middleware.ts → proxy.ts)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 /lib/auth/                   @jseifeddine
 /lib/rbac/                   @jseifeddine
 /lib/pdns/                   @jseifeddine
-/middleware.ts               @jseifeddine
+/proxy.ts                    @jseifeddine
 /.github/workflows/          @jseifeddine
 /Dockerfile                  @jseifeddine
 /SECURITY.md                 @jseifeddine


### PR DESCRIPTION
CODEOWNERS already exists and is comprehensive; it just had a stale `/middleware.ts` entry (renamed to `/proxy.ts` in #41). This fixes that one line — no new file. The existing catch-all (`* @jseifeddine`) already satisfies the code-owner-review branch-protection rule. Milestone: v1.1.4.