### PR TITLE
Mobile-first responsive UI + desktop ≥1080p (part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@
 
 [![CI](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/actions/workflows/ci.yml?query=branch%3Amain)
 [![Release](https://img.shields.io/github/v/release/PowerDNS-AuthAdmin/powerdns-authadmin)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/releases/latest)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/PowerDNS-AuthAdmin/powerdns-authadmin/badge)](https://scorecard.dev/viewer/?uri=github.com/PowerDNS-AuthAdmin/powerdns-authadmin)
+
 [![Container: GHCR](https://img.shields.io/badge/ghcr.io-powerdns--authadmin-2496ED?logo=docker&logoColor=white)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/pkgs/container/powerdns-authadmin)
 [![GHCR version](https://ghcr-badge.egpl.dev/powerdns-authadmin/powerdns-authadmin/latest_tag?ignore=latest,edge&label=ghcr.io&color=%232ea44f)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/pkgs/container/powerdns-authadmin)
-[![GHCR image size](https://ghcr-badge.egpl.dev/powerdns-authadmin/powerdns-authadmin/size?tag=latest&label=image%20size&color=%232ea44f)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/pkgs/container/powerdns-authadmin)
 [![GHCR pulls](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fghcr-badge.elias.eu.org%2Fapi%2Fpowerdns-authadmin%2Fpowerdns-authadmin&query=%24.downloadCount&label=ghcr%20pulls&logo=docker&logoColor=white&color=2496ED)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/pkgs/container/powerdns-authadmin)
+[![GHCR image size](https://ghcr-badge.egpl.dev/powerdns-authadmin/powerdns-authadmin/size?tag=latest&label=image%20size&color=%232ea44f)](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/pkgs/container/powerdns-authadmin)
 
 [![Node.js 24](https://img.shields.io/badge/Node.js-24-339933?logo=node.js&logoColor=white)](.nvmrc)
 [![Next.js 16](https://img.shields.io/badge/Next.js-16-000000?logo=next.js)](https://nextjs.org)

--- a/app/(app)/admin/audit/_components/audit-filter-form.tsx
+++ b/app/(app)/admin/audit/_components/audit-filter-form.tsx
@@ -104,93 +104,92 @@ export function AuditFilterForm({ initial, actionGroups, hasFilters }: Props) {
   return (
     <form
       onSubmit={apply}
-      className="grid gap-3 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] p-4 text-sm sm:grid-cols-3"
+      className="grid gap-3 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] p-3 text-xs sm:grid-cols-3"
     >
-      <label className="space-y-1">
-        <span className="block text-xs text-[color:var(--color-fg-muted)]">Action</span>
+      <Field label="Action">
         <SelectMenu
           value={action}
           onChange={setAction}
           placeholder="All actions"
           ariaLabel="Action"
-          className="w-full"
+          className="w-full text-xs"
           options={actionGroups.flatMap((g) =>
             g.actions.map((a) => ({ value: a, label: a, description: g.ns })),
           )}
         />
-      </label>
-      <label className="space-y-1">
-        <span className="block text-xs text-[color:var(--color-fg-muted)]">Actor type</span>
+      </Field>
+      <Field label="Actor type">
         <SelectMenu
           value={actorType}
           onChange={setActorType}
           placeholder="Any"
           ariaLabel="Actor type"
-          className="w-full"
+          className="w-full text-xs"
           options={[
             { value: "user", label: "user" },
             { value: "token", label: "token" },
             { value: "system", label: "system" },
           ]}
         />
-      </label>
-      <label className="space-y-1">
-        <span className="block text-xs text-[color:var(--color-fg-muted)]">Resource type</span>
+      </Field>
+      <Field label="Resource type">
         <input
           value={resourceType}
           onChange={(e) => setResourceType(e.target.value)}
           placeholder="e.g. user, pdns_server"
-          className="block w-full rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1.5"
+          className="block w-full rounded border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 text-xs"
         />
-      </label>
-      <label className="space-y-1">
-        <span className="block text-xs text-[color:var(--color-fg-muted)]">Actor id (UUID)</span>
+      </Field>
+      <Field label="Actor id (UUID)">
         <input
           value={actorId}
           onChange={(e) => setActorId(e.target.value)}
-          className="block w-full rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1.5 font-mono"
+          className="block w-full rounded border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 font-mono text-xs"
         />
-      </label>
-      <label className="space-y-1">
-        <span className="block text-xs text-[color:var(--color-fg-muted)]">Resource id</span>
+      </Field>
+      <Field label="Resource id">
         <input
           value={resourceId}
           onChange={(e) => setResourceId(e.target.value)}
-          className="block w-full rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1.5 font-mono"
+          className="block w-full rounded border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 font-mono text-xs"
         />
-      </label>
-      <label className="space-y-1">
-        <span className="block text-xs text-[color:var(--color-fg-muted)]">Request id</span>
+      </Field>
+      <Field label="Request id">
         <input
           value={requestId}
           onChange={(e) => setRequestId(e.target.value)}
           placeholder="From a log line or error toast"
-          className="block w-full rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1.5 font-mono"
+          className="block w-full rounded border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 font-mono text-xs"
         />
-      </label>
-      <label className="space-y-1 sm:col-span-3">
-        <span className="block text-xs text-[color:var(--color-fg-muted)]">
-          Search (action / resource / before / after)
-        </span>
+      </Field>
+      <Field label="Search (action / resource / before / after)" colSpan={3}>
         <input
           value={q}
           onChange={(e) => setQ(e.target.value)}
           placeholder="e.g. example.com, captcha-failed, 169.254"
-          className="block w-full rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1.5 font-mono"
+          className="block w-full rounded border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 font-mono text-xs"
         />
-      </label>
-      <label className="space-y-1">
-        <span className="block text-xs text-[color:var(--color-fg-muted)]">From</span>
-        <DateTimePicker value={from} onChange={setFrom} side="from" />
-      </label>
-      <label className="space-y-1">
-        <span className="block text-xs text-[color:var(--color-fg-muted)]">To</span>
-        <DateTimePicker value={to} onChange={setTo} side="to" />
-      </label>
-      <div className="flex items-end gap-2">
+      </Field>
+      <Field label="From">
+        <DateTimePicker
+          value={from}
+          onChange={setFrom}
+          side="from"
+          className="block w-full rounded border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 text-xs"
+        />
+      </Field>
+      <Field label="To">
+        <DateTimePicker
+          value={to}
+          onChange={setTo}
+          side="to"
+          className="block w-full rounded border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 text-xs"
+        />
+      </Field>
+      <div className="flex items-end gap-2 sm:col-span-3">
         <button
           type="submit"
-          className="rounded-md bg-[color:var(--color-accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95"
+          className="rounded bg-[color:var(--color-accent)] px-3 py-1 text-xs font-medium text-[color:var(--color-accent-fg)] hover:opacity-95"
         >
           Apply
         </button>
@@ -198,12 +197,32 @@ export function AuditFilterForm({ initial, actionGroups, hasFilters }: Props) {
           <button
             type="button"
             onClick={clear}
-            className="rounded-md border border-[color:var(--color-border)] px-3 py-1.5 text-sm hover:bg-[color:var(--color-bg-subtle)]"
+            className="rounded border border-[color:var(--color-border)] px-3 py-1 text-xs hover:bg-[color:var(--color-bg-muted)]"
           >
             Clear
           </button>
         ) : null}
       </div>
     </form>
+  );
+}
+
+function Field({
+  label,
+  colSpan,
+  children,
+}: {
+  label: string;
+  colSpan?: 2 | 3;
+  children: React.ReactNode;
+}) {
+  const col = colSpan === 3 ? "sm:col-span-3" : colSpan === 2 ? "sm:col-span-2" : "";
+  return (
+    <label className={`space-y-1 ${col}`}>
+      <span className="block text-[0.625rem] tracking-wide text-[color:var(--color-fg-muted)] uppercase">
+        {label}
+      </span>
+      {children}
+    </label>
   );
 }

--- a/app/(app)/admin/audit/_components/audit-filter-form.tsx
+++ b/app/(app)/admin/audit/_components/audit-filter-form.tsx
@@ -14,7 +14,7 @@
  */
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DateTimePicker } from "@/components/ui/datetime-picker";
 import { SelectMenu } from "@/components/ui/select-menu";
 
@@ -52,6 +52,25 @@ export function AuditFilterForm({ initial, actionGroups, hasFilters }: Props) {
   const [q, setQ] = useState(initial.q);
   const [from, setFrom] = useState(initial.from);
   const [to, setTo] = useState(initial.to);
+
+  // Sync the inputs with the URL: when an outside link populates query params
+  // (e.g. clicking a `req:` link on a row, or a quick-filter chip) the page
+  // re-renders with a new `initial`, but useState only takes the first value.
+  // Without this the inputs stay blank even though the URL is filtered — the
+  // operator can't see WHAT they're filtered to.
+  const initialKey = JSON.stringify(initial);
+  useEffect(() => {
+    setAction(initial.action);
+    setActorType(initial.actorType);
+    setResourceType(initial.resourceType);
+    setActorId(initial.actorId);
+    setResourceId(initial.resourceId);
+    setRequestId(initial.requestId);
+    setQ(initial.q);
+    setFrom(initial.from);
+    setTo(initial.to);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialKey]);
 
   function apply(e: React.FormEvent) {
     e.preventDefault();

--- a/app/(app)/admin/audit/_components/audit-table.tsx
+++ b/app/(app)/admin/audit/_components/audit-table.tsx
@@ -53,10 +53,10 @@ export function AuditTable({ rows }: { rows: AuditRowClient[] }) {
         cell: (ctx) => (
           <LocalTime
             ts={ctx.getValue<string>()}
-            className="font-mono text-xs whitespace-nowrap text-[color:var(--color-fg-muted)]"
+            className="font-mono text-[0.6875rem] whitespace-nowrap text-[color:var(--color-fg-muted)]"
           />
         ),
-        meta: { className: "w-44 align-top" },
+        meta: { className: "w-44" },
       },
       {
         id: "actor",
@@ -65,8 +65,7 @@ export function AuditTable({ rows }: { rows: AuditRowClient[] }) {
         cell: (ctx) => {
           const row = ctx.row.original;
           return (
-            <div className="text-xs">
-              <div>{row.actorType}</div>
+            <div>
               {row.actorEmail ? (
                 row.actorHref ? (
                   <Link
@@ -81,22 +80,23 @@ export function AuditTable({ rows }: { rows: AuditRowClient[] }) {
                     {row.actorEmail}
                   </div>
                 )
-              ) : null}
-              {row.actorId ? (
-                <div className="truncate font-mono text-[0.625rem] text-[color:var(--color-fg-muted)]">
-                  {row.actorId}
-                </div>
-              ) : null}
+              ) : (
+                <div>{row.actorType}</div>
+              )}
+              <div className="text-xs text-[color:var(--color-fg-muted)]">
+                {row.actorType}
+                {row.actorId ? (
+                  <span className="ml-1 font-mono text-[0.625rem]">{row.actorId}</span>
+                ) : null}
+              </div>
             </div>
           );
         },
-        meta: { className: "align-top" },
       },
       {
         accessorKey: "action",
         header: "Action",
-        cell: (ctx) => <span className="font-mono text-xs">{ctx.getValue<string>()}</span>,
-        meta: { className: "align-top" },
+        cell: (ctx) => <span className="font-mono">{ctx.getValue<string>()}</span>,
       },
       {
         id: "resource",
@@ -105,8 +105,7 @@ export function AuditTable({ rows }: { rows: AuditRowClient[] }) {
         cell: (ctx) => {
           const row = ctx.row.original;
           return (
-            <div className="text-xs">
-              <div>{row.resourceType}</div>
+            <div>
               {row.resourceId ? (
                 row.resourceHref ? (
                   <Link
@@ -125,10 +124,10 @@ export function AuditTable({ rows }: { rows: AuditRowClient[] }) {
                   </div>
                 )
               ) : null}
+              <div className="text-xs text-[color:var(--color-fg-muted)]">{row.resourceType}</div>
             </div>
           );
         },
-        meta: { className: "align-top" },
       },
       {
         id: "detail",
@@ -177,7 +176,6 @@ export function AuditTable({ rows }: { rows: AuditRowClient[] }) {
             </div>
           );
         },
-        meta: { className: "align-top" },
       },
     ],
     [],

--- a/app/(app)/admin/audit/_components/audit-table.tsx
+++ b/app/(app)/admin/audit/_components/audit-table.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+/**
+ * app/(app)/admin/audit/_components/audit-table.tsx
+ *
+ * Client wrapper around the shared <DataTable> for the audit log. The page
+ * pre-resolves everything that needs server-side data (user emails, resource
+ * hrefs, per-row PDNS HTTP entries, before/after diff lines) and passes a
+ * plain row shape — this component does no fetching.
+ *
+ * Pagination is intentionally hidden: the audit log can be huge, so the page
+ * keeps its own server-side `?offset=` prev/next nav (one limit-wide window
+ * per HTTP request). DataTable's only job here is the consistent table chrome
+ * (mobile cards, sortable headers, same CSS as every other list in the app).
+ */
+import { useMemo } from "react";
+import Link from "next/link";
+import { type ColumnDef } from "@tanstack/react-table";
+import { DataTable } from "@/components/ui/data-table";
+import { LocalTime } from "@/components/ui/local-time";
+import { Disclosure } from "@/components/ui/disclosure";
+import { BareDiff } from "@/app/(app)/zones/[zoneId]/_components/bare-diff";
+import {
+  PdnsHttpLog,
+  type PdnsHttpLogEntry,
+} from "@/app/(app)/zones/[zoneId]/_components/pdns-http-log";
+
+export interface AuditRowClient {
+  id: string;
+  ts: string;
+  actorType: string;
+  actorEmail: string | null;
+  actorId: string | null;
+  actorHref: string | null;
+  action: string;
+  resourceType: string;
+  resourceId: string | null;
+  resourceDisplay: string | null;
+  resourceHref: string | null;
+  beforeLines: string[];
+  afterLines: string[];
+  httpEntries: PdnsHttpLogEntry[];
+  ip: string | null;
+  requestId: string | null;
+}
+
+export function AuditTable({ rows }: { rows: AuditRowClient[] }) {
+  const columns = useMemo<Array<ColumnDef<AuditRowClient, unknown>>>(
+    () => [
+      {
+        accessorKey: "ts",
+        header: "When",
+        cell: (ctx) => (
+          <LocalTime
+            ts={ctx.getValue<string>()}
+            className="font-mono text-xs whitespace-nowrap text-[color:var(--color-fg-muted)]"
+          />
+        ),
+        meta: { className: "w-44 align-top" },
+      },
+      {
+        id: "actor",
+        accessorFn: (row) => row.actorEmail ?? row.actorId ?? row.actorType,
+        header: "Actor",
+        cell: (ctx) => {
+          const row = ctx.row.original;
+          return (
+            <div className="text-xs">
+              <div>{row.actorType}</div>
+              {row.actorEmail ? (
+                row.actorHref ? (
+                  <Link
+                    href={row.actorHref}
+                    className="block truncate text-[color:var(--color-accent)] hover:underline"
+                    title={row.actorEmail}
+                  >
+                    {row.actorEmail}
+                  </Link>
+                ) : (
+                  <div className="truncate" title={row.actorEmail}>
+                    {row.actorEmail}
+                  </div>
+                )
+              ) : null}
+              {row.actorId ? (
+                <div className="truncate font-mono text-[0.625rem] text-[color:var(--color-fg-muted)]">
+                  {row.actorId}
+                </div>
+              ) : null}
+            </div>
+          );
+        },
+        meta: { className: "align-top" },
+      },
+      {
+        accessorKey: "action",
+        header: "Action",
+        cell: (ctx) => <span className="font-mono text-xs">{ctx.getValue<string>()}</span>,
+        meta: { className: "align-top" },
+      },
+      {
+        id: "resource",
+        accessorFn: (row) => row.resourceDisplay ?? row.resourceId ?? row.resourceType,
+        header: "Resource",
+        cell: (ctx) => {
+          const row = ctx.row.original;
+          return (
+            <div className="text-xs">
+              <div>{row.resourceType}</div>
+              {row.resourceId ? (
+                row.resourceHref ? (
+                  <Link
+                    href={row.resourceHref}
+                    className="block truncate text-[color:var(--color-accent)] hover:underline"
+                    title={row.resourceId}
+                  >
+                    {row.resourceDisplay ?? row.resourceId}
+                  </Link>
+                ) : (
+                  <div
+                    className="truncate font-mono text-[color:var(--color-fg-muted)]"
+                    title={row.resourceId}
+                  >
+                    {row.resourceDisplay ?? row.resourceId}
+                  </div>
+                )
+              ) : null}
+            </div>
+          );
+        },
+        meta: { className: "align-top" },
+      },
+      {
+        id: "detail",
+        header: "Detail",
+        enableSorting: false,
+        cell: (ctx) => {
+          const row = ctx.row.original;
+          const hasBeforeAfter = row.beforeLines.length > 0 || row.afterLines.length > 0;
+          return (
+            <div className="space-y-1 text-xs">
+              {hasBeforeAfter ? (
+                <Disclosure
+                  label="BEFORE / AFTER"
+                  className="space-y-1"
+                  summaryClassName="uppercase tracking-wide"
+                  bodyClassName="mt-1"
+                >
+                  <BareDiff removed={row.beforeLines} added={row.afterLines} layout="stacked" />
+                </Disclosure>
+              ) : null}
+              {row.httpEntries.length > 0 ? (
+                <Disclosure
+                  label={`POWERDNS HTTP REQUESTS (${row.httpEntries.length})`}
+                  className="space-y-1"
+                  summaryClassName="uppercase tracking-wide"
+                  bodyClassName="mt-1"
+                >
+                  <PdnsHttpLog entries={row.httpEntries} collapsible={false} />
+                </Disclosure>
+              ) : null}
+              {row.ip ? (
+                <div className="text-[color:var(--color-fg-muted)]">ip: {row.ip}</div>
+              ) : null}
+              {row.requestId ? (
+                <div className="text-[color:var(--color-fg-muted)]">
+                  req:{" "}
+                  <Link
+                    href={`/admin/audit?${new URLSearchParams({ requestId: row.requestId }).toString()}`}
+                    className="font-mono text-[color:var(--color-accent)] hover:underline"
+                    title="Filter to all rows from this request"
+                  >
+                    {row.requestId}
+                  </Link>
+                </div>
+              ) : null}
+            </div>
+          );
+        },
+        meta: { className: "align-top" },
+      },
+    ],
+    [],
+  );
+
+  return (
+    <DataTable
+      data={rows}
+      columns={columns}
+      pageSize={Math.max(rows.length, 50)}
+      hidePagination
+      hideSearch
+      emptyMessage="No entries match the current filter."
+      noDataMessage="No audit rows yet."
+    />
+  );
+}

--- a/app/(app)/admin/audit/page.tsx
+++ b/app/(app)/admin/audit/page.tsx
@@ -14,19 +14,17 @@ import { requireUserForPage } from "@/lib/auth/require-user";
 import { queryAuditLog } from "@/lib/db/repositories/audit";
 import { AUDIT_ACTIONS } from "@/lib/audit/actions";
 import { auditQuerySchema } from "@/lib/validators/audit";
-import { BareDiff } from "@/app/(app)/zones/[zoneId]/_components/bare-diff";
-import { Disclosure } from "@/components/ui/disclosure";
-import {
-  PdnsHttpLog,
-  type PdnsHttpLogEntry,
-} from "@/app/(app)/zones/[zoneId]/_components/pdns-http-log";
+import { type PdnsHttpLogEntry } from "@/app/(app)/zones/[zoneId]/_components/pdns-http-log";
 import { findPdnsRequestsByRequestIds } from "@/lib/db/repositories/pdns-requests";
 import { listAllPdnsServers } from "@/lib/db/repositories/pdns-servers";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import { inArray } from "drizzle-orm";
 import type { PdnsRequestRow } from "@/lib/db/schema";
 import { jsonToDiffLines } from "@/lib/diff/json-lines";
 import { LiveFeedSubscriber } from "@/components/ui/live-feed-subscriber";
-import { LocalTime } from "@/components/ui/local-time";
 import { AuditFilterForm } from "./_components/audit-filter-form";
+import { AuditTable, type AuditRowClient } from "./_components/audit-table";
 
 /**
  * Quick-filter chips. Each is a curated subset of the audit query
@@ -185,6 +183,29 @@ export default async function AuditLogPage({ searchParams }: PageProps) {
   ]);
   const serverById = new Map(allPdnsServers.map((s) => [s.id, s]));
   const serverBySlug = new Map(allPdnsServers.map((s) => [s.slug, s]));
+
+  // Resolve "user" resource ids → emails so the audit row renders the email
+  // (operator-friendly) instead of the UUID. The link still targets the
+  // /admin/users/<uuid> detail page.
+  const userResourceIds = Array.from(
+    new Set(
+      page.entries
+        .filter((e) => e.resourceType === "user" && typeof e.resourceId === "string")
+        .map((e) => e.resourceId!),
+    ),
+  );
+  const userEmailById =
+    userResourceIds.length > 0
+      ? new Map(
+          (
+            await db
+              .select({ id: users.id, email: users.email })
+              .from(users)
+              .where(inArray(users.id, userResourceIds))
+          ).map((u) => [u.id, u.email]),
+        )
+      : new Map<string, string>();
+
   function httpEntriesFor(
     requestId: string | null | undefined,
     action: string,
@@ -317,138 +338,9 @@ export default async function AuditLogPage({ searchParams }: PageProps) {
         ) : null}
       </div>
 
-      {page.entries.length === 0 ? (
-        <div className="rounded-md border border-dashed border-[color:var(--color-border)] p-8 text-center text-sm text-[color:var(--color-fg-muted)]">
-          No entries match.
-        </div>
-      ) : (
-        <div className="overflow-hidden rounded-md border border-[color:var(--color-border)]">
-          <table className="w-full text-sm">
-            <thead className="bg-[color:var(--color-bg-subtle)] text-left text-xs tracking-wide text-[color:var(--color-fg-muted)] uppercase">
-              <tr>
-                <th className="px-4 py-2">When</th>
-                <th className="px-4 py-2">Actor</th>
-                <th className="px-4 py-2">Action</th>
-                <th className="px-4 py-2">Resource</th>
-                <th className="px-4 py-2">Detail</th>
-              </tr>
-            </thead>
-            <tbody>
-              {page.entries.map((entry) => (
-                <tr
-                  key={String(entry.id)}
-                  className="border-t border-[color:var(--color-border)] align-top"
-                >
-                  <td className="px-4 py-3 font-mono text-xs">
-                    <LocalTime ts={entry.ts} />
-                  </td>
-                  <td className="px-4 py-3 text-xs">
-                    <div>{entry.actorType}</div>
-                    {entry.actorEmail ? (
-                      // Email is the operator-friendly identifier;
-                      // surface it above the UUID when available
-                      // (deleted users / system / token actors fall
-                      // back to UUID-only rendering below). Linked
-                      // to the user-detail page when the operator
-                      // has user.read so investigations get a one-
-                      // click pivot from "who did this" to "manage
-                      // them".
-                      navAbilities.user && entry.actorType === "user" && entry.actorId ? (
-                        <Link
-                          href={`/admin/users/${entry.actorId}`}
-                          className="block truncate text-[color:var(--color-accent)] hover:underline"
-                          title={entry.actorEmail}
-                        >
-                          {entry.actorEmail}
-                        </Link>
-                      ) : (
-                        <div className="truncate" title={entry.actorEmail}>
-                          {entry.actorEmail}
-                        </div>
-                      )
-                    ) : null}
-                    {entry.actorId ? (
-                      <div className="truncate font-mono text-[0.625rem] text-[color:var(--color-fg-muted)]">
-                        {entry.actorId}
-                      </div>
-                    ) : null}
-                  </td>
-                  <td className="px-4 py-3 font-mono text-xs">{entry.action}</td>
-                  <td className="px-4 py-3 text-xs">
-                    <div>{entry.resourceType}</div>
-                    {entry.resourceId
-                      ? (() => {
-                          const href = resourceLinkHref(
-                            entry.resourceType,
-                            entry.resourceId,
-                            navAbilities,
-                          );
-                          if (href) {
-                            return (
-                              <Link
-                                href={href}
-                                className="block truncate font-mono text-[color:var(--color-accent)] hover:underline"
-                                title={entry.resourceId}
-                              >
-                                {entry.resourceId}
-                              </Link>
-                            );
-                          }
-                          return (
-                            <div
-                              className="truncate font-mono text-[color:var(--color-fg-muted)]"
-                              title={entry.resourceId}
-                            >
-                              {entry.resourceId}
-                            </div>
-                          );
-                        })()
-                      : null}
-                  </td>
-                  <td className="px-4 py-3 text-xs">
-                    {entry.before || entry.after ? (
-                      <Disclosure
-                        label="before/after"
-                        className="space-y-1"
-                        bodyClassName="mt-1 max-w-md overflow-hidden rounded border border-[color:var(--color-border)]"
-                      >
-                        <BareDiff
-                          removed={jsonToDiffLines(entry.before)}
-                          added={jsonToDiffLines(entry.after)}
-                          layout="stacked"
-                        />
-                      </Disclosure>
-                    ) : null}
-                    {(() => {
-                      const httpEntries = httpEntriesFor(entry.requestId, entry.action);
-                      return httpEntries.length > 0 ? (
-                        <div className="mt-1 max-w-md overflow-hidden rounded border border-[color:var(--color-border)]">
-                          <PdnsHttpLog entries={httpEntries} />
-                        </div>
-                      ) : null;
-                    })()}
-                    {entry.ip ? (
-                      <div className="text-[color:var(--color-fg-muted)]">ip: {entry.ip}</div>
-                    ) : null}
-                    {entry.requestId ? (
-                      <div className="text-[color:var(--color-fg-muted)]">
-                        req:{" "}
-                        <Link
-                          href={`/admin/audit?${new URLSearchParams({ requestId: entry.requestId }).toString()}`}
-                          className="font-mono text-[color:var(--color-accent)] hover:underline"
-                          title="Filter to all rows from this request"
-                        >
-                          {entry.requestId}
-                        </Link>
-                      </div>
-                    ) : null}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <AuditTable
+        rows={buildAuditRows(page.entries, navAbilities, userEmailById, httpEntriesFor)}
+      />
 
       <nav className="flex items-center justify-between text-sm">
         {prevHref ? (
@@ -507,6 +399,53 @@ interface NavAbilities {
   template: boolean;
 }
 
+/**
+ * Server-side row builder: resolve user emails, resource hrefs, before/after
+ * line snapshots, and the per-row PDNS HTTP entries into the plain shape the
+ * client AuditTable renders. Keeping this off the client component means the
+ * table itself does no fetching — every value lands ready to render.
+ */
+function buildAuditRows(
+  entries: Awaited<ReturnType<typeof queryAuditLog>>["entries"],
+  nav: NavAbilities,
+  userEmailById: Map<string, string>,
+  httpEntriesFor: (requestId: string | null | undefined, action: string) => PdnsHttpLogEntry[],
+): AuditRowClient[] {
+  return entries.map((entry) => {
+    const resourceHref = entry.resourceId
+      ? resourceLinkHref(entry.resourceType, entry.resourceId, nav)
+      : null;
+    const resourceDisplay = entry.resourceId
+      ? entry.resourceType === "user"
+        ? (userEmailById.get(entry.resourceId) ?? entry.resourceId)
+        : entry.resourceId
+      : null;
+    const actorHref =
+      nav.user && entry.actorType === "user" && entry.actorId
+        ? `/admin/users/${entry.actorId}`
+        : null;
+    const hasBeforeAfter = entry.before != null || entry.after != null;
+    return {
+      id: String(entry.id),
+      ts: entry.ts.toISOString(),
+      actorType: entry.actorType,
+      actorEmail: entry.actorEmail ?? null,
+      actorId: entry.actorId ?? null,
+      actorHref,
+      action: entry.action,
+      resourceType: entry.resourceType,
+      resourceId: entry.resourceId ?? null,
+      resourceDisplay,
+      resourceHref,
+      beforeLines: hasBeforeAfter ? jsonToDiffLines(entry.before) : [],
+      afterLines: hasBeforeAfter ? jsonToDiffLines(entry.after) : [],
+      httpEntries: httpEntriesFor(entry.requestId, entry.action),
+      ip: entry.ip ?? null,
+      requestId: entry.requestId ?? null,
+    };
+  });
+}
+
 function resourceLinkHref(
   resourceType: string,
   resourceId: string,
@@ -526,6 +465,19 @@ function resourceLinkHref(
       return nav.oidc ? `/admin/oidc-providers/${enc}` : null;
     case "zone_template":
       return nav.template ? `/admin/zone-templates/${enc}` : null;
+    case "zone":
+    case "rrset": {
+      // Audit stores the zone resourceId as `<serverSlug>:<zoneName>` (and
+      // rrset as `<serverSlug>:<zoneName>:<rrset>|<type>`). Split on the
+      // first colon and link to the zone detail page so the operator gets a
+      // one-click pivot from the audit row to the actual records.
+      const idx = resourceId.indexOf(":");
+      if (idx < 0) return null;
+      const slug = resourceId.slice(0, idx);
+      const rest = resourceId.slice(idx + 1);
+      const zoneName = resourceType === "rrset" ? rest.split(":")[0]! : rest;
+      return `/zones/${encodeURIComponent(zoneName)}?server=${encodeURIComponent(slug)}`;
+    }
     default:
       return null;
   }

--- a/app/(app)/admin/autoprimaries/_components/autoprimary-actions.tsx
+++ b/app/(app)/admin/autoprimaries/_components/autoprimary-actions.tsx
@@ -8,9 +8,13 @@
  */
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { Plus } from "lucide-react";
+import { type ColumnDef } from "@tanstack/react-table";
 import { useDialog } from "@/components/ui/dialog";
 import { mutate } from "@/lib/client/api-fetch";
+import { createCtaClass } from "@/components/ui/create-button";
+import { DataTable } from "@/components/ui/data-table";
 
 interface Row {
   ip: string;
@@ -154,48 +158,91 @@ export function AutoprimaryActions({ serverSlug, rows }: Props) {
             type="button"
             onClick={handleCreate}
             disabled={creating}
-            className="rounded bg-[color:var(--color-accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95 disabled:opacity-50"
+            className={`${createCtaClass} disabled:opacity-50`}
           >
+            <Plus className="h-4 w-4" aria-hidden />
             {creating ? "Adding…" : "Add"}
           </button>
         </div>
       </div>
 
       {rows.length > 0 ? (
-        <div className="overflow-hidden rounded-md border border-[color:var(--color-border)]">
-          <table className="w-full text-sm">
-            <thead className="bg-[color:var(--color-bg-subtle)] text-left text-xs tracking-wide text-[color:var(--color-fg-muted)] uppercase">
-              <tr>
-                <th className="px-4 py-2">IP</th>
-                <th className="px-4 py-2">Nameserver</th>
-                <th className="px-4 py-2">Account</th>
-                <th className="px-4 py-2"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row) => (
-                <tr key={rowKey(row)} className="border-t border-[color:var(--color-border)]">
-                  <td className="px-4 py-3 font-mono text-xs">{row.ip}</td>
-                  <td className="px-4 py-3 font-mono text-xs">{row.nameserver}</td>
-                  <td className="px-4 py-3 text-xs text-[color:var(--color-fg-muted)]">
-                    {row.account ?? "—"}
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    <button
-                      type="button"
-                      onClick={() => handleDelete(row)}
-                      disabled={deletingKey === rowKey(row)}
-                      className="rounded border border-[color:var(--color-error)] px-2 py-1 text-xs text-[color:var(--color-error)] hover:bg-[color:var(--color-error)]/10 disabled:opacity-50"
-                    >
-                      {deletingKey === rowKey(row) ? "Removing…" : "Remove"}
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <AutoprimariesTable
+          rows={rows}
+          onDelete={handleDelete}
+          busyKey={deletingKey}
+          rowKey={rowKey}
+        />
       ) : null}
     </section>
+  );
+}
+
+function AutoprimariesTable({
+  rows,
+  onDelete,
+  busyKey,
+  rowKey,
+}: {
+  rows: Row[];
+  onDelete: (row: Row) => void;
+  busyKey: string | null;
+  rowKey: (row: Row) => string;
+}) {
+  const columns = useMemo<Array<ColumnDef<Row, unknown>>>(
+    () => [
+      {
+        accessorKey: "ip",
+        header: "IP",
+        cell: (ctx) => <span className="font-mono text-xs">{ctx.getValue<string>()}</span>,
+      },
+      {
+        accessorKey: "nameserver",
+        header: "Nameserver",
+        cell: (ctx) => <span className="font-mono text-xs">{ctx.getValue<string>()}</span>,
+      },
+      {
+        accessorKey: "account",
+        header: "Account",
+        cell: (ctx) => (
+          <span className="text-xs text-[color:var(--color-fg-muted)]">
+            {ctx.getValue<string | undefined>() ?? "—"}
+          </span>
+        ),
+      },
+      {
+        id: "actions",
+        header: "",
+        enableSorting: false,
+        cell: (ctx) => {
+          const row = ctx.row.original;
+          const busy = busyKey === rowKey(row);
+          return (
+            <button
+              type="button"
+              onClick={() => onDelete(row)}
+              disabled={busy}
+              className="rounded border border-[color:var(--color-error)] px-2 py-1 text-xs text-[color:var(--color-error)] hover:bg-[color:var(--color-error)]/10 disabled:opacity-50"
+            >
+              {busy ? "Removing…" : "Remove"}
+            </button>
+          );
+        },
+      },
+    ],
+    [busyKey, onDelete, rowKey],
+  );
+
+  return (
+    <DataTable
+      data={rows}
+      columns={columns}
+      pageSize={Math.max(rows.length, 10)}
+      hidePagination
+      hideSearch
+      noDataMessage="No autoprimaries configured."
+      emptyMessage="No autoprimaries match."
+      stateKey="autoprimaries"
+    />
   );
 }

--- a/app/(app)/admin/oidc-providers/_components/oidc-providers-table.tsx
+++ b/app/(app)/admin/oidc-providers/_components/oidc-providers-table.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+/**
+ * app/(app)/admin/oidc-providers/_components/oidc-providers-table.tsx
+ *
+ * Client wrapper using the shared <DataTable>. The env-configured provider (when
+ * not shadowed by a DB row) is folded into the same row list so it renders with
+ * the same column shape — its read-only/no-edit nature is encoded per-cell, not
+ * by a parallel table. Per-row icon, the discovery badge, the freshness label,
+ * and the per-row attention tint all live here so the page can hand over
+ * fully-serializable data.
+ */
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { type ColumnDef } from "@tanstack/react-table";
+import { DataTable } from "@/components/ui/data-table";
+import { freshnessOf } from "@/lib/freshness";
+import { TestDiscoveryButton } from "./test-discovery-button";
+
+export interface OidcProviderRow {
+  /** Empty string for the env-only synthetic row — disables actions. */
+  id: string;
+  name: string;
+  slug: string;
+  issuerUrl: string;
+  enabled: boolean;
+  iconUrl: string | null;
+  allowedEmailDomains: string[] | null;
+  discoveryCache: { fetchedAt: string; ok: boolean; reason?: string } | null;
+  /** Pre-resolved by lib/freshness — server can compute it once. */
+  lastAdminEditLabel: string | null;
+  lastAdminEditTitle: string | null;
+  /** Pre-resolved human-readable failure hint for the badge tooltip. */
+  discoveryFailHint: string | null;
+  isEnvManaged: boolean;
+}
+
+interface Props {
+  rows: OidcProviderRow[];
+  canManage: boolean;
+  canReadAudit: boolean;
+}
+
+export function OidcProvidersTable({ rows, canManage, canReadAudit }: Props) {
+  const columns = useMemo<Array<ColumnDef<OidcProviderRow, unknown>>>(() => {
+    const base: Array<ColumnDef<OidcProviderRow, unknown>> = [
+      {
+        id: "icon",
+        header: "",
+        enableSorting: false,
+        cell: (ctx) => {
+          const row = ctx.row.original;
+          return row.iconUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={row.iconUrl}
+              alt=""
+              style={{ width: 20, height: 20, objectFit: "contain", display: "block" }}
+            />
+          ) : (
+            <span
+              className="block h-5 w-5 rounded bg-[color:var(--color-bg-muted)]"
+              title="No icon set"
+            />
+          );
+        },
+      },
+      {
+        accessorKey: "name",
+        header: "Name",
+        cell: (ctx) => {
+          const row = ctx.row.original;
+          return (
+            <span className="inline-flex items-center gap-2">
+              {row.name}
+              {row.isEnvManaged ? (
+                <span
+                  className="rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-bg-muted)] px-2 py-0.5 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase"
+                  title="Configured via OIDC_* environment variables. Edit by changing env vars, not the UI."
+                >
+                  Configured by ENV
+                </span>
+              ) : null}
+            </span>
+          );
+        },
+      },
+      {
+        accessorKey: "slug",
+        header: "Slug",
+        cell: (ctx) => (
+          <code className="rounded bg-[color:var(--color-bg-subtle)] px-1 text-xs">
+            {ctx.getValue<string>()}
+          </code>
+        ),
+      },
+      {
+        accessorKey: "issuerUrl",
+        header: "Issuer",
+        cell: (ctx) => (
+          <span className="text-[color:var(--color-fg-muted)]">{ctx.getValue<string>()}</span>
+        ),
+      },
+      {
+        accessorKey: "enabled",
+        header: "Enabled",
+        cell: (ctx) =>
+          ctx.getValue<boolean>() ? (
+            <span className="rounded-full bg-[color:var(--color-success)]/15 px-2 py-0.5 text-xs">
+              Yes
+            </span>
+          ) : (
+            <span className="rounded-full bg-[color:var(--color-fg-muted)]/15 px-2 py-0.5 text-xs">
+              No
+            </span>
+          ),
+      },
+      {
+        id: "domains",
+        accessorFn: (row) => row.allowedEmailDomains?.length ?? -1,
+        header: "Domains",
+        cell: (ctx) => <DomainsCell allowedEmailDomains={ctx.row.original.allowedEmailDomains} />,
+      },
+      {
+        id: "discovery",
+        header: "Discovery",
+        enableSorting: false,
+        cell: (ctx) => {
+          const row = ctx.row.original;
+          if (row.isEnvManaged) {
+            return <span className="text-xs text-[color:var(--color-fg-muted)]">—</span>;
+          }
+          return <DiscoveryBadge cache={row.discoveryCache} failHint={row.discoveryFailHint} />;
+        },
+      },
+    ];
+    if (canReadAudit) {
+      base.push({
+        id: "lastEdit",
+        header: "Last admin edit",
+        accessorFn: (row) => row.lastAdminEditLabel ?? "",
+        cell: (ctx) => {
+          const row = ctx.row.original;
+          if (row.isEnvManaged || !row.lastAdminEditLabel) {
+            return <span className="text-xs text-[color:var(--color-fg-muted)]">—</span>;
+          }
+          return (
+            <span
+              className="text-xs text-[color:var(--color-fg-muted)]"
+              title={row.lastAdminEditTitle ?? undefined}
+            >
+              {row.lastAdminEditLabel}
+            </span>
+          );
+        },
+      });
+    }
+    base.push({
+      id: "actions",
+      header: "",
+      enableSorting: false,
+      cell: (ctx) => {
+        const row = ctx.row.original;
+        if (row.isEnvManaged) {
+          return (
+            <span
+              className="text-xs text-[color:var(--color-fg-muted)]"
+              title="Read-only — edit via OIDC_* environment variables"
+            >
+              Read-only
+            </span>
+          );
+        }
+        return (
+          <span className="inline-flex items-center gap-2">
+            <TestDiscoveryButton providerId={row.id} />
+            <Link href={`/admin/oidc-providers/${row.id}`} className="text-sm underline">
+              {canManage ? "Edit" : "View"}
+            </Link>
+          </span>
+        );
+      },
+    });
+    return base;
+  }, [canManage, canReadAudit]);
+
+  return (
+    <DataTable
+      data={rows}
+      columns={columns}
+      pageSize={Math.max(rows.length, 10)}
+      hidePagination
+      hideSearch
+      stateKey="oidc-providers"
+      emptyMessage="No providers match."
+      noDataMessage="No providers configured yet."
+    />
+  );
+}
+
+/**
+ * Three-state renderer for the per-provider email-domain allow-list (matches the
+ * resolver semantics in `lib/auth/email-domain-allowlist.ts`):
+ *
+ *   null       → "(inherited)"  — env default applies
+ *   []         → "(unrestricted)" — explicit override of env
+ *   [a, b, …]  → "N domain(s)" with the list as a tooltip
+ */
+function DomainsCell({ allowedEmailDomains }: { allowedEmailDomains: string[] | null }) {
+  if (allowedEmailDomains === null) {
+    return (
+      <span
+        className="text-[color:var(--color-fg-muted)]"
+        title="Inherits OIDC_ALLOWED_EMAIL_DOMAINS from env."
+      >
+        (inherited)
+      </span>
+    );
+  }
+  if (allowedEmailDomains.length === 0) {
+    return (
+      <span
+        className="text-[color:var(--color-fg-muted)]"
+        title="Override: no restriction at this provider."
+      >
+        (unrestricted)
+      </span>
+    );
+  }
+  return (
+    <span title={allowedEmailDomains.join(", ")}>
+      {allowedEmailDomains.length} domain{allowedEmailDomains.length === 1 ? "" : "s"}
+    </span>
+  );
+}
+
+function DiscoveryBadge({
+  cache,
+  failHint,
+}: {
+  cache: { fetchedAt: string; ok: boolean; reason?: string } | null;
+  failHint: string | null;
+}) {
+  if (!cache) {
+    return (
+      <span
+        className="text-xs text-[color:var(--color-fg-muted)]"
+        title="Click Test to probe the issuer's discovery endpoint."
+      >
+        (not yet probed)
+      </span>
+    );
+  }
+  const label = freshnessOf(cache.fetchedAt).label;
+  if (cache.ok) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs">
+        <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--color-success)]" />
+        Reachable
+        <span className="text-[color:var(--color-fg-muted)]">· {label}</span>
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 text-xs"
+      title={failHint ?? "Discovery probe failed."}
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--color-error)]" />
+      Failed
+      <span className="text-[color:var(--color-fg-muted)]">· {label}</span>
+    </span>
+  );
+}

--- a/app/(app)/admin/oidc-providers/page.tsx
+++ b/app/(app)/admin/oidc-providers/page.tsx
@@ -11,6 +11,7 @@
 import Link from "next/link";
 import { env } from "@/lib/env";
 import { requireUserForPage } from "@/lib/auth/require-user";
+import { CreateButton } from "@/components/ui/create-button";
 import { listAllOidcProviders } from "@/lib/db/repositories/oidc-providers";
 import { envOidcProviderSummary, type EnvOidcProviderSummary } from "@/lib/auth/providers/oidc";
 import { latestAdminEditTimestampsForOidcProviders } from "@/lib/db/repositories/audit-log";
@@ -68,15 +69,10 @@ export default async function OidcProvidersPage() {
             .
           </p>
         </div>
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2 [&>*]:w-full sm:[&>*]:w-auto">
           {providers.length > 0 ? <RefreshAllButton /> : null}
           {canManage ? (
-            <Link
-              href="/admin/oidc-providers/new"
-              className="rounded-md bg-[color:var(--color-accent)] px-4 py-2 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95"
-            >
-              Add provider
-            </Link>
+            <CreateButton href="/admin/oidc-providers/new" label="Add provider" />
           ) : null}
         </div>
       </header>

--- a/app/(app)/admin/oidc-providers/page.tsx
+++ b/app/(app)/admin/oidc-providers/page.tsx
@@ -56,7 +56,7 @@ export default async function OidcProvidersPage() {
 
   return (
     <div className="space-y-6">
-      <header className="flex items-end justify-between">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">OIDC providers</h1>
           <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">
@@ -68,7 +68,7 @@ export default async function OidcProvidersPage() {
             .
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {providers.length > 0 ? <RefreshAllButton /> : null}
           {canManage ? (
             <Link

--- a/app/(app)/admin/oidc-providers/page.tsx
+++ b/app/(app)/admin/oidc-providers/page.tsx
@@ -8,19 +8,18 @@
  * shadows it.
  */
 
-import Link from "next/link";
 import { env } from "@/lib/env";
 import { requireUserForPage } from "@/lib/auth/require-user";
 import { CreateButton } from "@/components/ui/create-button";
 import { listAllOidcProviders } from "@/lib/db/repositories/oidc-providers";
-import { envOidcProviderSummary, type EnvOidcProviderSummary } from "@/lib/auth/providers/oidc";
+import { envOidcProviderSummary } from "@/lib/auth/providers/oidc";
 import { latestAdminEditTimestampsForOidcProviders } from "@/lib/db/repositories/audit-log";
 import { freshnessOf } from "@/lib/freshness";
 import { probeFailureLabel, type ProbeFailureReason } from "@/lib/auth/providers/oidc-probe";
 import { ensureFreshOidcDiscovery } from "@/lib/auth/providers/oidc-discovery-sampler";
 import { logger } from "@/lib/logger";
-import { TestDiscoveryButton } from "./_components/test-discovery-button";
 import { RefreshAllButton } from "./_components/refresh-all-button";
+import { OidcProvidersTable, type OidcProviderRow } from "./_components/oidc-providers-table";
 
 export default async function OidcProvidersPage() {
   const { ability } = await requireUserForPage({ can: "oidc.read" });
@@ -80,285 +79,49 @@ export default async function OidcProvidersPage() {
       {!hasAnyRow ? (
         <p className="text-sm text-[color:var(--color-fg-muted)]">No providers configured yet.</p>
       ) : (
-        <div className="overflow-hidden rounded-md border border-[color:var(--color-border)]">
-          <table className="w-full text-sm">
-            <thead className="bg-[color:var(--color-bg-subtle)] text-left">
-              <tr>
-                <Th />
-                <Th>Name</Th>
-                <Th>Slug</Th>
-                <Th>Issuer</Th>
-                <Th>Enabled</Th>
-                <Th>Domains</Th>
-                <Th>Discovery</Th>
-                {canReadAudit ? <Th>Last admin edit</Th> : null}
-                <Th />
-              </tr>
-            </thead>
-            <tbody>
-              {providers.map((p) => (
-                <tr
-                  key={p.id}
-                  className={`border-t border-[color:var(--color-border)] ${rowAttentionClass(
-                    p.enabled,
-                    p.discoveryCache,
-                  )}`}
-                >
-                  <Td>
-                    {p.iconUrl ? (
-                      // Operator-supplied icon — same trust as the
-                      // brand_logo_url surface. CSP `img-src` allows
-                      // https + data:. Sized to the row.
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        src={p.iconUrl}
-                        alt=""
-                        style={{
-                          width: 20,
-                          height: 20,
-                          objectFit: "contain",
-                          display: "block",
-                        }}
-                      />
-                    ) : (
-                      <span
-                        className="block h-5 w-5 rounded bg-[color:var(--color-bg-muted)]"
-                        title="No icon set"
-                      />
-                    )}
-                  </Td>
-                  <Td>{p.name}</Td>
-                  <Td>
-                    <code className="rounded bg-[color:var(--color-bg-subtle)] px-1">{p.slug}</code>
-                  </Td>
-                  <Td className="text-[color:var(--color-fg-muted)]">{p.issuerUrl}</Td>
-                  <Td>
-                    {p.enabled ? (
-                      <span className="rounded-full bg-[color:var(--color-success)]/15 px-2 py-0.5 text-xs">
-                        Yes
-                      </span>
-                    ) : (
-                      <span className="rounded-full bg-[color:var(--color-fg-muted)]/15 px-2 py-0.5 text-xs">
-                        No
-                      </span>
-                    )}
-                  </Td>
-                  <Td>
-                    <DomainsCell allowedEmailDomains={p.allowedEmailDomains} />
-                  </Td>
-                  <Td>
-                    <DiscoveryBadge discoveryCache={p.discoveryCache} />
-                  </Td>
-                  {canReadAudit ? (
-                    <Td className="text-xs text-[color:var(--color-fg-muted)]">
-                      {lastEdits.has(p.id) ? (
-                        <span title={lastEdits.get(p.id)!.toISOString()}>
-                          {freshnessOf(lastEdits.get(p.id)!.toISOString()).label}
-                        </span>
-                      ) : (
-                        "—"
-                      )}
-                    </Td>
-                  ) : null}
-                  <Td>
-                    <span className="inline-flex items-center gap-2">
-                      <TestDiscoveryButton providerId={p.id} />
-                      <Link href={`/admin/oidc-providers/${p.id}`} className="text-sm underline">
-                        {canManage ? "Edit" : "View"}
-                      </Link>
-                    </span>
-                  </Td>
-                </tr>
-              ))}
-              {showEnvRow && envProvider ? (
-                <EnvProviderRow provider={envProvider} canReadAudit={canReadAudit} />
-              ) : null}
-            </tbody>
-          </table>
-        </div>
+        <OidcProvidersTable
+          rows={[
+            ...providers.map<OidcProviderRow>((p) => {
+              const lastEdit = lastEdits.get(p.id);
+              const reason = p.discoveryCache?.reason as ProbeFailureReason | undefined;
+              return {
+                id: p.id,
+                name: p.name,
+                slug: p.slug,
+                issuerUrl: p.issuerUrl,
+                enabled: p.enabled,
+                iconUrl: p.iconUrl,
+                allowedEmailDomains: p.allowedEmailDomains,
+                discoveryCache: p.discoveryCache,
+                lastAdminEditLabel: lastEdit ? freshnessOf(lastEdit.toISOString()).label : null,
+                lastAdminEditTitle: lastEdit ? lastEdit.toISOString() : null,
+                discoveryFailHint: reason ? probeFailureLabel(reason) : null,
+                isEnvManaged: false,
+              };
+            }),
+            ...(showEnvRow && envProvider
+              ? [
+                  {
+                    id: "",
+                    name: envProvider.name,
+                    slug: envProvider.slug,
+                    issuerUrl: envProvider.issuerUrl,
+                    enabled: true,
+                    iconUrl: null,
+                    allowedEmailDomains: envProvider.allowedEmailDomains,
+                    discoveryCache: null,
+                    lastAdminEditLabel: null,
+                    lastAdminEditTitle: null,
+                    discoveryFailHint: null,
+                    isEnvManaged: true,
+                  } satisfies OidcProviderRow,
+                ]
+              : []),
+          ]}
+          canManage={canManage}
+          canReadAudit={canReadAudit}
+        />
       )}
     </div>
-  );
-}
-
-/**
- * Read-only row for the env-configured provider. It isn't a DB row, so it
- * carries no edit/test/audit affordances — just the "Configured by ENV" badge
- * making clear it's driven by `OIDC_*` and changed by editing env vars. The
- * env provider has no group→role mapping and no discovery probe.
- */
-function EnvProviderRow({
-  provider,
-  canReadAudit,
-}: {
-  provider: EnvOidcProviderSummary;
-  canReadAudit: boolean;
-}) {
-  return (
-    <tr className="border-t border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)]/40">
-      <Td>
-        <span
-          className="block h-5 w-5 rounded bg-[color:var(--color-bg-muted)]"
-          title="No icon (env provider)"
-        />
-      </Td>
-      <Td>
-        <span className="inline-flex items-center gap-2">
-          {provider.name}
-          <span
-            className="rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-bg-muted)] px-2 py-0.5 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase"
-            title="Configured via OIDC_* environment variables. Edit by changing env vars, not the UI."
-          >
-            Configured by ENV
-          </span>
-        </span>
-      </Td>
-      <Td>
-        <code className="rounded bg-[color:var(--color-bg-subtle)] px-1">{provider.slug}</code>
-      </Td>
-      <Td className="text-[color:var(--color-fg-muted)]">{provider.issuerUrl}</Td>
-      <Td>
-        <span className="rounded-full bg-[color:var(--color-success)]/15 px-2 py-0.5 text-xs">
-          Yes
-        </span>
-      </Td>
-      <Td>
-        <DomainsCell allowedEmailDomains={provider.allowedEmailDomains} />
-      </Td>
-      <Td className="text-xs text-[color:var(--color-fg-muted)]">—</Td>
-      {canReadAudit ? <Td className="text-xs text-[color:var(--color-fg-muted)]">—</Td> : null}
-      <Td>
-        <span
-          className="text-xs text-[color:var(--color-fg-muted)]"
-          title="Read-only — edit via OIDC_* environment variables"
-        >
-          Read-only
-        </span>
-      </Td>
-    </tr>
-  );
-}
-
-/**
- * Per-row attention class. Enabled providers that are
- * either never-probed or failing get a left-edge accent + subtle
- * tinted background, matching the dashboard attention widget
- * (T-104) tones — operators arriving from the widget's tile can
- * eyeball which row(s) caused it to fire instead of reading the
- * Discovery column on every row.
- *
- * Disabled providers stay neutral (operator-intentional, not
- * actionable). Same gating logic as `oidcAttentionCounts` so the
- * row highlight and the dashboard count never disagree.
- *
- * The classes use the project's color tokens directly — kept in
- * one place so the visual vocabulary stays cross-page consistent.
- */
-function rowAttentionClass(
-  enabled: boolean,
-  cache: { fetchedAt: string; ok: boolean; reason?: string } | null,
-): string {
-  if (!enabled) return "";
-  if (cache === null) {
-    // Never probed — warn tone (could be fresh + healthy; just
-    // hasn't been checked yet).
-    return "bg-[color:var(--color-warn)]/5 border-l-2 border-l-[color:var(--color-warn)]";
-  }
-  if (!cache.ok) {
-    // Active failure — error tone.
-    return "bg-[color:var(--color-error)]/5 border-l-2 border-l-[color:var(--color-error)]";
-  }
-  return "";
-}
-
-function Th({ children }: { children?: React.ReactNode }) {
-  return <th className="px-3 py-2 text-xs font-medium tracking-wide uppercase">{children}</th>;
-}
-function Td({ children, className }: { children?: React.ReactNode; className?: string }) {
-  return <td className={`px-3 py-2 ${className ?? ""}`}>{children}</td>;
-}
-
-/**
- * Three-state renderer for the per-provider email-domain allow-list
- * (S-7 / Ticks 43-44). Matches the resolver semantics in
- * `lib/auth/email-domain-allowlist.ts`:
- *
- *   null       → "(inherited)"  — env default applies
- *   []         → "(unrestricted)" — explicit override of env
- *   [a, b, …]  → "N domain(s)" with the list as a tooltip
- */
-function DomainsCell({ allowedEmailDomains }: { allowedEmailDomains: string[] | null }) {
-  if (allowedEmailDomains === null) {
-    return (
-      <span
-        className="text-[color:var(--color-fg-muted)]"
-        title="Inherits OIDC_ALLOWED_EMAIL_DOMAINS from env."
-      >
-        (inherited)
-      </span>
-    );
-  }
-  if (allowedEmailDomains.length === 0) {
-    return (
-      <span
-        className="text-[color:var(--color-fg-muted)]"
-        title="Override: no restriction at this provider."
-      >
-        (unrestricted)
-      </span>
-    );
-  }
-  return (
-    <span title={allowedEmailDomains.join(", ")}>
-      {allowedEmailDomains.length} domain{allowedEmailDomains.length === 1 ? "" : "s"}
-    </span>
-  );
-}
-
-/**
- * Health badge for the cached discovery probe. Three
- * states matching the resource semantics elsewhere:
- *   - null cache (never probed) → muted "(not yet probed)"
- *   - cache.ok=true → green dot + "Reachable · Nm ago"
- *     (freshness label via `freshnessOf`, same time-language as
- *     /admin/servers and /zones).
- *   - cache.ok=false → red dot + "Failed · Nm ago" + tooltip with
- *     the human-readable reason.
- */
-function DiscoveryBadge({
-  discoveryCache,
-}: {
-  discoveryCache: { fetchedAt: string; ok: boolean; reason?: string } | null;
-}) {
-  if (!discoveryCache) {
-    return (
-      <span
-        className="text-xs text-[color:var(--color-fg-muted)]"
-        title="Click Test to probe the issuer's discovery endpoint."
-      >
-        (not yet probed)
-      </span>
-    );
-  }
-  const fresh = freshnessOf(discoveryCache.fetchedAt);
-  if (discoveryCache.ok) {
-    return (
-      <span className="inline-flex items-center gap-1 text-xs">
-        <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--color-success)]" />
-        Reachable
-        <span className="text-[color:var(--color-fg-muted)]">· {fresh.label}</span>
-      </span>
-    );
-  }
-  // Failure: tooltip carries the human-readable hint so operators
-  // don't have to dig into the audit log for the reason.
-  const reason = discoveryCache.reason as ProbeFailureReason | undefined;
-  const hint = reason ? probeFailureLabel(reason) : "Discovery probe failed.";
-  return (
-    <span className="inline-flex items-center gap-1 text-xs" title={hint}>
-      <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--color-error)]" />
-      Failed
-      <span className="text-[color:var(--color-fg-muted)]">· {fresh.label}</span>
-    </span>
   );
 }

--- a/app/(app)/admin/pdns-clusters/_components/groups-table.tsx
+++ b/app/(app)/admin/pdns-clusters/_components/groups-table.tsx
@@ -86,6 +86,7 @@ export function GroupsTable({ rows }: { rows: GroupRow[] }) {
       initialSort={[{ id: "name", desc: false }]}
       sortParam="sort"
       pageSizeParam="pageSize"
+      rowHref={(r) => `/admin/pdns-clusters/${r.id}`}
     />
   );
 }

--- a/app/(app)/admin/pdns-clusters/_components/groups-table.tsx
+++ b/app/(app)/admin/pdns-clusters/_components/groups-table.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+/**
+ * app/(app)/admin/pdns-clusters/_components/groups-table.tsx
+ *
+ * Client wrapper around the shared `<DataTable>` for the Groups list —
+ * sortable columns + search on desktop, cards on mobile. Mirrors the other
+ * admin list tables (roles/users/teams).
+ */
+
+import Link from "next/link";
+import { useMemo } from "react";
+import { type ColumnDef } from "@tanstack/react-table";
+import { DataTable } from "@/components/ui/data-table";
+
+export interface GroupRow {
+  id: string;
+  name: string;
+  slug: string;
+  /** Human label from classifyGroup (e.g. "Multi-primary cluster"). */
+  typeLabel: string;
+  isMultiPrimary: boolean;
+  /** Raw write strategy (e.g. "round_robin"); only meaningful when multi-primary. */
+  writeStrategy: string;
+  memberCount: number;
+}
+
+export function GroupsTable({ rows }: { rows: GroupRow[] }) {
+  const columns = useMemo<Array<ColumnDef<GroupRow, unknown>>>(
+    () => [
+      {
+        accessorKey: "name",
+        header: "Name",
+        cell: (ctx) => (
+          <Link
+            href={`/admin/pdns-clusters/${ctx.row.original.id}`}
+            className="font-medium hover:text-[color:var(--color-accent)] hover:underline"
+          >
+            {ctx.getValue<string>()}
+          </Link>
+        ),
+      },
+      {
+        accessorKey: "slug",
+        header: "Slug",
+        cell: (ctx) => <code className="font-mono text-xs">{ctx.getValue<string>()}</code>,
+      },
+      {
+        accessorKey: "typeLabel",
+        header: "Type",
+        cell: (ctx) => (
+          <span className="rounded border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-1.5 py-0.5 text-[0.625rem] tracking-wide uppercase">
+            {ctx.getValue<string>()}
+          </span>
+        ),
+      },
+      {
+        id: "strategy",
+        header: "Strategy",
+        accessorFn: (row) => (row.isMultiPrimary ? row.writeStrategy : ""),
+        cell: (ctx) => {
+          const r = ctx.row.original;
+          return r.isMultiPrimary ? (
+            <span className="rounded bg-[color:var(--color-accent)]/15 px-1.5 py-0.5 font-mono text-[0.625rem] tracking-wide text-[color:var(--color-accent)] uppercase">
+              {r.writeStrategy.replace("_", " ")}
+            </span>
+          ) : (
+            <span className="text-xs text-[color:var(--color-fg-muted)]">—</span>
+          );
+        },
+      },
+      {
+        accessorKey: "memberCount",
+        header: "Members",
+        cell: (ctx) => <span className="text-xs">{ctx.getValue<number>()}</span>,
+      },
+    ],
+    [],
+  );
+
+  return (
+    <DataTable
+      columns={columns}
+      data={rows}
+      searchPlaceholder="Search groups by name or slug…"
+      initialSort={[{ id: "name", desc: false }]}
+      sortParam="sort"
+      pageSizeParam="pageSize"
+    />
+  );
+}

--- a/app/(app)/admin/pdns-clusters/page.tsx
+++ b/app/(app)/admin/pdns-clusters/page.tsx
@@ -13,6 +13,7 @@ import { listAllClusters } from "@/lib/db/repositories/pdns-clusters";
 import { listAllPdnsServers } from "@/lib/db/repositories/pdns-servers";
 import { classifyGroup } from "@/lib/pdns/capabilities";
 import type { PdnsServer } from "@/lib/db/schema";
+import { GroupsTable, type GroupRow } from "./_components/groups-table";
 
 export const metadata: Metadata = { title: "Groups" };
 
@@ -29,9 +30,23 @@ export default async function PdnsClustersListPage() {
     membersByCluster.set(s.clusterId, arr);
   }
 
+  const rows: GroupRow[] = clusters.map((c) => {
+    const members = membersByCluster.get(c.id) ?? [];
+    const composition = classifyGroup(members);
+    return {
+      id: c.id,
+      name: c.name,
+      slug: c.slug,
+      typeLabel: composition.typeLabel,
+      isMultiPrimary: composition.isMultiPrimary,
+      writeStrategy: c.writeStrategy,
+      memberCount: members.length,
+    };
+  });
+
   return (
     <div className="space-y-6">
-      <header className="flex items-start justify-between gap-4">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Groups</h1>
           <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">
@@ -57,43 +72,7 @@ export default async function PdnsClustersListPage() {
           backends don&rsquo;t need a group.
         </div>
       ) : (
-        <ul className="divide-y divide-[color:var(--color-border)] rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)]">
-          {clusters.map((c) => {
-            const members = membersByCluster.get(c.id) ?? [];
-            const composition = classifyGroup(members);
-            return (
-              <li key={c.id} className="flex items-center justify-between gap-4 px-4 py-3">
-                <div className="min-w-0 flex-1">
-                  <Link
-                    href={`/admin/pdns-clusters/${c.id}`}
-                    className="block font-medium hover:text-[color:var(--color-accent)] hover:underline"
-                  >
-                    {c.name}
-                  </Link>
-                  <div className="mt-0.5 flex flex-wrap items-center gap-3 text-xs text-[color:var(--color-fg-muted)]">
-                    <code className="font-mono">{c.slug}</code>
-                    <span className="rounded border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-1.5 py-0.5 text-[0.625rem] tracking-wide uppercase">
-                      {composition.typeLabel}
-                    </span>
-                    {composition.isMultiPrimary ? (
-                      <span className="rounded bg-[color:var(--color-accent)]/15 px-1.5 py-0.5 font-mono text-[0.625rem] tracking-wide text-[color:var(--color-accent)] uppercase">
-                        {c.writeStrategy.replace("_", " ")}
-                      </span>
-                    ) : null}
-                    <span>
-                      {members.length} member{members.length === 1 ? "" : "s"}
-                    </span>
-                  </div>
-                  {c.description ? (
-                    <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">
-                      {c.description}
-                    </p>
-                  ) : null}
-                </div>
-              </li>
-            );
-          })}
-        </ul>
+        <GroupsTable rows={rows} />
       )}
     </div>
   );

--- a/app/(app)/admin/pdns-clusters/page.tsx
+++ b/app/(app)/admin/pdns-clusters/page.tsx
@@ -55,7 +55,7 @@ export default async function PdnsClustersListPage() {
             strategy applies only to multi-primary clusters.
           </p>
         </div>
-        {canCreate ? <CreateButton href="/admin/pdns-clusters/new" label="New group" /> : null}
+        {canCreate ? <CreateButton href="/admin/pdns-clusters/new" label="Add group" /> : null}
       </header>
 
       {clusters.length === 0 ? (

--- a/app/(app)/admin/pdns-clusters/page.tsx
+++ b/app/(app)/admin/pdns-clusters/page.tsx
@@ -7,12 +7,12 @@
  */
 
 import type { Metadata } from "next";
-import Link from "next/link";
 import { requireUserForPage } from "@/lib/auth/require-user";
 import { listAllClusters } from "@/lib/db/repositories/pdns-clusters";
 import { listAllPdnsServers } from "@/lib/db/repositories/pdns-servers";
 import { classifyGroup } from "@/lib/pdns/capabilities";
 import type { PdnsServer } from "@/lib/db/schema";
+import { CreateButton } from "@/components/ui/create-button";
 import { GroupsTable, type GroupRow } from "./_components/groups-table";
 
 export const metadata: Metadata = { title: "Groups" };
@@ -55,14 +55,7 @@ export default async function PdnsClustersListPage() {
             strategy applies only to multi-primary clusters.
           </p>
         </div>
-        {canCreate ? (
-          <Link
-            href="/admin/pdns-clusters/new"
-            className="shrink-0 rounded bg-[color:var(--color-accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95"
-          >
-            New group
-          </Link>
-        ) : null}
+        {canCreate ? <CreateButton href="/admin/pdns-clusters/new" label="New group" /> : null}
       </header>
 
       {clusters.length === 0 ? (

--- a/app/(app)/admin/pdns-requests/_components/pdns-requests-table.tsx
+++ b/app/(app)/admin/pdns-requests/_components/pdns-requests-table.tsx
@@ -19,7 +19,7 @@
  * `router.refresh()` so new rows appear without manual reloads.
  */
 
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { type ColumnDef } from "@tanstack/react-table";
@@ -27,6 +27,7 @@ import { DataTable } from "@/components/ui/data-table";
 import { DateTimePicker } from "@/components/ui/datetime-picker";
 import { SelectMenu } from "@/components/ui/select-menu";
 import { LocalTime } from "@/components/ui/local-time";
+import { Disclosure } from "@/components/ui/disclosure";
 import { useRealtimeEvent } from "@/components/realtime/realtime-provider";
 import { PdnsHttpLog } from "@/app/(app)/zones/[zoneId]/_components/pdns-http-log";
 
@@ -77,6 +78,21 @@ export function PdnsRequestsTable(props: Props) {
   const [requestId, setRequestId] = useState(props.initial.requestId);
   const [fromIso, setFromIso] = useState(props.initial.fromIso);
   const [toIso, setToIso] = useState(props.initial.toIso);
+
+  // Sync inputs with the URL. Outside links (e.g. clicking a row's `req` cell,
+  // or arriving from the audit log's req: link) update the URL but useState
+  // only takes the first value — without this the form inputs stay blank
+  // even though the URL is filtered, making it look like nothing happened.
+  const initKey = JSON.stringify(props.initial);
+  useEffect(() => {
+    setServerSlug(props.initial.serverSlug);
+    setOp(props.initial.op);
+    setStatus(props.initial.status);
+    setRequestId(props.initial.requestId);
+    setFromIso(props.initial.fromIso);
+    setToIso(props.initial.toIso);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initKey]);
 
   const filtersDirty =
     serverSlug !== props.initial.serverSlug ||
@@ -191,73 +207,57 @@ export function PdnsRequestsTable(props: Props) {
         meta: { className: "w-20" },
       },
       {
-        accessorKey: "requestId",
-        header: "Request",
-        cell: (ctx) => {
-          const v = ctx.getValue<string | null>();
-          if (!v) return <span>—</span>;
-          return (
-            <button
-              type="button"
-              onClick={() => {
-                setRequestId(v);
-                const params = new URLSearchParams();
-                params.set("requestId", v);
-                router.replace(`/admin/pdns-requests?${params.toString()}`, {
-                  scroll: false,
-                });
-              }}
-              className="font-mono text-[color:var(--color-accent)] hover:underline"
-            >
-              {v.slice(0, 8)}…
-            </button>
-          );
-        },
-        meta: { className: "w-24" },
-      },
-    ],
-    [router],
-  );
-
-  // Expandable row body — the PdnsHttpLog viewer rendered inline beneath the
-  // row via DataTable's `renderRowDetail`, controlled by a Set of expanded ids.
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-
-  function toggle(id: string) {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }
-
-  // Augment columns with an expander column at index 0.
-  const columnsWithExpand = useMemo<Array<ColumnDef<PdnsRequestRowClient, unknown>>>(
-    () => [
-      {
-        id: "expand",
-        header: "",
+        id: "detail",
+        header: "Detail",
         enableSorting: false,
         cell: (ctx) => {
-          const id = ctx.row.original.id;
-          const open = expanded.has(id);
+          const row = ctx.row.original;
           return (
-            <button
-              type="button"
-              onClick={() => toggle(id)}
-              aria-label={open ? "Collapse" : "Expand"}
-              className="rounded px-1.5 text-xs text-[color:var(--color-fg-muted)] hover:bg-[color:var(--color-bg-subtle)]"
-            >
-              {open ? "▾" : "▸"}
-            </button>
+            <div className="space-y-1 text-xs">
+              <Disclosure
+                label="POWERDNS HTTP REQUESTS (1)"
+                className="space-y-1"
+                summaryClassName="uppercase tracking-wide"
+                bodyClassName="mt-1"
+              >
+                <PdnsHttpLog
+                  collapsible={false}
+                  entries={[
+                    {
+                      id: row.id,
+                      ts: row.ts,
+                      serverSlug: row.serverSlug,
+                      serverName: row.serverName,
+                      serverDbId: row.serverDbId,
+                      op: row.op,
+                      method: row.method,
+                      url: row.url,
+                      requestHeaders: row.requestHeaders,
+                      requestBody: row.requestBody,
+                      responseStatus: row.responseStatus,
+                      error: row.error,
+                    },
+                  ]}
+                />
+              </Disclosure>
+              {row.requestId ? (
+                <div className="text-[color:var(--color-fg-muted)]">
+                  req:{" "}
+                  <Link
+                    href={`/admin/pdns-requests?${new URLSearchParams({ requestId: row.requestId }).toString()}`}
+                    className="font-mono text-[color:var(--color-accent)] hover:underline"
+                    title="Filter to all rows from this request"
+                  >
+                    {row.requestId}
+                  </Link>
+                </div>
+              ) : null}
+            </div>
           );
         },
-        meta: { className: "w-8" },
       },
-      ...columns,
     ],
-    [columns, expanded],
+    [],
   );
 
   return (
@@ -348,7 +348,7 @@ export function PdnsRequestsTable(props: Props) {
 
       <DataTable
         data={props.rows}
-        columns={columnsWithExpand}
+        columns={columns}
         pageSize={50}
         pageSizeOptions={[25, 50, 100, 200]}
         searchPlaceholder="Search URLs, ops, methods…"
@@ -356,29 +356,6 @@ export function PdnsRequestsTable(props: Props) {
         noDataMessage="No PowerDNS HTTP traffic recorded yet."
         sortParam="sort"
         pageSizeParam="pageSize"
-        renderRowDetail={(row) =>
-          expanded.has(row.id) ? (
-            <PdnsHttpLog
-              collapsible={false}
-              entries={[
-                {
-                  id: row.id,
-                  ts: row.ts,
-                  serverSlug: row.serverSlug,
-                  serverName: row.serverName,
-                  serverDbId: row.serverDbId,
-                  op: row.op,
-                  method: row.method,
-                  url: row.url,
-                  requestHeaders: row.requestHeaders,
-                  requestBody: row.requestBody,
-                  responseStatus: row.responseStatus,
-                  error: row.error,
-                },
-              ]}
-            />
-          ) : null
-        }
       />
     </div>
   );

--- a/app/(app)/admin/roles/_components/role-form.tsx
+++ b/app/(app)/admin/roles/_components/role-form.tsx
@@ -290,7 +290,7 @@ export function RoleForm({
           disabled={!canSubmit}
           className="rounded bg-[color:var(--color-accent)] px-4 py-1.5 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95 disabled:opacity-50"
         >
-          {busy ? "Saving…" : mode === "create" ? "Create role" : "Save changes"}
+          {busy ? "Saving…" : mode === "create" ? "Add role" : "Save changes"}
         </button>
       </div>
     </form>

--- a/app/(app)/admin/roles/_components/roles-table.tsx
+++ b/app/(app)/admin/roles/_components/roles-table.tsx
@@ -112,6 +112,7 @@ export function RolesTable({
       initialSort={[{ id: "name", desc: false }]}
       sortParam="sort"
       pageSizeParam="pageSize"
+      rowHref={(r) => `/admin/roles/${r.id}`}
     />
   );
 }

--- a/app/(app)/admin/roles/new/page.tsx
+++ b/app/(app)/admin/roles/new/page.tsx
@@ -26,7 +26,7 @@ export default async function NewRolePage() {
         </Link>
       </div>
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight">New role</h1>
+        <h1 className="text-2xl font-semibold tracking-tight">Add role</h1>
         <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">
           Custom roles bundle permissions an org needs in addition to the five seeded system roles.
           The slug you choose here is also what you reference in OIDC group → role mappings.

--- a/app/(app)/admin/roles/page.tsx
+++ b/app/(app)/admin/roles/page.tsx
@@ -28,7 +28,7 @@ export default async function RolesListPage() {
 
   return (
     <div className="space-y-6">
-      <header className="flex items-start justify-between gap-4">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Roles</h1>
           <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">

--- a/app/(app)/admin/roles/page.tsx
+++ b/app/(app)/admin/roles/page.tsx
@@ -36,7 +36,7 @@ export default async function RolesListPage() {
             (only the MFA-required toggle); custom roles support full CRUD.
           </p>
         </div>
-        {canCreate ? <CreateButton href="/admin/roles/new" label="New role" /> : null}
+        {canCreate ? <CreateButton href="/admin/roles/new" label="Add role" /> : null}
       </header>
 
       <RolesTable

--- a/app/(app)/admin/roles/page.tsx
+++ b/app/(app)/admin/roles/page.tsx
@@ -8,8 +8,8 @@
  */
 
 import type { Metadata } from "next";
-import Link from "next/link";
 import { requireUserForPage } from "@/lib/auth/require-user";
+import { CreateButton } from "@/components/ui/create-button";
 import { listRoles } from "@/lib/db/repositories/roles";
 import { latestAdminEditTimestampsForRoles } from "@/lib/db/repositories/audit-log";
 import { RolesTable, type RoleRow } from "./_components/roles-table";
@@ -36,14 +36,7 @@ export default async function RolesListPage() {
             (only the MFA-required toggle); custom roles support full CRUD.
           </p>
         </div>
-        {canCreate ? (
-          <Link
-            href="/admin/roles/new"
-            className="shrink-0 rounded bg-[color:var(--color-accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95"
-          >
-            New role
-          </Link>
-        ) : null}
+        {canCreate ? <CreateButton href="/admin/roles/new" label="New role" /> : null}
       </header>
 
       <RolesTable

--- a/app/(app)/admin/servers/[id]/page.tsx
+++ b/app/(app)/admin/servers/[id]/page.tsx
@@ -14,7 +14,8 @@ import { findPdnsServerById, listSecondariesForPrimary } from "@/lib/db/reposito
 import { listAllClusters } from "@/lib/db/repositories/pdns-clusters";
 import { latestServerAdminEdit, recentAdminEditsForServer } from "@/lib/db/repositories/audit-log";
 import { freshnessOf } from "@/lib/freshness";
-import { isWriteCapable, summarizeCapabilities } from "@/lib/pdns/capabilities";
+import { isWriteCapable } from "@/lib/pdns/capabilities";
+import { CapabilityBadges } from "@/components/domain/capability-badges";
 import { type SafeConfigRow } from "@/lib/pdns/config-advice";
 import { readDaemonConfig } from "@/lib/pdns/daemon-config-cache";
 import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
@@ -95,9 +96,9 @@ export default async function EditPdnsServerPage({ params }: PageProps) {
           )}
         </p>
         {row.capabilities ? (
-          <p className="text-xs text-[color:var(--color-fg-muted)]">
-            <span className="font-medium text-[color:var(--color-fg)]">Observed:</span>{" "}
-            {summarizeCapabilities(row.capabilities)}
+          <p className="flex flex-wrap items-center gap-2 text-xs text-[color:var(--color-fg-muted)]">
+            <span className="font-medium text-[color:var(--color-fg)]">Observed:</span>
+            <CapabilityBadges capabilities={row.capabilities} />
             {row.capabilities.backends.length > 0 ? (
               <> · {row.capabilities.backends.join(", ")}</>
             ) : null}

--- a/app/(app)/admin/servers/_components/servers-page-heartbeat.tsx
+++ b/app/(app)/admin/servers/_components/servers-page-heartbeat.tsx
@@ -5,14 +5,17 @@
  *
  * The unified background poller adaptively quickens when it sees any
  * primary↔secondary mismatch (replication in flight) and publishes a
- * `zone.updated` event each time a serial transitions; that event
- * arrives over the app-wide RealtimeProvider stream and triggers one
- * router.refresh() here. No 1 s timer, no per-tick RSC refetch storm.
+ * `zone.updated` event each time a serial transitions; that event arrives
+ * over the app-wide RealtimeProvider stream and triggers one router.refresh
+ * here. The visible "SYNCED / DESYNCED" chip lives in the shared
+ * HeaderStatusChip in the top bar — this component now also pushes the
+ * sync state into it via <HeaderStatusMode/>.
  */
 
 import { useRef } from "react";
 import { useRouter } from "next/navigation";
-import { useRealtimeEvent, useRealtimeStatus } from "@/components/realtime/realtime-provider";
+import { useRealtimeEvent } from "@/components/realtime/realtime-provider";
+import { HeaderStatusMode } from "@/components/realtime/header-status-chip";
 
 interface Props {
   inSync: boolean;
@@ -20,7 +23,6 @@ interface Props {
 
 export function ServersPageHeartbeat({ inSync }: Props) {
   const router = useRouter();
-  const { status, enabled, setEnabled } = useRealtimeStatus();
   const lastRefreshAt = useRef<number>(0);
 
   useRealtimeEvent(
@@ -38,47 +40,5 @@ export function ServersPageHeartbeat({ inSync }: Props) {
     },
   );
 
-  const fastMode = !inSync;
-
-  return (
-    <button
-      type="button"
-      onClick={() => setEnabled(!enabled)}
-      title={
-        status === "live"
-          ? fastMode
-            ? "Replication in flight — waiting for AXFR to complete."
-            : "Synced — click to pause."
-          : status === "paused"
-            ? "Live updates paused — click to resume"
-            : status === "connecting"
-              ? "Connecting…"
-              : "Connection lost — auto-retrying"
-      }
-      className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase hover:bg-[color:var(--color-bg-subtle)]"
-    >
-      <span
-        className={`inline-block h-2 w-2 rounded-full ${
-          status === "live"
-            ? fastMode
-              ? "animate-pulse bg-[color:var(--color-warn)]"
-              : "animate-pulse bg-[color:var(--color-success)]"
-            : status === "connecting"
-              ? "bg-[color:var(--color-warn)]"
-              : status === "paused"
-                ? "bg-[color:var(--color-fg-subtle)]"
-                : "bg-[color:var(--color-error)]"
-        }`}
-      />
-      {status === "live"
-        ? fastMode
-          ? "desynced"
-          : "synced"
-        : status === "connecting"
-          ? "connecting"
-          : status === "paused"
-            ? "paused"
-            : "offline"}
-    </button>
-  );
+  return <HeaderStatusMode kind="sync" inSync={inSync} />;
 }

--- a/app/(app)/admin/servers/page.tsx
+++ b/app/(app)/admin/servers/page.tsx
@@ -20,7 +20,9 @@ import { latestAdminEditTimestampsForServers } from "@/lib/db/repositories/audit
 import { freshnessOf } from "@/lib/freshness";
 import { rawCache } from "@/lib/pdns/zone-state-cache";
 import { derivedParentOf } from "@/lib/pdns/topology-cache";
-import { isReadOnlyMirror, summarizeCapabilities } from "@/lib/pdns/capabilities";
+import { isReadOnlyMirror } from "@/lib/pdns/capabilities";
+import { CapabilityBadges } from "@/components/domain/capability-badges";
+import { ClickableTr, ClickableDiv } from "@/components/ui/clickable-row";
 import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
 import { backendUnreachability } from "@/lib/realtime/backend-status";
 import type { PdnsServer } from "@/lib/db/schema";
@@ -409,7 +411,8 @@ function ServerRow({
   reachability,
 }: ServerRowProps) {
   return (
-    <tr
+    <ClickableTr
+      href={`/admin/servers/${row.id}`}
       className={`border-t border-[color:var(--color-border)] ${serverRowAttentionClass(
         row.disabledAt,
         row.lastSeenAt,
@@ -424,15 +427,7 @@ function ServerRow({
             </span>
           ) : null}
           <div className="font-medium">{row.name}</div>
-          <span
-            className={
-              isReadOnlyMirror(row.capabilities)
-                ? "rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] px-1.5 py-0.5 font-mono text-[0.6rem] font-medium text-[color:var(--color-fg-muted)]"
-                : "rounded-full border border-[color:var(--color-accent)] bg-[color-mix(in_oklch,var(--color-accent)_12%,transparent)] px-1.5 py-0.5 font-mono text-[0.6rem] font-medium text-[color:var(--color-accent)]"
-            }
-          >
-            {summarizeCapabilities(row.capabilities)}
-          </span>
+          <CapabilityBadges capabilities={row.capabilities} />
         </div>
         <div className="mt-0.5 text-xs text-[color:var(--color-fg-muted)]">
           {row.slug}
@@ -482,7 +477,7 @@ function ServerRow({
           </Link>
         </span>
       </td>
-    </tr>
+    </ClickableTr>
   );
 }
 
@@ -490,7 +485,8 @@ function ServerRow({
 function ServerCard({ row, canReadAudit, lastEdits, syncChip, reachability }: ServerRowProps) {
   const isMirror = isReadOnlyMirror(row.capabilities);
   return (
-    <div
+    <ClickableDiv
+      href={`/admin/servers/${row.id}`}
       className={`rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-4 ${serverRowAttentionClass(
         row.disabledAt,
         row.lastSeenAt,
@@ -499,15 +495,7 @@ function ServerCard({ row, canReadAudit, lastEdits, syncChip, reachability }: Se
     >
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-base font-medium">{row.name}</span>
-        <span
-          className={
-            isMirror
-              ? "rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] px-1.5 py-0.5 font-mono text-[0.6rem] font-medium text-[color:var(--color-fg-muted)]"
-              : "rounded-full border border-[color:var(--color-accent)] bg-[color-mix(in_oklch,var(--color-accent)_12%,transparent)] px-1.5 py-0.5 font-mono text-[0.6rem] font-medium text-[color:var(--color-accent)]"
-          }
-        >
-          {summarizeCapabilities(row.capabilities)}
-        </span>
+        <CapabilityBadges capabilities={row.capabilities} />
         {row.isDefault ? (
           <span className="rounded bg-[color:var(--color-bg-muted)] px-1.5 py-0.5 text-[0.65rem] tracking-wide uppercase">
             default
@@ -558,7 +546,7 @@ function ServerCard({ row, canReadAudit, lastEdits, syncChip, reachability }: Se
           Edit
         </Link>
       </div>
-    </div>
+    </ClickableDiv>
   );
 }
 

--- a/app/(app)/admin/servers/page.tsx
+++ b/app/(app)/admin/servers/page.tsx
@@ -23,6 +23,7 @@ import { derivedParentOf } from "@/lib/pdns/topology-cache";
 import { isReadOnlyMirror } from "@/lib/pdns/capabilities";
 import { CapabilityBadges } from "@/components/domain/capability-badges";
 import { ClickableTr, ClickableDiv } from "@/components/ui/clickable-row";
+import { SyncIndicator } from "@/components/ui/sync-indicator";
 import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
 import { backendUnreachability } from "@/lib/realtime/backend-status";
 import type { PdnsServer } from "@/lib/db/schema";
@@ -197,19 +198,21 @@ export default async function PdnsServersListPage() {
             ) : null}
           </div>
 
-          {/* Desktop (md+): the dense grouped table. */}
-          <div className="hidden overflow-hidden rounded-md border border-[color:var(--color-border)] md:block">
+          {/* Desktop (md+): the dense grouped table. Header + row styling kept
+              in lock-step with components/ui/data-table.tsx so the bespoke
+              grouped layout reads as one of the standard tables. */}
+          <div className="hidden overflow-hidden rounded-lg border border-[color:var(--color-border)] md:block">
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
-                <thead className="bg-[color:var(--color-bg-subtle)] text-left text-xs tracking-wide text-[color:var(--color-fg-muted)] uppercase">
+                <thead className="bg-[color:var(--color-bg-muted)] text-left text-xs font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">
                   <tr>
-                    <th className="px-4 py-2">Name</th>
-                    <th className="px-4 py-2">Base URL</th>
-                    <th className="px-4 py-2">Status</th>
-                    <th className="px-4 py-2">Version</th>
-                    <th className="px-4 py-2">Sync</th>
-                    {canReadAudit ? <th className="px-4 py-2">Last admin edit</th> : null}
-                    <th className="w-px px-4 py-2 whitespace-nowrap"></th>
+                    <th className="px-4 py-2.5">Name</th>
+                    <th className="px-4 py-2.5">Base URL</th>
+                    <th className="px-4 py-2.5">Status</th>
+                    <th className="px-4 py-2.5">Version</th>
+                    <th className="px-4 py-2.5">Sync</th>
+                    {canReadAudit ? <th className="px-4 py-2.5">Last admin edit</th> : null}
+                    <th className="w-px px-4 py-2.5 whitespace-nowrap"></th>
                   </tr>
                 </thead>
                 <tbody>
@@ -410,16 +413,19 @@ function ServerRow({
   syncChip,
   reachability,
 }: ServerRowProps) {
+  // Mirror DataTable's row styling exactly. The attention tint (warn/error
+  // backgrounds for not-yet-reached / unreachable rows) replaces the
+  // even-stripe on those rows — they're already noisier than a stripe, and
+  // letting both render would mean the same status renders differently
+  // depending on row parity.
+  const attentionClass = serverRowAttentionClass(row.disabledAt, row.lastSeenAt, reachability);
+  const stripeClass = attentionClass ? "" : "even:bg-[color:var(--color-bg-subtle)]";
   return (
     <ClickableTr
       href={`/admin/servers/${row.id}`}
-      className={`border-t border-[color:var(--color-border)] ${serverRowAttentionClass(
-        row.disabledAt,
-        row.lastSeenAt,
-        reachability,
-      )}`}
+      className={`border-t border-[color:var(--color-border)] transition-colors hover:bg-[color-mix(in_oklch,var(--color-accent)_14%,transparent)] ${stripeClass} ${attentionClass}`}
     >
-      <td className={`px-4 py-3 ${indented ? "pl-10" : ""}`}>
+      <td className={`px-4 py-3 align-top ${indented ? "pl-10" : ""}`}>
         <div className="flex items-center gap-2">
           {indented ? (
             <span aria-hidden className="font-mono text-[color:var(--color-fg-subtle)] select-none">
@@ -443,20 +449,20 @@ function ServerRow({
           </div>
         ) : null}
       </td>
-      <td className="px-4 py-3 font-mono text-xs">{row.baseUrl}</td>
-      <td className="px-4 py-3">
+      <td className="px-4 py-3 align-top font-mono text-xs">{row.baseUrl}</td>
+      <td className="px-4 py-3 align-top">
         <HealthBadge
           disabledAt={row.disabledAt}
           lastSeenAt={row.lastSeenAt}
           reachability={reachability}
         />
       </td>
-      <td className="px-4 py-3 text-xs">{row.versionCache?.version ?? "—"}</td>
-      <td className="px-4 py-3 text-xs">
+      <td className="px-4 py-3 align-top text-xs">{row.versionCache?.version ?? "—"}</td>
+      <td className="px-4 py-3 align-top text-xs">
         <SyncChip verdict={syncChip} isMirror={isReadOnlyMirror(row.capabilities)} />
       </td>
       {canReadAudit ? (
-        <td className="px-4 py-3 text-xs text-[color:var(--color-fg-muted)]">
+        <td className="px-4 py-3 align-top text-xs text-[color:var(--color-fg-muted)]">
           {lastEdits.has(row.id) ? (
             <span title={lastEdits.get(row.id)!.toISOString()}>
               {freshnessOf(lastEdits.get(row.id)!.toISOString()).label}
@@ -466,7 +472,7 @@ function ServerRow({
           )}
         </td>
       ) : null}
-      <td className="w-px px-4 py-3 text-right whitespace-nowrap">
+      <td className="w-px px-4 py-3 text-right align-top whitespace-nowrap">
         <span className="inline-flex items-center gap-2">
           <TestServerButton serverId={row.id} />
           <Link
@@ -574,15 +580,15 @@ function SyncChip({ verdict, isMirror }: { verdict: SyncVerdict | null; isMirror
   }
   if (verdict === "in-sync") {
     return (
-      <span className="inline-flex items-center gap-1">
-        <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--color-success)]" />
+      <span className="inline-flex items-center gap-1.5">
+        <SyncIndicator state="synced" />
         Synced
       </span>
     );
   }
   return (
-    <span className="inline-flex items-center gap-1 text-[color:var(--color-warn)]">
-      <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--color-warn)]" />
+    <span className="inline-flex items-center gap-1.5 text-[color:var(--color-error)]">
+      <SyncIndicator state="desynced" />
       Desynced
     </span>
   );

--- a/app/(app)/admin/servers/page.tsx
+++ b/app/(app)/admin/servers/page.tsx
@@ -107,14 +107,14 @@ export default async function PdnsServersListPage() {
 
   return (
     <div className="space-y-6">
-      <header className="flex items-end justify-between">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">PowerDNS servers</h1>
           <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">
             One row per upstream PowerDNS Authoritative backend.
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {servers.some((s) => s.disabledAt === null) ? (
             <ServersPageHeartbeat inSync={!anyLagging} />
           ) : null}
@@ -133,95 +133,167 @@ export default async function PdnsServersListPage() {
       {servers.length === 0 ? (
         <EmptyState canCreate={canCreate} />
       ) : (
-        <div className="overflow-hidden rounded-md border border-[color:var(--color-border)]">
-          <table className="w-full text-sm">
-            <thead className="bg-[color:var(--color-bg-subtle)] text-left text-xs tracking-wide text-[color:var(--color-fg-muted)] uppercase">
-              <tr>
-                <th className="px-4 py-2">Name</th>
-                <th className="px-4 py-2">Base URL</th>
-                <th className="px-4 py-2">Status</th>
-                <th className="px-4 py-2">Version</th>
-                <th className="px-4 py-2">Sync</th>
-                {canReadAudit ? <th className="px-4 py-2">Last admin edit</th> : null}
-                <th className="px-4 py-2"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {primaries.map((primary) => {
-                const kids = secondariesByPrimary.get(primary.id) ?? [];
-                return (
-                  <Fragment key={primary.id}>
-                    <ServerRow
-                      row={primary}
-                      indented={false}
-                      canReadAudit={canReadAudit}
-                      lastEdits={lastEdits}
-                      syncChip={null}
-                      reachability={reachability.get(primary.id)}
-                    />
-                    {kids.map((s) => (
-                      <ServerRow
-                        key={s.id}
-                        row={s}
-                        indented={true}
-                        canReadAudit={canReadAudit}
-                        lastEdits={lastEdits}
-                        syncChip={syncBySecondary.get(s.id) ?? null}
-                        reachability={reachability.get(s.id)}
-                      />
-                    ))}
-                  </Fragment>
-                );
-              })}
-              {standaloneSecondaries.length > 0 ? (
-                <Fragment>
-                  <tr className="border-t border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)]">
-                    <td
-                      colSpan={canReadAudit ? 7 : 6}
-                      className="px-4 py-1.5 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase"
-                    >
-                      Standalone secondaries (mirror an external / unmanaged primary)
-                    </td>
-                  </tr>
-                  {standaloneSecondaries.map((s) => (
-                    <ServerRow
+        <>
+          {/* Mobile (< md): a card per backend, preserving the primary →
+              secondary grouping. Avoids the wide table overflowing the phone. */}
+          <div className="space-y-3 md:hidden">
+            {primaries.map((primary) => {
+              const kids = secondariesByPrimary.get(primary.id) ?? [];
+              return (
+                <Fragment key={primary.id}>
+                  <ServerCard
+                    row={primary}
+                    indented={false}
+                    canReadAudit={canReadAudit}
+                    lastEdits={lastEdits}
+                    syncChip={null}
+                    reachability={reachability.get(primary.id)}
+                  />
+                  {kids.map((s) => (
+                    <ServerCard
                       key={s.id}
                       row={s}
-                      indented={true}
+                      indented
                       canReadAudit={canReadAudit}
                       lastEdits={lastEdits}
-                      syncChip={null}
+                      syncChip={syncBySecondary.get(s.id) ?? null}
                       reachability={reachability.get(s.id)}
                     />
                   ))}
                 </Fragment>
-              ) : null}
-              {orphanSecondaries.length > 0 ? (
-                <Fragment>
-                  <tr className="border-t border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)]">
-                    <td
-                      colSpan={canReadAudit ? 7 : 6}
-                      className="px-4 py-1.5 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase"
-                    >
-                      Orphan secondaries (parent disabled or deleted)
-                    </td>
+              );
+            })}
+            {standaloneSecondaries.length > 0 ? (
+              <>
+                <ServersGroupHeading>
+                  Standalone secondaries (mirror an external / unmanaged primary)
+                </ServersGroupHeading>
+                {standaloneSecondaries.map((s) => (
+                  <ServerCard
+                    key={s.id}
+                    row={s}
+                    indented
+                    canReadAudit={canReadAudit}
+                    lastEdits={lastEdits}
+                    syncChip={null}
+                    reachability={reachability.get(s.id)}
+                  />
+                ))}
+              </>
+            ) : null}
+            {orphanSecondaries.length > 0 ? (
+              <>
+                <ServersGroupHeading>
+                  Orphan secondaries (parent disabled or deleted)
+                </ServersGroupHeading>
+                {orphanSecondaries.map((s) => (
+                  <ServerCard
+                    key={s.id}
+                    row={s}
+                    indented
+                    canReadAudit={canReadAudit}
+                    lastEdits={lastEdits}
+                    syncChip={null}
+                    reachability={reachability.get(s.id)}
+                  />
+                ))}
+              </>
+            ) : null}
+          </div>
+
+          {/* Desktop (md+): the dense grouped table. */}
+          <div className="hidden overflow-hidden rounded-md border border-[color:var(--color-border)] md:block">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-[color:var(--color-bg-subtle)] text-left text-xs tracking-wide text-[color:var(--color-fg-muted)] uppercase">
+                  <tr>
+                    <th className="px-4 py-2">Name</th>
+                    <th className="px-4 py-2">Base URL</th>
+                    <th className="px-4 py-2">Status</th>
+                    <th className="px-4 py-2">Version</th>
+                    <th className="px-4 py-2">Sync</th>
+                    {canReadAudit ? <th className="px-4 py-2">Last admin edit</th> : null}
+                    <th className="px-4 py-2"></th>
                   </tr>
-                  {orphanSecondaries.map((s) => (
-                    <ServerRow
-                      key={s.id}
-                      row={s}
-                      indented={true}
-                      canReadAudit={canReadAudit}
-                      lastEdits={lastEdits}
-                      syncChip={null}
-                      reachability={reachability.get(s.id)}
-                    />
-                  ))}
-                </Fragment>
-              ) : null}
-            </tbody>
-          </table>
-        </div>
+                </thead>
+                <tbody>
+                  {primaries.map((primary) => {
+                    const kids = secondariesByPrimary.get(primary.id) ?? [];
+                    return (
+                      <Fragment key={primary.id}>
+                        <ServerRow
+                          row={primary}
+                          indented={false}
+                          canReadAudit={canReadAudit}
+                          lastEdits={lastEdits}
+                          syncChip={null}
+                          reachability={reachability.get(primary.id)}
+                        />
+                        {kids.map((s) => (
+                          <ServerRow
+                            key={s.id}
+                            row={s}
+                            indented={true}
+                            canReadAudit={canReadAudit}
+                            lastEdits={lastEdits}
+                            syncChip={syncBySecondary.get(s.id) ?? null}
+                            reachability={reachability.get(s.id)}
+                          />
+                        ))}
+                      </Fragment>
+                    );
+                  })}
+                  {standaloneSecondaries.length > 0 ? (
+                    <Fragment>
+                      <tr className="border-t border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)]">
+                        <td
+                          colSpan={canReadAudit ? 7 : 6}
+                          className="px-4 py-1.5 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase"
+                        >
+                          Standalone secondaries (mirror an external / unmanaged primary)
+                        </td>
+                      </tr>
+                      {standaloneSecondaries.map((s) => (
+                        <ServerRow
+                          key={s.id}
+                          row={s}
+                          indented={true}
+                          canReadAudit={canReadAudit}
+                          lastEdits={lastEdits}
+                          syncChip={null}
+                          reachability={reachability.get(s.id)}
+                        />
+                      ))}
+                    </Fragment>
+                  ) : null}
+                  {orphanSecondaries.length > 0 ? (
+                    <Fragment>
+                      <tr className="border-t border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)]">
+                        <td
+                          colSpan={canReadAudit ? 7 : 6}
+                          className="px-4 py-1.5 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase"
+                        >
+                          Orphan secondaries (parent disabled or deleted)
+                        </td>
+                      </tr>
+                      {orphanSecondaries.map((s) => (
+                        <ServerRow
+                          key={s.id}
+                          row={s}
+                          indented={true}
+                          canReadAudit={canReadAudit}
+                          lastEdits={lastEdits}
+                          syncChip={null}
+                          reachability={reachability.get(s.id)}
+                        />
+                      ))}
+                    </Fragment>
+                  ) : null}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
       )}
     </div>
   );
@@ -309,11 +381,16 @@ function HealthBadge({
   // this is always seconds old ("· just now"); the red state above (not this
   // label) is what conveys an outage.
   const fresh = freshnessOf(lastSeenAt.toISOString());
+  // "Reachable" on its own line with the last-contact label stacked beneath it
+  // (aligned under the text, no separator). Avoids the ragged "Reachable ·"
+  // wrap when the Status column is narrow.
   return (
-    <span className="inline-flex items-center gap-1 text-xs">
-      <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--color-success)]" />
-      Reachable
-      <span className="text-[color:var(--color-fg-muted)]">· {fresh.label}</span>
+    <span className="inline-flex flex-col gap-0.5 text-xs">
+      <span className="inline-flex items-center gap-1">
+        <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--color-success)]" />
+        Reachable
+      </span>
+      <span className="pl-2.5 text-[color:var(--color-fg-muted)]">{fresh.label}</span>
     </span>
   );
 }
@@ -412,6 +489,99 @@ function ServerRow({
         </span>
       </td>
     </tr>
+  );
+}
+
+/** Mobile (< md) card rendering of a server row — same data as ServerRow. */
+function ServerCard({ row, canReadAudit, lastEdits, syncChip, reachability }: ServerRowProps) {
+  const isMirror = isReadOnlyMirror(row.capabilities);
+  return (
+    <div
+      className={`rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-4 ${serverRowAttentionClass(
+        row.disabledAt,
+        row.lastSeenAt,
+        reachability,
+      )}`}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-base font-medium">{row.name}</span>
+        <span
+          className={
+            isMirror
+              ? "rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] px-1.5 py-0.5 font-mono text-[0.6rem] font-medium text-[color:var(--color-fg-muted)]"
+              : "rounded-full border border-[color:var(--color-accent)] bg-[color-mix(in_oklch,var(--color-accent)_12%,transparent)] px-1.5 py-0.5 font-mono text-[0.6rem] font-medium text-[color:var(--color-accent)]"
+          }
+        >
+          {summarizeCapabilities(row.capabilities)}
+        </span>
+        {row.isDefault ? (
+          <span className="rounded bg-[color:var(--color-bg-muted)] px-1.5 py-0.5 text-[0.65rem] tracking-wide uppercase">
+            default
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-0.5 text-xs text-[color:var(--color-fg-muted)]">{row.slug}</div>
+      {row.description ? (
+        <div className="mt-1 text-xs text-[color:var(--color-fg-muted)] italic">
+          {row.description}
+        </div>
+      ) : null}
+
+      <dl className="mt-3 text-sm">
+        <Field label="Base URL">
+          <span className="font-mono text-xs break-all">{row.baseUrl}</span>
+        </Field>
+        <Field label="Status">
+          <HealthBadge
+            disabledAt={row.disabledAt}
+            lastSeenAt={row.lastSeenAt}
+            reachability={reachability}
+          />
+        </Field>
+        <Field label="Version">
+          <span className="text-xs">{row.versionCache?.version ?? "—"}</span>
+        </Field>
+        <Field label="Sync">
+          <SyncChip verdict={syncChip} isMirror={isMirror} />
+        </Field>
+        {canReadAudit ? (
+          <Field label="Last admin edit">
+            <span className="text-xs text-[color:var(--color-fg-muted)]">
+              {lastEdits.has(row.id)
+                ? freshnessOf(lastEdits.get(row.id)!.toISOString()).label
+                : "—"}
+            </span>
+          </Field>
+        ) : null}
+      </dl>
+
+      <div className="mt-3 flex items-center gap-3">
+        <TestServerButton serverId={row.id} />
+        <Link
+          href={`/admin/servers/${row.id}`}
+          className="text-[color:var(--color-accent)] hover:underline"
+        >
+          Edit
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex justify-between gap-3 border-t border-[color:var(--color-border)] py-1.5 first:border-t-0">
+      <dt className="shrink-0 text-[color:var(--color-fg-muted)]">{label}</dt>
+      <dd className="min-w-0 text-right">{children}</dd>
+    </div>
+  );
+}
+
+function ServersGroupHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="px-1 pt-2 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">
+      {children}
+    </div>
   );
 }
 

--- a/app/(app)/admin/servers/page.tsx
+++ b/app/(app)/admin/servers/page.tsx
@@ -13,6 +13,7 @@
 import type { Metadata } from "next";
 import { Fragment } from "react";
 import Link from "next/link";
+import { CreateButton } from "@/components/ui/create-button";
 import { requireUserForPage } from "@/lib/auth/require-user";
 import { listAllPdnsServers } from "@/lib/db/repositories/pdns-servers";
 import { latestAdminEditTimestampsForServers } from "@/lib/db/repositories/audit-log";
@@ -114,19 +115,12 @@ export default async function PdnsServersListPage() {
             One row per upstream PowerDNS Authoritative backend.
           </p>
         </div>
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2 [&>*]:w-full sm:[&>*]:w-auto">
           {servers.some((s) => s.disabledAt === null) ? (
             <ServersPageHeartbeat inSync={!anyLagging} />
           ) : null}
           {servers.some((s) => s.disabledAt === null) ? <RefreshAllButton /> : null}
-          {canCreate ? (
-            <Link
-              href="/admin/servers/new"
-              className="rounded-md bg-[color:var(--color-accent)] px-4 py-2 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95"
-            >
-              Add server
-            </Link>
-          ) : null}
+          {canCreate ? <CreateButton href="/admin/servers/new" label="Add server" /> : null}
         </div>
       </header>
 
@@ -213,7 +207,7 @@ export default async function PdnsServersListPage() {
                     <th className="px-4 py-2">Version</th>
                     <th className="px-4 py-2">Sync</th>
                     {canReadAudit ? <th className="px-4 py-2">Last admin edit</th> : null}
-                    <th className="px-4 py-2"></th>
+                    <th className="w-px px-4 py-2 whitespace-nowrap"></th>
                   </tr>
                 </thead>
                 <tbody>
@@ -477,7 +471,7 @@ function ServerRow({
           )}
         </td>
       ) : null}
-      <td className="px-4 py-3 text-right">
+      <td className="w-px px-4 py-3 text-right whitespace-nowrap">
         <span className="inline-flex items-center gap-2">
           <TestServerButton serverId={row.id} />
           <Link

--- a/app/(app)/admin/teams/_components/create-team-form.tsx
+++ b/app/(app)/admin/teams/_components/create-team-form.tsx
@@ -122,7 +122,7 @@ export function CreateTeamForm() {
           disabled={loading}
           className="rounded-md bg-[color:var(--color-accent)] px-4 py-2 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95 disabled:opacity-50"
         >
-          {loading ? "Creating…" : "Create team"}
+          {loading ? "Adding…" : "Add team"}
         </button>
         <button
           type="button"

--- a/app/(app)/admin/teams/_components/team-members-panel.tsx
+++ b/app/(app)/admin/teams/_components/team-members-panel.tsx
@@ -110,26 +110,29 @@ export function TeamMembersPanel(props: PanelProps) {
       {props.members.length === 0 ? (
         <p className="text-sm text-[color:var(--color-fg-muted)]">No members yet.</p>
       ) : (
-        <div className="overflow-hidden rounded-md border border-[color:var(--color-border)]">
+        <div className="overflow-hidden rounded-lg border border-[color:var(--color-border)]">
           <table className="w-full text-sm">
-            <thead className="bg-[color:var(--color-bg-subtle)] text-left text-xs tracking-wide text-[color:var(--color-fg-muted)] uppercase">
+            <thead className="bg-[color:var(--color-bg-muted)] text-left text-xs font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">
               <tr>
-                <th className="px-4 py-2">Email</th>
-                <th className="px-4 py-2">Role</th>
-                <th className="px-4 py-2">Joined</th>
-                <th className="px-4 py-2"></th>
+                <th className="px-4 py-2.5">Email</th>
+                <th className="px-4 py-2.5">Role</th>
+                <th className="px-4 py-2.5">Joined</th>
+                <th className="px-4 py-2.5"></th>
               </tr>
             </thead>
             <tbody>
               {props.members.map((m) => (
-                <tr key={m.userId} className="border-t border-[color:var(--color-border)]">
-                  <td className="px-4 py-3">
+                <tr
+                  key={m.userId}
+                  className="border-t border-[color:var(--color-border)] transition-colors even:bg-[color:var(--color-bg-subtle)] hover:bg-[color-mix(in_oklch,var(--color-accent)_14%,transparent)]"
+                >
+                  <td className="px-4 py-3 align-top">
                     <div className="font-medium">{m.email}</div>
                     {m.name ? (
                       <div className="text-xs text-[color:var(--color-fg-muted)]">{m.name}</div>
                     ) : null}
                   </td>
-                  <td className="px-4 py-3 text-xs">
+                  <td className="px-4 py-3 align-top text-xs">
                     {props.canManage ? (
                       <SelectMenu
                         value={m.teamRole}
@@ -145,10 +148,10 @@ export function TeamMembersPanel(props: PanelProps) {
                       m.teamRole
                     )}
                   </td>
-                  <td className="px-4 py-3 text-xs">
+                  <td className="px-4 py-3 align-top text-xs">
                     <LocalTime ts={m.addedAt} />
                   </td>
-                  <td className="px-4 py-3 text-right">
+                  <td className="px-4 py-3 text-right align-top">
                     {props.canManage ? (
                       <button
                         type="button"

--- a/app/(app)/admin/teams/_components/teams-table.tsx
+++ b/app/(app)/admin/teams/_components/teams-table.tsx
@@ -93,6 +93,7 @@ export function TeamsTable({
       initialSort={[{ id: "name", desc: false }]}
       sortParam="sort"
       pageSizeParam="pageSize"
+      rowHref={(r) => `/admin/teams/${r.id}`}
     />
   );
 }

--- a/app/(app)/admin/teams/page.tsx
+++ b/app/(app)/admin/teams/page.tsx
@@ -3,8 +3,8 @@
  */
 
 import type { Metadata } from "next";
-import Link from "next/link";
 import { requireUserForPage } from "@/lib/auth/require-user";
+import { CreateButton } from "@/components/ui/create-button";
 import { countMembersByTeam, listAllTeams } from "@/lib/db/repositories/teams";
 import { latestAdminEditTimestampsForTeams } from "@/lib/db/repositories/audit-log";
 import { TeamsTable, type TeamRow } from "./_components/teams-table";
@@ -31,14 +31,7 @@ export default async function TeamsListPage() {
             {teams.length} team{teams.length === 1 ? "" : "s"}.
           </p>
         </div>
-        {canCreate ? (
-          <Link
-            href="/admin/teams/new"
-            className="rounded-md bg-[color:var(--color-accent)] px-4 py-2 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95"
-          >
-            Add team
-          </Link>
-        ) : null}
+        {canCreate ? <CreateButton href="/admin/teams/new" label="Add team" /> : null}
       </header>
 
       {teams.length === 0 ? (

--- a/app/(app)/admin/teams/page.tsx
+++ b/app/(app)/admin/teams/page.tsx
@@ -24,7 +24,7 @@ export default async function TeamsListPage() {
 
   return (
     <div className="space-y-6">
-      <header className="flex items-end justify-between">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Teams</h1>
           <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">

--- a/app/(app)/admin/tsig-keys/_components/tsig-actions.tsx
+++ b/app/(app)/admin/tsig-keys/_components/tsig-actions.tsx
@@ -16,11 +16,13 @@
  */
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Plus } from "lucide-react";
+import { type ColumnDef } from "@tanstack/react-table";
 import { useDialog } from "@/components/ui/dialog";
 import { mutate } from "@/lib/client/api-fetch";
 import { createCtaClass } from "@/components/ui/create-button";
+import { DataTable } from "@/components/ui/data-table";
 import { TsigKeyWizard, type InstallSecondary } from "./tsig-key-wizard";
 
 interface Row {
@@ -135,63 +137,14 @@ export function TsigActions({ serverSlug, rows, isPrimary, secondaries, zones }:
       </div>
 
       {rows !== null ? (
-        <div className="overflow-hidden rounded-md border border-[color:var(--color-border)]">
-          <table className="w-full text-sm">
-            <thead className="bg-[color:var(--color-bg-subtle)] text-left text-xs tracking-wide text-[color:var(--color-fg-muted)] uppercase">
-              <tr>
-                <th className="px-4 py-2">Name</th>
-                <th className="px-4 py-2">Algorithm</th>
-                <th className="px-4 py-2"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {keys.map((row) => (
-                <tr key={row.id} className="border-t border-[color:var(--color-border)]">
-                  <td className="px-4 py-3 font-mono text-xs">{row.name}</td>
-                  <td className="px-4 py-3">
-                    <span className="rounded bg-[color:var(--color-bg-muted)] px-2 py-0.5 font-mono text-xs">
-                      {row.algorithm}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    <div className="flex justify-end gap-1.5">
-                      {canInstall ? (
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setWizard({ mode: "existing", keyId: row.id, keyName: row.name })
-                          }
-                          className="rounded border border-[color:var(--color-border)] px-2 py-1 text-xs hover:bg-[color:var(--color-bg-muted)]"
-                        >
-                          Set up
-                        </button>
-                      ) : null}
-                      <button
-                        type="button"
-                        onClick={() => handleDelete(row)}
-                        disabled={deletingId === row.id}
-                        className="rounded border border-[color:var(--color-error)] px-2 py-1 text-xs text-[color:var(--color-error)] hover:bg-[color:var(--color-error)]/10 disabled:opacity-50"
-                      >
-                        {deletingId === row.id ? "Deleting…" : "Delete"}
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-              {keys.length === 0 ? (
-                <tr className="border-t border-[color:var(--color-border)]">
-                  <td
-                    colSpan={3}
-                    className="px-4 py-6 text-center text-[color:var(--color-fg-muted)]"
-                  >
-                    No TSIG keys configured on <code>{serverSlug}</code>. AXFR and NOTIFY between
-                    this backend and its peers happens without shared-secret authentication.
-                  </td>
-                </tr>
-              ) : null}
-            </tbody>
-          </table>
-        </div>
+        <TsigKeysTable
+          serverSlug={serverSlug}
+          keys={keys}
+          canInstall={canInstall}
+          busyDeleteId={deletingId}
+          onDelete={handleDelete}
+          onSetUp={(row) => setWizard({ mode: "existing", keyId: row.id, keyName: row.name })}
+        />
       ) : null}
 
       {wizard ? (
@@ -212,5 +165,83 @@ export function TsigActions({ serverSlug, rows, isPrimary, secondaries, zones }:
         />
       ) : null}
     </section>
+  );
+}
+
+function TsigKeysTable({
+  serverSlug,
+  keys,
+  canInstall,
+  busyDeleteId,
+  onDelete,
+  onSetUp,
+}: {
+  serverSlug: string;
+  keys: Row[];
+  canInstall: boolean;
+  busyDeleteId: string | null;
+  onDelete: (row: Row) => void;
+  onSetUp: (row: Row) => void;
+}) {
+  const columns = useMemo<Array<ColumnDef<Row, unknown>>>(
+    () => [
+      {
+        accessorKey: "name",
+        header: "Name",
+        cell: (ctx) => <span className="font-mono text-xs">{ctx.getValue<string>()}</span>,
+      },
+      {
+        accessorKey: "algorithm",
+        header: "Algorithm",
+        cell: (ctx) => (
+          <span className="rounded bg-[color:var(--color-bg-muted)] px-2 py-0.5 font-mono text-xs">
+            {ctx.getValue<string>()}
+          </span>
+        ),
+      },
+      {
+        id: "actions",
+        header: "",
+        enableSorting: false,
+        cell: (ctx) => {
+          const row = ctx.row.original;
+          return (
+            <div className="flex justify-end gap-1.5">
+              {canInstall ? (
+                <button
+                  type="button"
+                  onClick={() => onSetUp(row)}
+                  className="rounded border border-[color:var(--color-border)] px-2 py-1 text-xs hover:bg-[color:var(--color-bg-muted)]"
+                >
+                  Set up
+                </button>
+              ) : null}
+              <button
+                type="button"
+                onClick={() => onDelete(row)}
+                disabled={busyDeleteId === row.id}
+                className="rounded border border-[color:var(--color-error)] px-2 py-1 text-xs text-[color:var(--color-error)] hover:bg-[color:var(--color-error)]/10 disabled:opacity-50"
+              >
+                {busyDeleteId === row.id ? "Deleting…" : "Delete"}
+              </button>
+            </div>
+          );
+        },
+      },
+    ],
+    [canInstall, busyDeleteId, onDelete, onSetUp],
+  );
+
+  return (
+    <DataTable
+      data={keys}
+      columns={columns}
+      pageSize={Math.max(keys.length, 10)}
+      hidePagination
+      hideSearch
+      stateKey={`tsig:${serverSlug}`}
+      emptyMessage="No keys match."
+      noDataMessage={`No TSIG keys configured on ${serverSlug}. AXFR and NOTIFY between this backend and its peers happens without shared-secret authentication.`}
+    />
   );
 }

--- a/app/(app)/admin/tsig-keys/_components/tsig-actions.tsx
+++ b/app/(app)/admin/tsig-keys/_components/tsig-actions.tsx
@@ -17,8 +17,10 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { Plus } from "lucide-react";
 import { useDialog } from "@/components/ui/dialog";
 import { mutate } from "@/lib/client/api-fetch";
+import { createCtaClass } from "@/components/ui/create-button";
 import { TsigKeyWizard, type InstallSecondary } from "./tsig-key-wizard";
 
 interface Row {
@@ -125,9 +127,10 @@ export function TsigActions({ serverSlug, rows, isPrimary, secondaries, zones }:
         <button
           type="button"
           onClick={() => setWizard({ mode: "create" })}
-          className="rounded-md bg-[color:var(--color-accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95"
+          className={createCtaClass}
         >
-          Create key
+          <Plus className="h-4 w-4" aria-hidden />
+          Add TSIG key
         </button>
       </div>
 

--- a/app/(app)/admin/tsig-keys/_components/tsig-key-wizard.tsx
+++ b/app/(app)/admin/tsig-keys/_components/tsig-key-wizard.tsx
@@ -280,7 +280,7 @@ export function TsigKeyWizard({
         <div
           role="dialog"
           aria-modal="true"
-          aria-label="Create TSIG key"
+          aria-label="Add TSIG key"
           className="relative w-full max-w-lg rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-6 shadow-xl"
         >
           <div className="flex items-baseline justify-between">

--- a/app/(app)/admin/tsig-keys/_components/tsig-keys-readonly.tsx
+++ b/app/(app)/admin/tsig-keys/_components/tsig-keys-readonly.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+/**
+ * Read-only TSIG keys table for operators with `tsig.read` but not
+ * `tsig.manage`. Same column shape as the writable variant in
+ * <TsigActions/>, just no per-row actions — funnels both views onto the
+ * shared <DataTable> so the mobile-card layout, sort, and spacing match.
+ */
+
+import { useMemo } from "react";
+import { type ColumnDef } from "@tanstack/react-table";
+import { DataTable } from "@/components/ui/data-table";
+
+interface Row {
+  id: string;
+  name: string;
+  algorithm: string;
+}
+
+export function TsigKeysReadOnly({ serverSlug, rows }: { serverSlug: string; rows: Row[] }) {
+  const columns = useMemo<Array<ColumnDef<Row, unknown>>>(
+    () => [
+      {
+        accessorKey: "name",
+        header: "Name",
+        cell: (ctx) => <span className="font-mono text-xs">{ctx.getValue<string>()}</span>,
+      },
+      {
+        accessorKey: "algorithm",
+        header: "Algorithm",
+        cell: (ctx) => (
+          <span className="rounded bg-[color:var(--color-bg-muted)] px-2 py-0.5 font-mono text-xs">
+            {ctx.getValue<string>()}
+          </span>
+        ),
+      },
+      {
+        accessorKey: "id",
+        header: "id",
+        cell: (ctx) => (
+          <span className="font-mono text-[0.625rem] text-[color:var(--color-fg-muted)]">
+            {ctx.getValue<string>()}
+          </span>
+        ),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <DataTable
+      data={rows}
+      columns={columns}
+      pageSize={Math.max(rows.length, 10)}
+      hidePagination
+      hideSearch
+      stateKey={`tsig-ro:${serverSlug}`}
+      emptyMessage="No keys match."
+      noDataMessage={`No TSIG keys configured on ${serverSlug}. AXFR and NOTIFY between this backend and its peers happens without shared-secret authentication.`}
+    />
+  );
+}

--- a/app/(app)/admin/tsig-keys/page.tsx
+++ b/app/(app)/admin/tsig-keys/page.tsx
@@ -27,6 +27,7 @@ import { PdnsAuthError } from "@/lib/pdns/errors";
 import { logger } from "@/lib/logger";
 import { redact } from "@/lib/errors/redact";
 import { TsigActions } from "./_components/tsig-actions";
+import { TsigKeysReadOnly } from "./_components/tsig-keys-readonly";
 
 const PRIMARY_KINDS = new Set(["master", "primary"]);
 
@@ -151,44 +152,7 @@ export default async function TsigKeysPage({ searchParams }: PageProps) {
           zones={primaryZones}
         />
       ) : fetchError ? null : (
-        <div className="overflow-hidden rounded-md border border-[color:var(--color-border)]">
-          <table className="w-full text-sm">
-            <thead className="bg-[color:var(--color-bg-subtle)] text-left text-xs tracking-wide text-[color:var(--color-fg-muted)] uppercase">
-              <tr>
-                <th className="px-4 py-2">Name</th>
-                <th className="px-4 py-2">Algorithm</th>
-                <th className="px-4 py-2 font-mono text-[0.625rem] normal-case">id</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sorted && sorted.length > 0 ? (
-                sorted.map((k) => (
-                  <tr key={k.id} className="border-t border-[color:var(--color-border)]">
-                    <td className="px-4 py-3 font-mono text-xs">{k.name}</td>
-                    <td className="px-4 py-3">
-                      <span className="rounded bg-[color:var(--color-bg-muted)] px-2 py-0.5 font-mono text-xs">
-                        {k.algorithm}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 font-mono text-[0.625rem] text-[color:var(--color-fg-muted)]">
-                      {k.id}
-                    </td>
-                  </tr>
-                ))
-              ) : (
-                <tr className="border-t border-[color:var(--color-border)]">
-                  <td
-                    colSpan={3}
-                    className="px-4 py-6 text-center text-[color:var(--color-fg-muted)]"
-                  >
-                    No TSIG keys configured on <code>{selected.slug}</code>. AXFR and NOTIFY between
-                    this backend and its peers happens without shared-secret authentication.
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
+        <TsigKeysReadOnly serverSlug={selected.slug} rows={sorted ?? []} />
       )}
     </div>
   );

--- a/app/(app)/admin/users/_components/create-user-form.tsx
+++ b/app/(app)/admin/users/_components/create-user-form.tsx
@@ -132,7 +132,7 @@ export function CreateUserForm({ roles = [] }: { roles?: RoleOption[] }) {
           disabled={loading}
           className="rounded-md bg-[color:var(--color-accent)] px-4 py-2 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95 disabled:opacity-50"
         >
-          {loading ? "Creating…" : "Create user"}
+          {loading ? "Adding…" : "Add user"}
         </button>
         <button
           type="button"

--- a/app/(app)/admin/users/_components/role-assignments-panel.tsx
+++ b/app/(app)/admin/users/_components/role-assignments-panel.tsx
@@ -142,20 +142,23 @@ export function RoleAssignmentsPanel(props: PanelProps) {
       {props.assignments.length === 0 ? (
         <p className="text-sm text-[color:var(--color-fg-muted)]">No role assignments yet.</p>
       ) : (
-        <div className="overflow-hidden rounded-md border border-[color:var(--color-border)]">
+        <div className="overflow-hidden rounded-lg border border-[color:var(--color-border)]">
           <table className="w-full text-sm">
-            <thead className="bg-[color:var(--color-bg-subtle)] text-left text-xs tracking-wide text-[color:var(--color-fg-muted)] uppercase">
+            <thead className="bg-[color:var(--color-bg-muted)] text-left text-xs font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">
               <tr>
-                <th className="px-4 py-2">Role</th>
-                <th className="px-4 py-2">Scope</th>
-                <th className="px-4 py-2">Assigned</th>
-                <th className="px-4 py-2"></th>
+                <th className="px-4 py-2.5">Role</th>
+                <th className="px-4 py-2.5">Scope</th>
+                <th className="px-4 py-2.5">Assigned</th>
+                <th className="px-4 py-2.5"></th>
               </tr>
             </thead>
             <tbody>
               {props.assignments.map((a) => (
-                <tr key={a.assignmentId} className="border-t border-[color:var(--color-border)]">
-                  <td className="px-4 py-3">
+                <tr
+                  key={a.assignmentId}
+                  className="border-t border-[color:var(--color-border)] transition-colors even:bg-[color:var(--color-bg-subtle)] hover:bg-[color-mix(in_oklch,var(--color-accent)_14%,transparent)]"
+                >
+                  <td className="px-4 py-3 align-top">
                     <span className="font-medium">{a.roleName}</span>
                     {a.isSystem ? (
                       <span className="ml-2 rounded bg-[color:var(--color-bg-muted)] px-1.5 py-0.5 text-[0.65rem] tracking-wide uppercase">
@@ -163,11 +166,11 @@ export function RoleAssignmentsPanel(props: PanelProps) {
                       </span>
                     ) : null}
                   </td>
-                  <td className="px-4 py-3 font-mono text-xs">{a.scopeLabel}</td>
-                  <td className="px-4 py-3 text-xs">
+                  <td className="px-4 py-3 align-top font-mono text-xs">{a.scopeLabel}</td>
+                  <td className="px-4 py-3 align-top text-xs">
                     <LocalTime ts={a.createdAt} />
                   </td>
-                  <td className="px-4 py-3 text-right">
+                  <td className="px-4 py-3 text-right align-top">
                     {props.canManage ? (
                       <button
                         type="button"

--- a/app/(app)/admin/users/_components/users-table.tsx
+++ b/app/(app)/admin/users/_components/users-table.tsx
@@ -165,6 +165,7 @@ export function UsersTable({
       initialSort={[{ id: "email", desc: false }]}
       sortParam="sort"
       pageSizeParam="pageSize"
+      rowHref={(r) => `/admin/users/${r.id}`}
       noDataMessage="No users match this filter."
     />
   );

--- a/app/(app)/admin/users/page.tsx
+++ b/app/(app)/admin/users/page.tsx
@@ -8,6 +8,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { requireUserForPage } from "@/lib/auth/require-user";
+import { CreateButton } from "@/components/ui/create-button";
 import { listAllUsers } from "@/lib/db/repositories/users";
 import { countAssignmentsForUsers } from "@/lib/db/repositories/roles";
 import { latestAdminEditTimestampsForUsers } from "@/lib/db/repositories/audit-log";
@@ -74,16 +75,9 @@ export default async function UsersListPage({
             {filter ? ` matching "${FILTER_LABELS[filter]}"` : " — newest first"}.
           </p>
         </div>
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2 [&>*]:w-full sm:[&>*]:w-auto">
           {canBulkRevoke ? <RevokeAllSessionsButton /> : null}
-          {canCreate ? (
-            <Link
-              href="/admin/users/new"
-              className="rounded-md bg-[color:var(--color-accent)] px-4 py-2 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95"
-            >
-              Add user
-            </Link>
-          ) : null}
+          {canCreate ? <CreateButton href="/admin/users/new" label="Add user" /> : null}
         </div>
       </header>
 

--- a/app/(app)/admin/users/page.tsx
+++ b/app/(app)/admin/users/page.tsx
@@ -66,7 +66,7 @@ export default async function UsersListPage({
 
   return (
     <div className="space-y-6">
-      <header className="flex items-end justify-between">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Users</h1>
           <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">
@@ -74,7 +74,7 @@ export default async function UsersListPage({
             {filter ? ` matching "${FILTER_LABELS[filter]}"` : " — newest first"}.
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {canBulkRevoke ? <RevokeAllSessionsButton /> : null}
           {canCreate ? (
             <Link

--- a/app/(app)/admin/zone-templates/_components/zone-template-form.tsx
+++ b/app/(app)/admin/zone-templates/_components/zone-template-form.tsx
@@ -554,7 +554,7 @@ export function ZoneTemplateForm(props: Props) {
             disabled={saving}
             className="rounded-md bg-[color:var(--color-accent)] px-4 py-2 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95 disabled:opacity-50"
           >
-            {saving ? "Saving…" : props.mode === "edit" ? "Save changes" : "Create template"}
+            {saving ? "Saving…" : props.mode === "edit" ? "Save changes" : "Add template"}
           </button>
           <button
             type="button"

--- a/app/(app)/admin/zone-templates/_components/zone-templates-table.tsx
+++ b/app/(app)/admin/zone-templates/_components/zone-templates-table.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+/**
+ * app/(app)/admin/zone-templates/_components/zone-templates-table.tsx
+ *
+ * Client wrapper around the shared <DataTable> for the Zone-templates list.
+ * Clickable rows on desktop, cards on mobile, searchable + sortable. Mirrors
+ * the other admin list tables (roles/users/teams/groups).
+ */
+
+import Link from "next/link";
+import { useMemo } from "react";
+import { type ColumnDef } from "@tanstack/react-table";
+import { DataTable } from "@/components/ui/data-table";
+import { freshnessOf } from "@/lib/freshness";
+
+export interface ZoneTemplateRow {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  /** Resolved primary names this template is the default for ([] if none). */
+  defaultForNames: string[];
+  nameserverCount: number;
+  recordCount: number;
+  lastAdminEditIso: string | null;
+}
+
+export function ZoneTemplatesTable({
+  rows,
+  showLastAdminEdit,
+  canManage,
+}: {
+  rows: ZoneTemplateRow[];
+  showLastAdminEdit: boolean;
+  canManage: boolean;
+}) {
+  const columns = useMemo<Array<ColumnDef<ZoneTemplateRow, unknown>>>(() => {
+    const cols: Array<ColumnDef<ZoneTemplateRow, unknown>> = [
+      {
+        accessorKey: "name",
+        header: "Name",
+        cell: (ctx) => {
+          const r = ctx.row.original;
+          return (
+            <div>
+              <div className="font-medium">{r.name}</div>
+              {r.description ? (
+                <div className="text-xs text-[color:var(--color-fg-muted)]">{r.description}</div>
+              ) : null}
+              {r.defaultForNames.length > 0 ? (
+                <div className="mt-1 inline-flex items-center gap-1 text-xs text-[color:var(--color-success)]">
+                  <svg aria-hidden viewBox="0 0 16 16" className="h-3 w-3" fill="currentColor">
+                    <path d="M6.173 11.207 2.93 7.964l1.06-1.06 2.183 2.182 5.834-5.834 1.06 1.06z" />
+                  </svg>
+                  <span>
+                    default for <span className="font-medium">{r.defaultForNames.join(", ")}</span>
+                  </span>
+                </div>
+              ) : null}
+            </div>
+          );
+        },
+      },
+      {
+        accessorKey: "slug",
+        header: "Slug",
+        cell: (ctx) => (
+          <code className="rounded bg-[color:var(--color-bg-subtle)] px-1 font-mono text-xs">
+            {ctx.getValue<string>()}
+          </code>
+        ),
+      },
+      {
+        accessorKey: "nameserverCount",
+        header: "Nameservers",
+        cell: (ctx) => {
+          const n = ctx.getValue<number>();
+          if (n === 0) return <span className="text-[color:var(--color-fg-muted)]">—</span>;
+          return (
+            <span className="font-mono text-xs">
+              {n} {n === 1 ? "NS" : "NSs"}
+            </span>
+          );
+        },
+      },
+      {
+        accessorKey: "recordCount",
+        header: "Records",
+        cell: (ctx) => <span className="font-mono text-xs">{ctx.getValue<number>()}</span>,
+      },
+    ];
+
+    if (showLastAdminEdit) {
+      cols.push({
+        accessorKey: "lastAdminEditIso",
+        header: "Last admin edit",
+        sortUndefined: "last",
+        cell: (ctx) => {
+          const iso = ctx.getValue<string | null>();
+          if (!iso) return <span className="text-xs text-[color:var(--color-fg-muted)]">—</span>;
+          return (
+            <span className="text-xs text-[color:var(--color-fg-muted)]" title={iso}>
+              {freshnessOf(iso).label}
+            </span>
+          );
+        },
+      });
+    }
+
+    cols.push({
+      id: "actions",
+      header: "",
+      enableSorting: false,
+      cell: (ctx) => (
+        <Link
+          href={`/admin/zone-templates/${ctx.row.original.id}`}
+          className="text-[color:var(--color-accent)] hover:underline"
+        >
+          {canManage ? "Edit" : "View"}
+        </Link>
+      ),
+    });
+
+    return cols;
+  }, [showLastAdminEdit, canManage]);
+
+  return (
+    <DataTable
+      columns={columns}
+      data={rows}
+      searchPlaceholder="Search templates by name or slug…"
+      initialSort={[{ id: "name", desc: false }]}
+      sortParam="sort"
+      pageSizeParam="pageSize"
+      rowHref={(r) => `/admin/zone-templates/${r.id}`}
+    />
+  );
+}

--- a/app/(app)/admin/zone-templates/new/page.tsx
+++ b/app/(app)/admin/zone-templates/new/page.tsx
@@ -12,7 +12,7 @@ export default async function NewZoneTemplatePage() {
   return (
     <div className="mx-auto max-w-3xl space-y-6">
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight">New zone template</h1>
+        <h1 className="text-2xl font-semibold tracking-tight">Add zone template</h1>
         <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">
           Define defaults for new zones. Operators pick this template on the create-zone form and
           the NS records + SOA timers + prelude records are applied automatically.

--- a/app/(app)/admin/zone-templates/page.tsx
+++ b/app/(app)/admin/zone-templates/page.tsx
@@ -37,7 +37,7 @@ export default async function ZoneTemplatesListPage() {
             prelude records you want on every zone of this kind.
           </p>
         </div>
-        {canManage ? <CreateButton href="/admin/zone-templates/new" label="New template" /> : null}
+        {canManage ? <CreateButton href="/admin/zone-templates/new" label="Add template" /> : null}
       </header>
 
       {templates.length === 0 ? (

--- a/app/(app)/admin/zone-templates/page.tsx
+++ b/app/(app)/admin/zone-templates/page.tsx
@@ -6,13 +6,12 @@
  * records (MX, CAA, SPF…) the operator wants on every zone.
  */
 
-import Link from "next/link";
 import { requireUserForPage } from "@/lib/auth/require-user";
 import { CreateButton } from "@/components/ui/create-button";
 import { listAllZoneTemplates } from "@/lib/db/repositories/zone-templates";
 import { latestAdminEditTimestampsForZoneTemplates } from "@/lib/db/repositories/audit-log";
 import { listAllPrimaries } from "@/lib/db/repositories/pdns-servers";
-import { freshnessOf } from "@/lib/freshness";
+import { ZoneTemplatesTable, type ZoneTemplateRow } from "./_components/zone-templates-table";
 
 export const metadata = { title: "Zone templates" };
 
@@ -26,6 +25,19 @@ export default async function ZoneTemplatesListPage() {
     canReadAudit && templates.length > 0
       ? await latestAdminEditTimestampsForZoneTemplates(templates.map((t) => t.id))
       : new Map<string, Date>();
+
+  const rows: ZoneTemplateRow[] = templates.map((t) => ({
+    id: t.id,
+    name: t.name,
+    slug: t.slug,
+    description: t.description ?? null,
+    defaultForNames: (t.defaultForPrimaryIds ?? [])
+      .map((id) => primaryNameById.get(id))
+      .filter((n): n is string => Boolean(n)),
+    nameserverCount: t.nameservers.length,
+    recordCount: t.records.length,
+    lastAdminEditIso: lastEdits.get(t.id)?.toISOString() ?? null,
+  }));
 
   return (
     <div className="space-y-6">
@@ -55,87 +67,7 @@ export default async function ZoneTemplatesListPage() {
           </p>
         </div>
       ) : (
-        <div className="overflow-hidden rounded-md border border-[color:var(--color-border)]">
-          <table className="w-full text-sm">
-            <thead className="bg-[color:var(--color-bg-subtle)] text-left text-xs tracking-wide text-[color:var(--color-fg-muted)] uppercase">
-              <tr>
-                <th className="px-3 py-2">Name</th>
-                <th className="px-3 py-2">Slug</th>
-                <th className="px-3 py-2">Nameservers</th>
-                <th className="px-3 py-2">Records</th>
-                {canReadAudit ? <th className="px-3 py-2">Last admin edit</th> : null}
-                <th className="w-px px-3 py-2 whitespace-nowrap"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {templates.map((t) => (
-                <tr key={t.id} className="border-t border-[color:var(--color-border)]">
-                  <td className="px-3 py-2">
-                    <div className="font-medium">{t.name}</div>
-                    {t.description ? (
-                      <div className="text-xs text-[color:var(--color-fg-muted)]">
-                        {t.description}
-                      </div>
-                    ) : null}
-                    {(() => {
-                      const names = (t.defaultForPrimaryIds ?? [])
-                        .map((id) => primaryNameById.get(id))
-                        .filter((n): n is string => Boolean(n));
-                      if (names.length === 0) return null;
-                      return (
-                        <div className="mt-1 flex items-center gap-1 text-xs text-[color:var(--color-success)]">
-                          <svg
-                            aria-hidden
-                            viewBox="0 0 16 16"
-                            className="h-3 w-3"
-                            fill="currentColor"
-                          >
-                            <path d="M6.173 11.207 2.93 7.964l1.06-1.06 2.183 2.182 5.834-5.834 1.06 1.06z" />
-                          </svg>
-                          <span>
-                            default for <span className="font-medium">{names.join(", ")}</span>
-                          </span>
-                        </div>
-                      );
-                    })()}
-                  </td>
-                  <td className="px-3 py-2 font-mono text-xs">
-                    <code className="rounded bg-[color:var(--color-bg-subtle)] px-1">{t.slug}</code>
-                  </td>
-                  <td className="px-3 py-2 text-xs">
-                    {t.nameservers.length === 0 ? (
-                      <span className="text-[color:var(--color-fg-muted)]">—</span>
-                    ) : (
-                      <span className="font-mono">
-                        {t.nameservers.length} {t.nameservers.length === 1 ? "NS" : "NSs"}
-                      </span>
-                    )}
-                  </td>
-                  <td className="px-3 py-2 font-mono text-xs">{t.records.length}</td>
-                  {canReadAudit ? (
-                    <td className="px-3 py-2 text-xs text-[color:var(--color-fg-muted)]">
-                      {lastEdits.has(t.id) ? (
-                        <span title={lastEdits.get(t.id)!.toISOString()}>
-                          {freshnessOf(lastEdits.get(t.id)!.toISOString()).label}
-                        </span>
-                      ) : (
-                        "—"
-                      )}
-                    </td>
-                  ) : null}
-                  <td className="w-px px-3 py-2 text-right text-xs whitespace-nowrap">
-                    <Link
-                      href={`/admin/zone-templates/${t.id}`}
-                      className="text-[color:var(--color-accent)] hover:underline"
-                    >
-                      {canManage ? "Edit" : "View"}
-                    </Link>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <ZoneTemplatesTable rows={rows} showLastAdminEdit={canReadAudit} canManage={canManage} />
       )}
     </div>
   );

--- a/app/(app)/admin/zone-templates/page.tsx
+++ b/app/(app)/admin/zone-templates/page.tsx
@@ -28,7 +28,7 @@ export default async function ZoneTemplatesListPage() {
 
   return (
     <div className="space-y-6">
-      <header className="flex items-end justify-between">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Zone templates</h1>
           <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">

--- a/app/(app)/admin/zone-templates/page.tsx
+++ b/app/(app)/admin/zone-templates/page.tsx
@@ -8,6 +8,7 @@
 
 import Link from "next/link";
 import { requireUserForPage } from "@/lib/auth/require-user";
+import { CreateButton } from "@/components/ui/create-button";
 import { listAllZoneTemplates } from "@/lib/db/repositories/zone-templates";
 import { latestAdminEditTimestampsForZoneTemplates } from "@/lib/db/repositories/audit-log";
 import { listAllPrimaries } from "@/lib/db/repositories/pdns-servers";
@@ -36,14 +37,7 @@ export default async function ZoneTemplatesListPage() {
             prelude records you want on every zone of this kind.
           </p>
         </div>
-        {canManage ? (
-          <Link
-            href="/admin/zone-templates/new"
-            className="rounded-md bg-[color:var(--color-accent)] px-4 py-2 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95"
-          >
-            New template
-          </Link>
-        ) : null}
+        {canManage ? <CreateButton href="/admin/zone-templates/new" label="New template" /> : null}
       </header>
 
       {templates.length === 0 ? (
@@ -70,7 +64,7 @@ export default async function ZoneTemplatesListPage() {
                 <th className="px-3 py-2">Nameservers</th>
                 <th className="px-3 py-2">Records</th>
                 {canReadAudit ? <th className="px-3 py-2">Last admin edit</th> : null}
-                <th className="px-3 py-2"></th>
+                <th className="w-px px-3 py-2 whitespace-nowrap"></th>
               </tr>
             </thead>
             <tbody>
@@ -129,7 +123,7 @@ export default async function ZoneTemplatesListPage() {
                       )}
                     </td>
                   ) : null}
-                  <td className="px-3 py-2 text-right text-xs">
+                  <td className="w-px px-3 py-2 text-right text-xs whitespace-nowrap">
                     <Link
                       href={`/admin/zone-templates/${t.id}`}
                       className="text-[color:var(--color-accent)] hover:underline"

--- a/app/(app)/dashboard/_components/dashboard-live-feed.tsx
+++ b/app/(app)/dashboard/_components/dashboard-live-feed.tsx
@@ -1,21 +1,22 @@
 "use client";
 
 /**
- * Dashboard live-feed indicator — consumes the app-wide
- * RealtimeProvider stream. Refreshes the page whenever an audit row
- * or PDNS request is appended (both feed the dashboard's KPI cards +
- * charts).
+ * Dashboard live-feed listener — refreshes the page whenever an audit row or
+ * PDNS request is appended (both feed the dashboard's KPI cards + charts).
+ *
+ * Renders nothing: the visible "LIVE" chip moved to the shared HeaderStatusChip
+ * in the top bar. This component is purely the SSE event subscriber now; the
+ * dashboard is "live" by default in the header chip so no mode-setter is needed.
  */
 
 import { useRef } from "react";
 import { useRouter } from "next/navigation";
-import { useRealtimeEvent, useRealtimeStatus } from "@/components/realtime/realtime-provider";
+import { useRealtimeEvent } from "@/components/realtime/realtime-provider";
 
 const DASHBOARD_TYPES = ["audit.appended", "pdns.request.appended"] as const;
 
 export function DashboardLiveFeed() {
   const router = useRouter();
-  const { status, enabled, setEnabled } = useRealtimeStatus();
   const lastRefreshAt = useRef<number>(0);
 
   useRealtimeEvent(
@@ -28,39 +29,5 @@ export function DashboardLiveFeed() {
     },
   );
 
-  return (
-    <button
-      type="button"
-      onClick={() => setEnabled(!enabled)}
-      title={
-        status === "live"
-          ? "Live updates streaming — click to pause"
-          : status === "paused"
-            ? "Live updates paused — click to resume"
-            : status === "connecting"
-              ? "Connecting…"
-              : "Connection lost — auto-retrying"
-      }
-      className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase hover:bg-[color:var(--color-bg-subtle)]"
-    >
-      <span
-        className={`inline-block h-2 w-2 rounded-full ${
-          status === "live"
-            ? "animate-pulse bg-[color:var(--color-success)]"
-            : status === "connecting"
-              ? "bg-[color:var(--color-warn)]"
-              : status === "paused"
-                ? "bg-[color:var(--color-fg-subtle)]"
-                : "bg-[color:var(--color-error)]"
-        }`}
-      />
-      {status === "live"
-        ? "live"
-        : status === "connecting"
-          ? "connecting"
-          : status === "paused"
-            ? "paused"
-            : "offline"}
-    </button>
-  );
+  return null;
 }

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -45,6 +45,7 @@ import { Chart } from "@/components/ui/chart";
 import { LocalTime } from "@/components/ui/local-time";
 import { UnverifiedEmailBanner } from "./_components/unverified-email-banner";
 import { DashboardLiveFeed } from "./_components/dashboard-live-feed";
+import { countActiveSessions } from "@/lib/db/repositories/sessions";
 import {
   actionPieOption,
   bucketResponseSizes,
@@ -102,6 +103,7 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
     backendsLatest,
     backendTimeSeries,
     sessionsTimeSeries,
+    currentActiveSessions,
     recent,
     servers,
     attention,
@@ -118,6 +120,7 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
     canReadServers ? latestBackendSamples() : Promise.resolve([]),
     canReadServers ? backendSeries(HOURS_7D) : Promise.resolve([]),
     canReadAudit ? sessionsSeries(HOURS_7D) : Promise.resolve([]),
+    canReadAudit ? countActiveSessions() : Promise.resolve(0),
     canReadAudit ? recentAudit(12) : Promise.resolve([]),
     canReadServers ? listAllPdnsServers() : Promise.resolve([]),
     canReadUsers
@@ -154,7 +157,10 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
     }
     return sum + (b.zoneCount ?? 0);
   }, 0);
-  const currentSessions = sessionsTimeSeries[sessionsTimeSeries.length - 1]?.activeSessions ?? 0;
+  // Real-time count for the KPI tile: the metric sampler writes a row every
+  // ~minute, so the last bucket lags freshly-issued sessions (a user logging
+  // in *just now* showed as 0). The 7-day chart still uses the sampled series.
+  const currentSessions = currentActiveSessions;
   const editCountLast24h = editsHourly.reduce((sum, b) => sum + b.count, 0);
   const hasAnyPanel = canReadAudit || canReadServers || canReadZones;
 

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -333,14 +333,14 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
               ) : null}
               {canReadServers ? (
                 <Card title="Backends snapshot">
-                  <div className="overflow-hidden rounded-md border border-[color:var(--color-border)] text-sm">
+                  <div className="overflow-hidden rounded-lg border border-[color:var(--color-border)] text-sm">
                     <table className="w-full">
-                      <thead className="bg-[color:var(--color-bg-subtle)] text-left text-xs tracking-wide text-[color:var(--color-fg-muted)] uppercase">
+                      <thead className="bg-[color:var(--color-bg-muted)] text-left text-xs font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">
                         <tr>
-                          <th className="px-3 py-1.5">Backend</th>
-                          <th className="px-3 py-1.5">Zones</th>
-                          <th className="px-3 py-1.5">p50</th>
-                          <th className="px-3 py-1.5">p95</th>
+                          <th className="px-3 py-2.5">Backend</th>
+                          <th className="px-3 py-2.5">Zones</th>
+                          <th className="px-3 py-2.5">p50</th>
+                          <th className="px-3 py-2.5">p95</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -369,9 +369,9 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
                           backendsLatest.map((b) => (
                             <tr
                               key={b.serverId}
-                              className="border-t border-[color:var(--color-border)]"
+                              className="border-t border-[color:var(--color-border)] transition-colors even:bg-[color:var(--color-bg-subtle)] hover:bg-[color-mix(in_oklch,var(--color-accent)_14%,transparent)]"
                             >
-                              <td className="px-3 py-2 font-medium">
+                              <td className="px-3 py-3 align-top font-medium">
                                 <Link
                                   href={`/admin/servers/${b.serverId}`}
                                   className="text-[color:var(--color-accent)] hover:underline"
@@ -379,11 +379,13 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
                                   {b.serverName}
                                 </Link>
                               </td>
-                              <td className="px-3 py-2 font-mono text-xs">{b.zoneCount ?? "—"}</td>
-                              <td className="px-3 py-2 font-mono text-xs">
+                              <td className="px-3 py-3 align-top font-mono text-xs">
+                                {b.zoneCount ?? "—"}
+                              </td>
+                              <td className="px-3 py-3 align-top font-mono text-xs">
                                 {b.latencyP50Ms === null ? "—" : `${Math.round(b.latencyP50Ms)}ms`}
                               </td>
-                              <td className="px-3 py-2 font-mono text-xs">
+                              <td className="px-3 py-3 align-top font-mono text-xs">
                                 {b.latencyP95Ms === null ? "—" : `${Math.round(b.latencyP95Ms)}ms`}
                               </td>
                             </tr>
@@ -413,25 +415,30 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
               {recent.length === 0 ? (
                 <p className="text-sm text-[color:var(--color-fg-muted)]">No audit entries yet.</p>
               ) : (
-                <div className="overflow-hidden rounded-md border border-[color:var(--color-border)] text-sm">
+                <div className="overflow-hidden rounded-lg border border-[color:var(--color-border)] text-sm">
                   <table className="w-full">
-                    <thead className="bg-[color:var(--color-bg-subtle)] text-left text-xs tracking-wide text-[color:var(--color-fg-muted)] uppercase">
+                    <thead className="bg-[color:var(--color-bg-muted)] text-left text-xs font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">
                       <tr>
-                        <th className="px-3 py-1.5">When</th>
-                        <th className="px-3 py-1.5">Actor</th>
-                        <th className="px-3 py-1.5">Action</th>
-                        <th className="px-3 py-1.5">Resource</th>
+                        <th className="px-3 py-2.5">When</th>
+                        <th className="px-3 py-2.5">Actor</th>
+                        <th className="px-3 py-2.5">Action</th>
+                        <th className="px-3 py-2.5">Resource</th>
                       </tr>
                     </thead>
                     <tbody>
                       {recent.map((row, idx) => (
-                        <tr key={idx} className="border-t border-[color:var(--color-border)]">
-                          <td className="px-3 py-2 font-mono text-xs">
+                        <tr
+                          key={idx}
+                          className="border-t border-[color:var(--color-border)] transition-colors even:bg-[color:var(--color-bg-subtle)] hover:bg-[color-mix(in_oklch,var(--color-accent)_14%,transparent)]"
+                        >
+                          <td className="px-3 py-3 align-top font-mono text-[0.6875rem] text-[color:var(--color-fg-muted)]">
                             <LocalTime ts={row.ts} />
                           </td>
-                          <td className="px-3 py-2 text-xs">{row.actorEmail ?? "system"}</td>
-                          <td className="px-3 py-2 font-mono text-xs">{row.action}</td>
-                          <td className="px-3 py-2 text-xs">
+                          <td className="px-3 py-3 align-top text-xs">
+                            {row.actorEmail ?? "system"}
+                          </td>
+                          <td className="px-3 py-3 align-top font-mono text-xs">{row.action}</td>
+                          <td className="px-3 py-3 align-top text-xs">
                             <span className="text-[color:var(--color-fg-muted)]">
                               {row.resourceType}
                             </span>

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -23,6 +23,7 @@ import { UserMenu } from "@/components/ui/user-menu";
 import { HealthBell } from "@/components/domain/health-bell";
 import { listActiveAdvisories } from "@/lib/db/repositories/backend-advisories";
 import { BrandMark } from "@/components/ui/brandmark";
+import { AppShell } from "@/components/ui/app-shell";
 import { DialogProvider } from "@/components/ui/dialog";
 import { FlashListener } from "@/components/ui/flash-listener";
 import { NavLink } from "@/components/ui/nav-link";
@@ -126,87 +127,83 @@ export default async function AppLayout({ children }: Readonly<{ children: React
   const hasAccess = canReadUsers || canReadRoles || canReadTeams || canReadOidc;
   const hasSystem = canReadSettings || canReadAudit;
 
+  const sidebar = (
+    <>
+      <div className="flex h-14 shrink-0 items-center overflow-hidden border-b border-[color:var(--color-border)] px-4">
+        <Link
+          href="/dashboard"
+          aria-label={`${appSettings.siteName} home`}
+          className="flex w-full items-center justify-center overflow-hidden"
+        >
+          <BrandMark
+            siteName={appSettings.siteName}
+            brandLogoUrl={appSettings.brandLogoUrl}
+            width={224}
+            maxHeight={40}
+            priority
+          />
+        </Link>
+      </div>
+      <nav className="flex-1 space-y-1 overflow-y-auto p-3 text-sm">
+        <NavLink href="/dashboard" label="Dashboard" />
+        {canReadZones ? <NavLink href="/zones" label="Zones" /> : null}
+
+        {hasInfrastructure ? (
+          <NavSection label="Infrastructure">
+            {canReadServers ? (
+              <NavLink nested href="/admin/servers" label="PowerDNS servers" />
+            ) : null}
+            {canReadServers ? <NavLink nested href="/admin/pdns-clusters" label="Groups" /> : null}
+            {canReadTsig ? <NavLink nested href="/admin/tsig-keys" label="TSIG keys" /> : null}
+            {canManageAutoprimary ? (
+              <NavLink nested href="/admin/autoprimaries" label="Autoprimaries" />
+            ) : null}
+            {canUseTemplates ? (
+              <NavLink nested href="/admin/zone-templates" label="Zone templates" />
+            ) : null}
+          </NavSection>
+        ) : null}
+
+        {hasAccess ? (
+          <NavSection label="Access">
+            {canReadUsers ? <NavLink nested href="/admin/users" label="Users" /> : null}
+            {canReadTeams ? <NavLink nested href="/admin/teams" label="Teams" /> : null}
+            {canReadRoles ? <NavLink nested href="/admin/roles" label="Roles" /> : null}
+            {canReadOidc ? (
+              <NavLink nested href="/admin/oidc-providers" label="OIDC providers" />
+            ) : null}
+          </NavSection>
+        ) : null}
+
+        {hasSystem ? (
+          <NavSection label="System">
+            {canReadSettings ? <NavLink nested href="/admin/settings" label="Settings" /> : null}
+            {canReadAudit ? <NavLink nested href="/admin/audit" label="Audit log" /> : null}
+            {canReadAudit ? (
+              <NavLink nested href="/admin/pdns-requests" label="Request log" />
+            ) : null}
+          </NavSection>
+        ) : null}
+      </nav>
+      <SidebarFooter />
+    </>
+  );
+
+  const headerControls = (
+    <>
+      {canReadServers ? <HealthBell advisories={advisories} /> : null}
+      <ThemeToggle />
+      <UserMenu email={current.user.email} name={current.user.name} />
+    </>
+  );
+
   return (
     <DialogProvider>
       <RealtimeProvider>
         <FlashListener />
-        {/* Fixed to the viewport height so the sidebar (and its version
-            footer) is always fully visible; only the main <section> scrolls. */}
-        <div className="grid h-dvh grid-cols-[16rem_1fr] grid-rows-[3.5rem_1fr] overflow-hidden">
-          <aside className="row-span-2 flex flex-col border-r border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)]">
-            <div className="flex h-14 items-center overflow-hidden border-b border-[color:var(--color-border)] px-4">
-              <Link
-                href="/dashboard"
-                aria-label={`${appSettings.siteName} home`}
-                className="flex w-full items-center justify-center overflow-hidden"
-              >
-                <BrandMark
-                  siteName={appSettings.siteName}
-                  brandLogoUrl={appSettings.brandLogoUrl}
-                  width={224}
-                  maxHeight={40}
-                  priority
-                />
-              </Link>
-            </div>
-            <nav className="flex-1 space-y-1 overflow-y-auto p-3 text-sm">
-              <NavLink href="/dashboard" label="Dashboard" />
-              {canReadZones ? <NavLink href="/zones" label="Zones" /> : null}
-
-              {hasInfrastructure ? (
-                <NavSection label="Infrastructure">
-                  {canReadServers ? (
-                    <NavLink nested href="/admin/servers" label="PowerDNS servers" />
-                  ) : null}
-                  {canReadServers ? (
-                    <NavLink nested href="/admin/pdns-clusters" label="Groups" />
-                  ) : null}
-                  {canReadTsig ? (
-                    <NavLink nested href="/admin/tsig-keys" label="TSIG keys" />
-                  ) : null}
-                  {canManageAutoprimary ? (
-                    <NavLink nested href="/admin/autoprimaries" label="Autoprimaries" />
-                  ) : null}
-                  {canUseTemplates ? (
-                    <NavLink nested href="/admin/zone-templates" label="Zone templates" />
-                  ) : null}
-                </NavSection>
-              ) : null}
-
-              {hasAccess ? (
-                <NavSection label="Access">
-                  {canReadUsers ? <NavLink nested href="/admin/users" label="Users" /> : null}
-                  {canReadTeams ? <NavLink nested href="/admin/teams" label="Teams" /> : null}
-                  {canReadRoles ? <NavLink nested href="/admin/roles" label="Roles" /> : null}
-                  {canReadOidc ? (
-                    <NavLink nested href="/admin/oidc-providers" label="OIDC providers" />
-                  ) : null}
-                </NavSection>
-              ) : null}
-
-              {hasSystem ? (
-                <NavSection label="System">
-                  {canReadSettings ? (
-                    <NavLink nested href="/admin/settings" label="Settings" />
-                  ) : null}
-                  {canReadAudit ? <NavLink nested href="/admin/audit" label="Audit log" /> : null}
-                  {canReadAudit ? (
-                    <NavLink nested href="/admin/pdns-requests" label="Request log" />
-                  ) : null}
-                </NavSection>
-              ) : null}
-            </nav>
-            <SidebarFooter />
-          </aside>
-
-          <header className="flex h-14 items-center justify-end gap-3 border-b border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-4">
-            {canReadServers ? <HealthBell advisories={advisories} /> : null}
-            <ThemeToggle />
-            <UserMenu email={current.user.email} name={current.user.name} />
-          </header>
-
-          <section className="overflow-y-auto p-8">{children}</section>
-        </div>
+        <AppShell sidebar={sidebar} headerControls={headerControls}>
+          {children}
+        </AppShell>
       </RealtimeProvider>
     </DialogProvider>
   );

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -28,6 +28,7 @@ import { DialogProvider } from "@/components/ui/dialog";
 import { FlashListener } from "@/components/ui/flash-listener";
 import { NavLink } from "@/components/ui/nav-link";
 import { RealtimeProvider } from "@/components/realtime/realtime-provider";
+import { HeaderStatusProvider } from "@/components/realtime/header-status-chip";
 import { getAppSettings } from "@/lib/settings/app-settings";
 
 /**
@@ -129,7 +130,7 @@ export default async function AppLayout({ children }: Readonly<{ children: React
 
   const sidebar = (
     <>
-      <div className="flex h-14 shrink-0 items-center overflow-hidden border-b border-[color:var(--color-border)] px-4">
+      <div className="flex h-20 shrink-0 items-center overflow-hidden border-b border-[color:var(--color-border)] px-4 pt-3">
         <Link
           href="/dashboard"
           aria-label={`${appSettings.siteName} home`}
@@ -138,13 +139,13 @@ export default async function AppLayout({ children }: Readonly<{ children: React
           <BrandMark
             siteName={appSettings.siteName}
             brandLogoUrl={appSettings.brandLogoUrl}
-            width={224}
-            maxHeight={40}
+            width={280}
+            maxHeight={56}
             priority
           />
         </Link>
       </div>
-      <nav className="flex-1 space-y-1 overflow-y-auto p-3 text-sm">
+      <nav className="flex-1 space-y-1 overflow-y-auto p-3 text-base">
         <NavLink href="/dashboard" label="Dashboard" />
         {canReadZones ? <NavLink href="/zones" label="Zones" /> : null}
 
@@ -200,10 +201,12 @@ export default async function AppLayout({ children }: Readonly<{ children: React
   return (
     <DialogProvider>
       <RealtimeProvider>
-        <FlashListener />
-        <AppShell sidebar={sidebar} headerControls={headerControls}>
-          {children}
-        </AppShell>
+        <HeaderStatusProvider>
+          <FlashListener />
+          <AppShell sidebar={sidebar} headerControls={headerControls}>
+            {children}
+          </AppShell>
+        </HeaderStatusProvider>
       </RealtimeProvider>
     </DialogProvider>
   );

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -29,7 +29,10 @@ import { FlashListener } from "@/components/ui/flash-listener";
 import { NavLink } from "@/components/ui/nav-link";
 import { RealtimeProvider } from "@/components/realtime/realtime-provider";
 import { HeaderStatusProvider } from "@/components/realtime/header-status-chip";
+import { MustChangePasswordProvider } from "@/components/auth/must-change-password-guard";
 import { getAppSettings } from "@/lib/settings/app-settings";
+import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
+import { globalAnyLagging } from "@/lib/pdns/sync";
 
 /**
  * Paths a non-compliant user (forced-MFA-not-enrolled, or flagged
@@ -203,6 +206,22 @@ export default async function AppLayout({ children }: Readonly<{ children: React
   // here avoids the stuck-on-CONNECTING chip + the wasted reconnect storm; the
   // chip self-hides when no provider is mounted.
   const realtimeAvailable = compliance.compliant && !current.user.mustChangePassword;
+
+  // Fleet-wide sync verdict as the chip's default mode. Pages that show
+  // their own (per-zone or per-page) sync state push it via
+  // <HeaderStatusMode/> and override this. Computed only when realtime is
+  // available + the operator can see backend state at all — otherwise the
+  // chip falls back to plain "Live" so a profile-only user doesn't see a
+  // signal they have no context for. The helper reads exclusively from the
+  // poller's in-process caches, so this is a near-free lookup once the
+  // first ensureBackendsObserved warms the store.
+  const showGlobalSync = realtimeAvailable && (canReadZones || canReadServers);
+  let initialChipMode: { kind: "live" } | { kind: "sync"; inSync: boolean } = { kind: "live" };
+  if (showGlobalSync) {
+    await ensureBackendsObserved();
+    initialChipMode = { kind: "sync", inSync: !(await globalAnyLagging()) };
+  }
+
   const shell = (
     <AppShell sidebar={sidebar} headerControls={headerControls}>
       {children}
@@ -211,19 +230,21 @@ export default async function AppLayout({ children }: Readonly<{ children: React
 
   return (
     <DialogProvider>
-      {realtimeAvailable ? (
-        <RealtimeProvider>
-          <HeaderStatusProvider>
+      <MustChangePasswordProvider blocked={current.user.mustChangePassword}>
+        {realtimeAvailable ? (
+          <RealtimeProvider>
+            <HeaderStatusProvider initialMode={initialChipMode}>
+              <FlashListener />
+              {shell}
+            </HeaderStatusProvider>
+          </RealtimeProvider>
+        ) : (
+          <>
             <FlashListener />
             {shell}
-          </HeaderStatusProvider>
-        </RealtimeProvider>
-      ) : (
-        <>
-          <FlashListener />
-          {shell}
-        </>
-      )}
+          </>
+        )}
+      </MustChangePasswordProvider>
     </DialogProvider>
   );
 }

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -198,16 +198,32 @@ export default async function AppLayout({ children }: Readonly<{ children: React
     </>
   );
 
+  // A user stuck on the must-change-password / MFA-enrolment screen can't reach
+  // /api/realtime (requireUser rejects them with 403). Skipping RealtimeProvider
+  // here avoids the stuck-on-CONNECTING chip + the wasted reconnect storm; the
+  // chip self-hides when no provider is mounted.
+  const realtimeAvailable = compliance.compliant && !current.user.mustChangePassword;
+  const shell = (
+    <AppShell sidebar={sidebar} headerControls={headerControls}>
+      {children}
+    </AppShell>
+  );
+
   return (
     <DialogProvider>
-      <RealtimeProvider>
-        <HeaderStatusProvider>
+      {realtimeAvailable ? (
+        <RealtimeProvider>
+          <HeaderStatusProvider>
+            <FlashListener />
+            {shell}
+          </HeaderStatusProvider>
+        </RealtimeProvider>
+      ) : (
+        <>
           <FlashListener />
-          <AppShell sidebar={sidebar} headerControls={headerControls}>
-            {children}
-          </AppShell>
-        </HeaderStatusProvider>
-      </RealtimeProvider>
+          {shell}
+        </>
+      )}
     </DialogProvider>
   );
 }

--- a/app/(app)/profile/_components/sessions-list.tsx
+++ b/app/(app)/profile/_components/sessions-list.tsx
@@ -7,12 +7,14 @@
  * Refreshes the page after a successful revoke so the list reflects state.
  *
  * We don't try to identify "this is your current session" here — that
- * requires reading the session cookie which is HttpOnly.can add
- * a server-prop pass for "current session id".
+ * requires reading the session cookie which is HttpOnly. can add a
+ * server-prop pass for "current session id".
  */
 
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { type ColumnDef } from "@tanstack/react-table";
+import { DataTable } from "@/components/ui/data-table";
 import { useDialog } from "@/components/ui/dialog";
 import { LocalTime } from "@/components/ui/local-time";
 import { mutate } from "@/lib/client/api-fetch";
@@ -57,49 +59,72 @@ export function SessionsList({ sessions }: { sessions: SessionSummary[] }) {
     }
   }
 
-  if (sessions.length === 0) {
-    return <p className="text-sm text-[color:var(--color-fg-muted)]">No active sessions.</p>;
-  }
+  const columns = useMemo<Array<ColumnDef<SessionSummary, unknown>>>(
+    () => [
+      {
+        accessorKey: "lastSeenAt",
+        header: "Last seen",
+        cell: (ctx) => <LocalTime ts={ctx.getValue<string>()} className="text-xs" />,
+        meta: { className: "w-44" },
+      },
+      {
+        accessorKey: "ip",
+        header: "IP",
+        cell: (ctx) => (
+          <span className="font-mono text-xs">{ctx.getValue<string | null>() ?? "—"}</span>
+        ),
+        meta: { className: "w-44" },
+      },
+      {
+        accessorKey: "userAgent",
+        header: "User agent",
+        cell: (ctx) => (
+          <span className="line-clamp-2 max-w-[36ch] text-xs">
+            {ctx.getValue<string | null>() ?? "—"}
+          </span>
+        ),
+      },
+      {
+        accessorKey: "expiresAt",
+        header: "Expires",
+        cell: (ctx) => <LocalTime ts={ctx.getValue<string>()} className="text-xs" />,
+        meta: { className: "w-44" },
+      },
+      {
+        id: "actions",
+        header: "",
+        enableSorting: false,
+        cell: (ctx) => {
+          const row = ctx.row.original;
+          return (
+            <button
+              type="button"
+              onClick={() => revoke(row.id)}
+              disabled={busy === row.id}
+              className="text-xs text-[color:var(--color-error)] hover:underline disabled:opacity-50"
+            >
+              {busy === row.id ? "Revoking…" : "Revoke"}
+            </button>
+          );
+        },
+      },
+    ],
+    // `revoke` closes over busy + the dialog/toast/router refs; rebuilt each
+    // render is fine for a short list, and avoids stale-busy reads.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [busy],
+  );
 
   return (
-    <div className="overflow-hidden rounded-md border border-[color:var(--color-border)]">
-      <table className="w-full text-sm">
-        <thead className="bg-[color:var(--color-bg-subtle)] text-left text-xs tracking-wide text-[color:var(--color-fg-muted)] uppercase">
-          <tr>
-            <th className="px-4 py-2">Last seen</th>
-            <th className="px-4 py-2">IP</th>
-            <th className="px-4 py-2">User agent</th>
-            <th className="px-4 py-2">Expires</th>
-            <th className="px-4 py-2"></th>
-          </tr>
-        </thead>
-        <tbody>
-          {sessions.map((s) => (
-            <tr key={s.id} className="border-t border-[color:var(--color-border)] align-top">
-              <td className="px-4 py-3 text-xs">
-                <LocalTime ts={s.lastSeenAt} />
-              </td>
-              <td className="px-4 py-3 font-mono text-xs">{s.ip ?? "—"}</td>
-              <td className="px-4 py-3 text-xs">
-                <span className="line-clamp-2 max-w-[36ch]">{s.userAgent ?? "—"}</span>
-              </td>
-              <td className="px-4 py-3 text-xs">
-                <LocalTime ts={s.expiresAt} />
-              </td>
-              <td className="px-4 py-3 text-right">
-                <button
-                  type="button"
-                  onClick={() => revoke(s.id)}
-                  disabled={busy === s.id}
-                  className="text-xs text-[color:var(--color-error)] hover:underline disabled:opacity-50"
-                >
-                  {busy === s.id ? "Revoking…" : "Revoke"}
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <DataTable
+      data={sessions}
+      columns={columns}
+      pageSize={Math.max(sessions.length, 10)}
+      hidePagination
+      hideSearch
+      noDataMessage="No active sessions."
+      emptyMessage="No active sessions."
+      stateKey="profile-sessions"
+    />
   );
 }

--- a/app/(app)/profile/page.tsx
+++ b/app/(app)/profile/page.tsx
@@ -17,6 +17,7 @@ import { NameEdit } from "./_components/name-edit";
 import { SessionsList } from "./_components/sessions-list";
 import { TotpSection } from "./_components/totp-section";
 import { ProfileTabsContainer, ProfileTabPanel } from "./_components/profile-tabs";
+import { MustChangePasswordBanner } from "@/components/auth/must-change-password-guard";
 import { env } from "@/lib/env";
 
 export const metadata: Metadata = { title: "Profile" };
@@ -73,11 +74,7 @@ export default async function ProfilePage({
       </header>
 
       <ProfileTabsContainer tabs={tabs} defaultTab="account">
-        {user.mustChangePassword ? (
-          <div className="rounded-md border border-[color:var(--color-warn)] bg-[color:var(--color-warn)]/10 p-4 text-sm">
-            <strong>Your password must be changed.</strong> Pick a new one below.
-          </div>
-        ) : null}
+        <MustChangePasswordBanner />
 
         <ProfileTabPanel id="account">
           <div className="space-y-3 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] p-5">

--- a/app/(app)/zones/[zoneId]/_components/bare-diff.tsx
+++ b/app/(app)/zones/[zoneId]/_components/bare-diff.tsx
@@ -347,7 +347,7 @@ function LineGutter({ n }: { n: number }) {
   return (
     <span
       aria-hidden
-      className="w-6 shrink-0 text-right tabular-nums text-[color:var(--color-fg-subtle)] select-none sm:w-8"
+      className="w-6 shrink-0 text-left text-[color:var(--color-fg-subtle)] tabular-nums select-none sm:w-8"
     >
       {n}
     </span>

--- a/app/(app)/zones/[zoneId]/_components/bare-diff.tsx
+++ b/app/(app)/zones/[zoneId]/_components/bare-diff.tsx
@@ -94,6 +94,7 @@ function SideBySideDiff({
             segments={p.beforeSegments}
             present={p.beforePresent}
             kind="removed"
+            lineNumber={i + 1}
           />
         ))}
       </DiffSection>
@@ -104,6 +105,7 @@ function SideBySideDiff({
             segments={p.afterSegments}
             present={p.afterPresent}
             kind="added"
+            lineNumber={i + 1}
           />
         ))}
       </DiffSection>
@@ -130,6 +132,7 @@ function StackedDiff({ removed, added }: { removed: readonly string[]; added: re
               present
               kind="removed"
               tinted={r.changed}
+              lineNumber={i + 1}
             />
           ))
         )}
@@ -139,7 +142,14 @@ function StackedDiff({ removed, added }: { removed: readonly string[]; added: re
           <EmptyRow kind="added" />
         ) : (
           afterRows.map((r, i) => (
-            <DiffRow key={`a-${i}`} segments={r.segments} present kind="added" tinted={r.changed} />
+            <DiffRow
+              key={`a-${i}`}
+              segments={r.segments}
+              present
+              kind="added"
+              tinted={r.changed}
+              lineNumber={i + 1}
+            />
           ))
         )}
       </DiffSection>
@@ -259,13 +269,9 @@ function DiffSection({ title, children }: { title: string; children: React.React
       <div className="border-b border-[color:var(--color-border)] px-4 py-1.5 text-[0.65rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">
         {title}
       </div>
-      {/* Container-level horizontal scroll so wide records get one scrollbar
-          per section instead of one per row. `inline-block` on the row
-          content keeps lines from soft-wrapping; the outer overflow handles
-          horizontal overflow for everything inside. */}
-      <div className="overflow-x-auto">
-        <div className="min-w-full">{children}</div>
-      </div>
+      {/* Lines wrap inside each row (see DiffRow) — no per-section horizontal
+          scrollbar. Long unbroken tokens still break via break-words. */}
+      <div>{children}</div>
     </div>
   );
 }
@@ -287,19 +293,24 @@ function DiffRow({
   present,
   kind,
   tinted,
+  lineNumber,
 }: {
   segments: Segment[];
   present: boolean;
   kind: "added" | "removed";
   /** Force the row tint on for stacked-layout lines flagged as changed. */
   tinted?: boolean;
+  /** 1-based line number shown in the gutter on the left. */
+  lineNumber: number;
 }) {
   if (!present) {
     // Placeholder for one-sided pairs: a muted dash so the row is still
-    // visible and aligned with its counterpart on the other side.
+    // visible and aligned with its counterpart on the other side. The gutter
+    // is preserved so the numbering on both sides stays in lock-step.
     return (
-      <div className="px-4 py-1 font-mono text-xs whitespace-pre text-[color:var(--color-fg-subtle)]">
-        —
+      <div className="flex gap-2 px-2 py-1 font-mono text-xs text-[color:var(--color-fg-subtle)] sm:gap-3 sm:px-3">
+        <LineGutter n={lineNumber} />
+        <span className="flex-1">—</span>
       </div>
     );
   }
@@ -312,16 +323,34 @@ function DiffRow({
 
   return (
     <div
-      className={`px-4 py-1 font-mono text-xs whitespace-pre text-[color:var(--color-fg)] ${rowTint}`}
+      className={`flex gap-2 px-2 py-1 font-mono text-xs text-[color:var(--color-fg)] sm:gap-3 sm:px-3 ${rowTint}`}
     >
-      {segments.length === 0 ? (
-        <span className="text-[color:var(--color-fg-subtle)]">—</span>
-      ) : (
-        segments.map((seg, i) => (
-          <SegmentSpan key={i} text={seg.text} changed={seg.changed} kind={kind} />
-        ))
-      )}
+      <LineGutter n={lineNumber} />
+      {/* `min-w-0` lets the flex child shrink so `break-words` + `whitespace-
+          pre-wrap` can actually wrap the line instead of forcing horizontal
+          overflow. Wrapped continuations indent under THIS column, not under
+          the gutter — same visual as a code editor with soft-wrap. */}
+      <span className="min-w-0 flex-1 break-words whitespace-pre-wrap">
+        {segments.length === 0 ? (
+          <span className="text-[color:var(--color-fg-subtle)]">—</span>
+        ) : (
+          segments.map((seg, i) => (
+            <SegmentSpan key={i} text={seg.text} changed={seg.changed} kind={kind} />
+          ))
+        )}
+      </span>
     </div>
+  );
+}
+
+function LineGutter({ n }: { n: number }) {
+  return (
+    <span
+      aria-hidden
+      className="w-6 shrink-0 text-right tabular-nums text-[color:var(--color-fg-subtle)] select-none sm:w-8"
+    >
+      {n}
+    </span>
   );
 }
 

--- a/app/(app)/zones/[zoneId]/_components/clone-zone-button.tsx
+++ b/app/(app)/zones/[zoneId]/_components/clone-zone-button.tsx
@@ -14,6 +14,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useDialog } from "@/components/ui/dialog";
 import { mutate } from "@/lib/client/api-fetch";
+import { displayZoneName } from "@/lib/dns/zone-name";
 
 interface Props {
   sourceName: string;
@@ -31,7 +32,7 @@ export function CloneZoneButton({ sourceName, serverSlug }: Props) {
   async function handleClick() {
     const target = await prompt({
       title: "Clone zone",
-      description: `Creates a new zone seeded with every rrset from ${sourceName} except the SOA. PDNS regenerates the SOA on the new zone.`,
+      description: `Creates a new zone seeded with every rrset from ${displayZoneName(sourceName)} except the SOA. PDNS regenerates the SOA on the new zone.`,
       label: "New zone name",
       defaultValue: suggestTargetName(sourceName),
       placeholder: "new-zone-name.example.",

--- a/app/(app)/zones/[zoneId]/_components/editable-record-table.tsx
+++ b/app/(app)/zones/[zoneId]/_components/editable-record-table.tsx
@@ -781,7 +781,7 @@ export function EditableRecordTable(props: EditableRecordTableProps) {
                 disabled={saving}
                 className="rounded-md bg-[color:var(--color-accent)] px-4 py-2 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95 disabled:opacity-50"
               >
-                {saving ? "Applying…" : "Apply"}
+                {saving ? "Saving…" : "Save"}
               </button>
             </div>
           </div>

--- a/app/(app)/zones/[zoneId]/_components/editable-record-table.tsx
+++ b/app/(app)/zones/[zoneId]/_components/editable-record-table.tsx
@@ -21,8 +21,10 @@
 import { useRouter } from "next/navigation";
 import { useMemo, useRef, useState } from "react";
 import { type ColumnDef } from "@tanstack/react-table";
+import { Plus } from "lucide-react";
 import { Dialog, useDialog } from "@/components/ui/dialog";
 import { DataTable } from "@/components/ui/data-table";
+import { createCtaClass } from "@/components/ui/create-button";
 import { SelectMenu } from "@/components/ui/select-menu";
 import { mutate } from "@/lib/client/api-fetch";
 import {
@@ -539,11 +541,8 @@ export function EditableRecordTable(props: EditableRecordTableProps) {
     <div className="space-y-3">
       <div className="flex items-center justify-end gap-3">
         {props.canCreate ? (
-          <button
-            type="button"
-            onClick={openCreate}
-            className="rounded-md bg-[color:var(--color-accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95"
-          >
+          <button type="button" onClick={openCreate} className={createCtaClass}>
+            <Plus className="h-4 w-4" aria-hidden />
             Add record
           </button>
         ) : null}

--- a/app/(app)/zones/[zoneId]/_components/scroll-to-tab.tsx
+++ b/app/(app)/zones/[zoneId]/_components/scroll-to-tab.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+/**
+ * app/(app)/zones/[zoneId]/_components/scroll-to-tab.tsx
+ *
+ * Mobile UX fix: when the URL carries `?tab=...` (e.g. arriving on the
+ * change-history tab via a deep link or clicking a tab from the bottom of
+ * a long records list), the zone header above the tabs can push the tab
+ * body below the fold on a phone viewport. This tiny client component
+ * watches the `tab` searchParam and scrolls the named anchor into view
+ * each time it changes — including the initial mount.
+ *
+ * Default tab ("records", no `tab=` query) is the page's natural landing
+ * state, so we deliberately skip scrolling there to preserve the
+ * scroll position users had before clicking Records.
+ */
+
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+export function ScrollToTab({ anchorId }: { anchorId: string }) {
+  const sp = useSearchParams();
+  const tab = sp.get("tab");
+  useEffect(() => {
+    if (!tab) return;
+    const el = document.getElementById(anchorId);
+    if (!el) return;
+    el.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, [tab, anchorId]);
+  return null;
+}

--- a/app/(app)/zones/[zoneId]/_components/zone-change-log.tsx
+++ b/app/(app)/zones/[zoneId]/_components/zone-change-log.tsx
@@ -187,34 +187,57 @@ export function ZoneChangeLog({ entries, zoneName, pdnsHttpByRequestId }: ZoneCh
           No events match the current filters.
         </p>
       ) : (
-        <div className="overflow-hidden rounded-lg border border-[color:var(--color-border)]">
-          <table className="w-full text-sm">
-            <thead className="bg-[color:var(--color-bg-muted)] text-left text-xs font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">
-              <tr>
-                <th className="w-8 px-4 py-2.5"></th>
-                <th className="px-4 py-2.5">When</th>
-                <th className="px-4 py-2.5">Action</th>
-                <th className="px-4 py-2.5">Resource</th>
-                <th className="px-4 py-2.5">Actor</th>
-              </tr>
-            </thead>
-            <tbody>
-              {shown.map((entry) => (
-                <ChangeRow
-                  key={entry.id}
-                  entry={entry}
-                  zoneName={zoneName}
-                  expanded={expanded.has(entry.id)}
-                  onToggle={() => toggleRow(entry.id)}
-                  httpLog={httpEntriesForAuditAction(
-                    entry.action,
-                    entry.requestId ? (pdnsHttpByRequestId?.get(entry.requestId) ?? []) : [],
-                  )}
-                />
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <>
+          {/* Mobile (< md): a stacked card per entry. The desktop 5-column
+              table doesn't fit a phone viewport — Resource + Actor get clipped
+              on the right. Cards reflow to one entry per line with the same
+              expand-to-diff interaction. */}
+          <div className="space-y-2 md:hidden">
+            {shown.map((entry) => (
+              <ChangeCard
+                key={entry.id}
+                entry={entry}
+                zoneName={zoneName}
+                expanded={expanded.has(entry.id)}
+                onToggle={() => toggleRow(entry.id)}
+                httpLog={httpEntriesForAuditAction(
+                  entry.action,
+                  entry.requestId ? (pdnsHttpByRequestId?.get(entry.requestId) ?? []) : [],
+                )}
+              />
+            ))}
+          </div>
+
+          {/* Desktop (md+): the dense 5-column table. */}
+          <div className="hidden overflow-hidden rounded-lg border border-[color:var(--color-border)] md:block">
+            <table className="w-full text-sm">
+              <thead className="bg-[color:var(--color-bg-muted)] text-left text-xs font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">
+                <tr>
+                  <th className="w-8 px-4 py-2.5"></th>
+                  <th className="px-4 py-2.5">When</th>
+                  <th className="px-4 py-2.5">Action</th>
+                  <th className="px-4 py-2.5">Resource</th>
+                  <th className="px-4 py-2.5">Actor</th>
+                </tr>
+              </thead>
+              <tbody>
+                {shown.map((entry) => (
+                  <ChangeRow
+                    key={entry.id}
+                    entry={entry}
+                    zoneName={zoneName}
+                    expanded={expanded.has(entry.id)}
+                    onToggle={() => toggleRow(entry.id)}
+                    httpLog={httpEntriesForAuditAction(
+                      entry.action,
+                      entry.requestId ? (pdnsHttpByRequestId?.get(entry.requestId) ?? []) : [],
+                    )}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
 
       {filtered.length > 0 ? (
@@ -227,6 +250,73 @@ export function ZoneChangeLog({ entries, zoneName, pdnsHttpByRequestId }: ZoneCh
         />
       ) : null}
     </div>
+  );
+}
+
+/**
+ * Shared body for the expand-on-click section — same content for both the
+ * desktop table row and the mobile card. Holds the `requestId` deep link,
+ * the BareDiff (for diffable actions) or one-line event summary, and the
+ * per-operation PDNS HTTP log.
+ */
+function ExpandedPanel({
+  entry,
+  httpLog,
+}: {
+  entry: ZoneAuditEntryClient;
+  httpLog: PdnsHttpLogEntry[];
+}) {
+  const { removed, added } = useMemo(() => computeEntryDiff(entry), [entry]);
+  const diffable = isDiffableAction(entry.action);
+  return (
+    <>
+      {entry.requestId ? (
+        <div className="flex justify-end border-b border-[color:var(--color-border)] px-4 py-2 text-[0.6875rem]">
+          <a
+            href={`/admin/audit?${new URLSearchParams({ requestId: entry.requestId }).toString()}`}
+            className="text-[color:var(--color-accent)] hover:underline"
+            title="See every audit row from this operation — record edit, notify, etc."
+          >
+            View operation in audit log →
+          </a>
+        </div>
+      ) : null}
+      {diffable ? (
+        removed.length === 0 && added.length === 0 ? (
+          <p className="px-4 py-3 text-xs text-[color:var(--color-fg-muted)]">
+            Audit row carries no diffable snapshot.
+          </p>
+        ) : (
+          <BareDiff removed={removed} added={added} />
+        )
+      ) : (
+        <div className="px-4 py-3">
+          <ZoneEventLine entry={entry} />
+        </div>
+      )}
+      {httpLog.length > 0 ? <PdnsHttpLog entries={httpLog} /> : null}
+    </>
+  );
+}
+
+function Chevron({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      aria-hidden
+      className={`transition-transform ${expanded ? "rotate-90" : ""}`}
+    >
+      <path
+        d="M3 2l4 3-4 3"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }
 
@@ -243,9 +333,7 @@ function ChangeRow({
   onToggle: () => void;
   httpLog: PdnsHttpLogEntry[];
 }) {
-  const { removed, added } = useMemo(() => computeEntryDiff(entry), [entry]);
   const resourceLabel = describeResource(entry, zoneName);
-  const diffable = isDiffableAction(entry.action);
   const actor = entry.actorEmail ?? (entry.actorType === "system" ? "system" : "—");
 
   return (
@@ -254,24 +342,10 @@ function ChangeRow({
         className="cursor-pointer border-t border-[color:var(--color-border)] transition-colors hover:bg-[color-mix(in_oklch,var(--color-accent)_14%,transparent)]"
         onClick={onToggle}
         aria-expanded={expanded}
+        data-change-entry-toggle="true"
       >
         <td className="w-8 px-4 py-3 align-top text-[color:var(--color-fg-muted)]">
-          <svg
-            width="10"
-            height="10"
-            viewBox="0 0 10 10"
-            aria-hidden
-            className={`transition-transform ${expanded ? "rotate-90" : ""}`}
-          >
-            <path
-              d="M3 2l4 3-4 3"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              fill="none"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          <Chevron expanded={expanded} />
         </td>
         <td className="px-4 py-3 align-top font-mono text-[0.6875rem] whitespace-nowrap text-[color:var(--color-fg-muted)]">
           {formatTimestamp(entry.ts)}
@@ -292,35 +366,70 @@ function ChangeRow({
       {expanded ? (
         <tr className="border-t border-[color:var(--color-border)]">
           <td colSpan={5} className="bg-[color:var(--color-bg)] p-0">
-            {entry.requestId ? (
-              <div className="flex justify-end border-b border-[color:var(--color-border)] px-4 py-2 text-[0.6875rem]">
-                <a
-                  href={`/admin/audit?${new URLSearchParams({ requestId: entry.requestId }).toString()}`}
-                  className="text-[color:var(--color-accent)] hover:underline"
-                  title="See every audit row from this operation — record edit, notify, etc."
-                >
-                  View operation in audit log →
-                </a>
-              </div>
-            ) : null}
-            {diffable ? (
-              removed.length === 0 && added.length === 0 ? (
-                <p className="px-4 py-3 text-xs text-[color:var(--color-fg-muted)]">
-                  Audit row carries no diffable snapshot.
-                </p>
-              ) : (
-                <BareDiff removed={removed} added={added} />
-              )
-            ) : (
-              <div className="px-4 py-3">
-                <ZoneEventLine entry={entry} />
-              </div>
-            )}
-            {httpLog.length > 0 ? <PdnsHttpLog entries={httpLog} /> : null}
+            <ExpandedPanel entry={entry} httpLog={httpLog} />
           </td>
         </tr>
       ) : null}
     </>
+  );
+}
+
+/**
+ * Mobile (< md) replacement for ChangeRow. A clickable card whose header
+ * stacks timestamp + action chip + resource + actor vertically so nothing
+ * gets clipped at 360 px wide. The expanded body reuses ExpandedPanel.
+ */
+function ChangeCard({
+  entry,
+  zoneName,
+  expanded,
+  onToggle,
+  httpLog,
+}: {
+  entry: ZoneAuditEntryClient;
+  zoneName: string;
+  expanded: boolean;
+  onToggle: () => void;
+  httpLog: PdnsHttpLogEntry[];
+}) {
+  const resourceLabel = describeResource(entry, zoneName);
+  const actor = entry.actorEmail ?? (entry.actorType === "system" ? "system" : "—");
+  return (
+    <div className="overflow-hidden rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)]">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        data-change-entry-toggle="true"
+        className="flex w-full items-start gap-2 p-3 text-left transition-colors hover:bg-[color:var(--color-bg-subtle)]"
+      >
+        <span className="mt-1.5 shrink-0 text-[color:var(--color-fg-muted)]">
+          <Chevron expanded={expanded} />
+        </span>
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1">
+            <span className="font-mono text-[0.6875rem] whitespace-nowrap text-[color:var(--color-fg-muted)]">
+              {formatTimestamp(entry.ts)}
+            </span>
+            <ActionChip action={entry.action} />
+          </div>
+          <div className="font-mono text-xs break-all text-[color:var(--color-fg)]">
+            {resourceLabel ?? "—"}
+          </div>
+          <div className="text-xs text-[color:var(--color-fg-muted)]">
+            {actor}
+            {entry.actorName ? (
+              <span className="ml-1 text-[color:var(--color-fg-subtle)]">({entry.actorName})</span>
+            ) : null}
+          </div>
+        </div>
+      </button>
+      {expanded ? (
+        <div className="border-t border-[color:var(--color-border)]">
+          <ExpandedPanel entry={entry} httpLog={httpLog} />
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/app/(app)/zones/[zoneId]/_components/zone-change-log.tsx
+++ b/app/(app)/zones/[zoneId]/_components/zone-change-log.tsx
@@ -187,15 +187,15 @@ export function ZoneChangeLog({ entries, zoneName, pdnsHttpByRequestId }: ZoneCh
           No events match the current filters.
         </p>
       ) : (
-        <div className="overflow-hidden rounded-md border border-[color:var(--color-border)]">
-          <table className="w-full text-xs">
-            <thead className="bg-[color:var(--color-bg-subtle)] text-left text-[0.625rem] tracking-wide text-[color:var(--color-fg-muted)] uppercase">
+        <div className="overflow-hidden rounded-lg border border-[color:var(--color-border)]">
+          <table className="w-full text-sm">
+            <thead className="bg-[color:var(--color-bg-muted)] text-left text-xs font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">
               <tr>
-                <th className="w-8 py-2 pr-2 pl-3"></th>
-                <th className="py-2 pr-3 font-medium">When</th>
-                <th className="py-2 pr-3 font-medium">Action</th>
-                <th className="py-2 pr-3 font-medium">Resource</th>
-                <th className="py-2 pr-3 font-medium">Actor</th>
+                <th className="w-8 px-4 py-2.5"></th>
+                <th className="px-4 py-2.5">When</th>
+                <th className="px-4 py-2.5">Action</th>
+                <th className="px-4 py-2.5">Resource</th>
+                <th className="px-4 py-2.5">Actor</th>
               </tr>
             </thead>
             <tbody>
@@ -251,11 +251,11 @@ function ChangeRow({
   return (
     <>
       <tr
-        className="cursor-pointer border-t border-[color:var(--color-border)] hover:bg-[color:var(--color-bg-subtle)]"
+        className="cursor-pointer border-t border-[color:var(--color-border)] transition-colors hover:bg-[color-mix(in_oklch,var(--color-accent)_14%,transparent)]"
         onClick={onToggle}
         aria-expanded={expanded}
       >
-        <td className="py-2 pr-2 pl-3 text-[color:var(--color-fg-muted)]">
+        <td className="w-8 px-4 py-3 align-top text-[color:var(--color-fg-muted)]">
           <svg
             width="10"
             height="10"
@@ -273,14 +273,16 @@ function ChangeRow({
             />
           </svg>
         </td>
-        <td className="py-2 pr-3 font-mono whitespace-nowrap text-[color:var(--color-fg-muted)]">
+        <td className="px-4 py-3 align-top font-mono text-[0.6875rem] whitespace-nowrap text-[color:var(--color-fg-muted)]">
           {formatTimestamp(entry.ts)}
         </td>
-        <td className="py-2 pr-3">
+        <td className="px-4 py-3 align-top">
           <ActionChip action={entry.action} />
         </td>
-        <td className="py-2 pr-3 font-mono text-[color:var(--color-fg)]">{resourceLabel ?? "—"}</td>
-        <td className="py-2 pr-3 text-[color:var(--color-fg-muted)]">
+        <td className="px-4 py-3 align-top font-mono text-xs text-[color:var(--color-fg)]">
+          {resourceLabel ?? "—"}
+        </td>
+        <td className="px-4 py-3 align-top text-xs text-[color:var(--color-fg-muted)]">
           {actor}
           {entry.actorName ? (
             <span className="ml-1 text-[color:var(--color-fg-subtle)]">({entry.actorName})</span>

--- a/app/(app)/zones/[zoneId]/_components/zone-header.tsx
+++ b/app/(app)/zones/[zoneId]/_components/zone-header.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { freshnessOf } from "@/lib/freshness";
+import { displayZoneName } from "@/lib/dns/zone-name";
 import type { PdnsZoneDetail } from "@/lib/pdns/types";
 import type { ZoneAuditEntry } from "@/lib/db/repositories/audit-log";
 import { CloneZoneButton } from "./clone-zone-button";
@@ -58,7 +59,9 @@ export function ZoneHeader({
 
       <header className="space-y-3">
         <div className="flex flex-wrap items-baseline justify-between gap-3">
-          <h1 className="font-mono text-2xl font-semibold tracking-tight">{zone.name}</h1>
+          <h1 className="font-mono text-2xl font-semibold tracking-tight">
+            {displayZoneName(zone.name)}
+          </h1>
           <ZoneRealtimeSubscriber zoneName={zone.name} inSync={inSync} />
         </div>
         <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm sm:grid-cols-4">

--- a/app/(app)/zones/[zoneId]/_components/zone-realtime-subscriber.tsx
+++ b/app/(app)/zones/[zoneId]/_components/zone-realtime-subscriber.tsx
@@ -1,20 +1,23 @@
 "use client";
 
 /**
- * Zone-detail realtime indicator. Pure SSE-driven via the app-wide
+ * Zone-detail realtime listener. Pure SSE-driven via the app-wide
  * RealtimeProvider — no client-side polling.
  *
- * The server-side poller adaptively quickens (chains a follow-up poll
- * every 2.5 s) while any primary↔secondary mismatch is observed, and
- * publishes a `zone.updated` event each time a serial transitions. So
- * the chip flips back to "live" within seconds of AXFR completing
- * with one router.refresh per actual change — no 1 s RSC refetch
- * storm.
+ * The server-side poller adaptively quickens (chains a follow-up poll every
+ * 2.5 s) while any primary↔secondary mismatch is observed, and publishes a
+ * `zone.updated` event each time a serial transitions. So the page refreshes
+ * within seconds of AXFR completing — one router.refresh per actual change.
+ *
+ * Renders nothing visible: the "SYNCED / DESYNCED" chip lives in the shared
+ * HeaderStatusChip in the top bar — we push the per-zone sync state into it
+ * via <HeaderStatusMode/>.
  */
 
 import { useRef } from "react";
 import { useRouter } from "next/navigation";
-import { useRealtimeEvent, useRealtimeStatus } from "@/components/realtime/realtime-provider";
+import { useRealtimeEvent } from "@/components/realtime/realtime-provider";
+import { HeaderStatusMode } from "@/components/realtime/header-status-chip";
 
 interface Props {
   zoneName: string;
@@ -23,7 +26,6 @@ interface Props {
 
 export function ZoneRealtimeSubscriber({ zoneName, inSync }: Props) {
   const router = useRouter();
-  const { status, enabled, setEnabled } = useRealtimeStatus();
   const lastRefreshAt = useRef<number>(0);
 
   useRealtimeEvent(
@@ -39,47 +41,5 @@ export function ZoneRealtimeSubscriber({ zoneName, inSync }: Props) {
     },
   );
 
-  const fastMode = !inSync;
-
-  return (
-    <button
-      type="button"
-      onClick={() => setEnabled(!enabled)}
-      title={
-        status === "live"
-          ? fastMode
-            ? "Replication in flight — waiting for AXFR to complete."
-            : "Synced — click to pause."
-          : status === "paused"
-            ? "Live updates paused — click to resume"
-            : status === "connecting"
-              ? "Connecting…"
-              : "Connection lost — auto-retrying"
-      }
-      className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase hover:bg-[color:var(--color-bg-subtle)]"
-    >
-      <span
-        className={`inline-block h-2 w-2 rounded-full ${
-          status === "live"
-            ? fastMode
-              ? "animate-pulse bg-[color:var(--color-warn)]"
-              : "animate-pulse bg-[color:var(--color-success)]"
-            : status === "connecting"
-              ? "bg-[color:var(--color-warn)]"
-              : status === "paused"
-                ? "bg-[color:var(--color-fg-subtle)]"
-                : "bg-[color:var(--color-error)]"
-        }`}
-      />
-      {status === "live"
-        ? fastMode
-          ? "desynced"
-          : "synced"
-        : status === "connecting"
-          ? "connecting"
-          : status === "paused"
-            ? "paused"
-            : "offline"}
-    </button>
-  );
+  return <HeaderStatusMode kind="sync" inSync={inSync} />;
 }

--- a/app/(app)/zones/[zoneId]/_components/zone-tabs.tsx
+++ b/app/(app)/zones/[zoneId]/_components/zone-tabs.tsx
@@ -41,8 +41,12 @@ export function ZoneTabs({
   const syncHref = `/zones/${zoneIdEncoded}?${qs}&tab=sync`;
 
   return (
-    <div className="overflow-x-auto border-b border-[color:var(--color-border)]">
-      <nav className="-mb-px flex w-max gap-6 text-sm whitespace-nowrap">
+    // Mobile (< sm): tabs wrap to multiple rows so the last one ("Change
+    // history" — the widest label) never lives off-screen. From sm+ they
+    // collapse back to a single horizontally-scrollable row, matching the
+    // dense desktop layout.
+    <div className="border-b border-[color:var(--color-border)] sm:overflow-x-auto">
+      <nav className="-mb-px flex flex-wrap gap-x-6 gap-y-2 text-sm sm:w-max sm:flex-nowrap sm:gap-y-0 sm:whitespace-nowrap">
         <TabLink href={detailHref} active={active === "records"}>
           Records
         </TabLink>

--- a/app/(app)/zones/[zoneId]/_components/zone-tabs.tsx
+++ b/app/(app)/zones/[zoneId]/_components/zone-tabs.tsx
@@ -41,8 +41,8 @@ export function ZoneTabs({
   const syncHref = `/zones/${zoneIdEncoded}?${qs}&tab=sync`;
 
   return (
-    <div className="border-b border-[color:var(--color-border)]">
-      <nav className="-mb-px flex gap-6 text-sm">
+    <div className="overflow-x-auto border-b border-[color:var(--color-border)]">
+      <nav className="-mb-px flex w-max gap-6 text-sm whitespace-nowrap">
         <TabLink href={detailHref} active={active === "records"}>
           Records
         </TabLink>
@@ -59,7 +59,7 @@ export function ZoneTabs({
         ) : null}
         {canReadMetadata ? (
           <TabLink href={metadataHref} active={active === "metadata"}>
-            Metadata
+            Metadata &amp; TSIG
           </TabLink>
         ) : null}
         <TabLink href={syncHref} active={active === "sync"}>

--- a/app/(app)/zones/[zoneId]/page.tsx
+++ b/app/(app)/zones/[zoneId]/page.tsx
@@ -54,6 +54,7 @@ import { ZoneChangeLog, type ZoneAuditEntryClient } from "./_components/zone-cha
 import type { PdnsHttpLogEntry } from "./_components/pdns-http-log";
 import { ZoneHeader } from "./_components/zone-header";
 import { ZoneTabs } from "./_components/zone-tabs";
+import { ScrollToTab } from "./_components/scroll-to-tab";
 import { redactSnapshot } from "@/lib/audit/log";
 import type { PdnsZoneDetail } from "@/lib/pdns/types";
 
@@ -382,14 +383,17 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
         </div>
       ) : null}
 
-      <ZoneTabs
-        active={tab}
-        zoneIdEncoded={encodeURIComponent(zoneId)}
-        serverSlug={selected.slug}
-        canReadDnssec={canReadDnssec}
-        canReadMetadata={canReadMetadata}
-        canReadAudit={canReadAudit}
-      />
+      <div id="zone-tabs-anchor" className="scroll-mt-4">
+        <ZoneTabs
+          active={tab}
+          zoneIdEncoded={encodeURIComponent(zoneId)}
+          serverSlug={selected.slug}
+          canReadDnssec={canReadDnssec}
+          canReadMetadata={canReadMetadata}
+          canReadAudit={canReadAudit}
+        />
+      </div>
+      <ScrollToTab anchorId="zone-tabs-anchor" />
 
       {/*
        * `key={tab}` makes React treat each tab switch as a fresh

--- a/app/(app)/zones/_components/create-zone-form.tsx
+++ b/app/(app)/zones/_components/create-zone-form.tsx
@@ -573,7 +573,7 @@ export function CreateZoneForm(props: Props) {
           disabled={saving}
           className="rounded-md bg-[color:var(--color-accent)] px-4 py-2 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95 disabled:opacity-50"
         >
-          {saving ? "Creating…" : "Create zone"}
+          {saving ? "Adding…" : "Add zone"}
         </button>
         <button
           type="button"

--- a/app/(app)/zones/_components/server-realtime-subscriber.tsx
+++ b/app/(app)/zones/_components/server-realtime-subscriber.tsx
@@ -1,37 +1,38 @@
 "use client";
 
 /**
- * Zones-list realtime indicator. Pure SSE-driven via the app-wide
- * RealtimeProvider — no client-side polling. The unified server-side
- * poller chains follow-up polls while replication is in flight, so
- * one router.refresh fires per real change, not per 1 s tick.
+ * Zones-list realtime listener. Pure SSE-driven — no client-side polling. The
+ * unified server-side poller chains follow-up polls while replication is in
+ * flight, so one router.refresh fires per real change, not per 1 s tick.
  *
- * The amalgamated zones list spans every configured backend, so the
- * subscriber listens on a *set* of channel slugs (every primary's slug
- * for primary+secondary topologies, every peer's slug for clusters)
- * and refreshes the page when any of them publishes a zone event.
+ * The amalgamated zones list spans every configured backend, so the subscriber
+ * listens on a *set* of channel slugs (every primary's slug for primary+
+ * secondary topologies, every peer's slug for clusters) and refreshes the page
+ * when any of them publishes a zone event.
+ *
+ * Renders nothing visible: the "SYNCED / DESYNCED" chip lives in the shared
+ * HeaderStatusChip in the top bar — we push the page's sync state into it via
+ * <HeaderStatusMode/>.
  */
 
 import { useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { useRealtimeEvent, useRealtimeStatus } from "@/components/realtime/realtime-provider";
+import { useRealtimeEvent } from "@/components/realtime/realtime-provider";
+import { HeaderStatusMode } from "@/components/realtime/header-status-chip";
 
 interface Props {
-  /** Channel slugs to listen on — see the file header for what counts
-   *  as a channel slug for each topology. */
+  /** Channel slugs to listen on — see the file header for what counts as a
+   *  channel slug for each topology. */
   serverSlugs: string[];
   inSync: boolean;
 }
 
 export function ServerRealtimeSubscriber({ serverSlugs, inSync }: Props) {
   const router = useRouter();
-  const { status, enabled, setEnabled } = useRealtimeStatus();
   const lastRefreshAt = useRef<number>(0);
 
-  // Sets give O(1) membership for the per-event predicate; rebuilt on
-  // the rare occasion the page's backend set changes (a server added
-  // / removed). Reads inside the predicate go through the ref captured
-  // by useRealtimeEvent so they see the latest set without resubscribing.
+  // Sets give O(1) membership for the per-event predicate; rebuilt on the rare
+  // occasion the page's backend set changes (a server added / removed).
   const slugSet = useMemo(() => new Set(serverSlugs), [serverSlugs]);
 
   useRealtimeEvent(
@@ -48,47 +49,5 @@ export function ServerRealtimeSubscriber({ serverSlugs, inSync }: Props) {
     },
   );
 
-  const fastMode = !inSync;
-
-  return (
-    <button
-      type="button"
-      onClick={() => setEnabled(!enabled)}
-      title={
-        status === "live"
-          ? fastMode
-            ? "Replication in flight — waiting for AXFR to complete."
-            : "Synced — click to pause."
-          : status === "paused"
-            ? "Live updates paused — click to resume"
-            : status === "connecting"
-              ? "Connecting…"
-              : "Connection lost — auto-retrying"
-      }
-      className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase hover:bg-[color:var(--color-bg-subtle)]"
-    >
-      <span
-        className={`inline-block h-2 w-2 rounded-full ${
-          status === "live"
-            ? fastMode
-              ? "animate-pulse bg-[color:var(--color-warn)]"
-              : "animate-pulse bg-[color:var(--color-success)]"
-            : status === "connecting"
-              ? "bg-[color:var(--color-warn)]"
-              : status === "paused"
-                ? "bg-[color:var(--color-fg-subtle)]"
-                : "bg-[color:var(--color-error)]"
-        }`}
-      />
-      {status === "live"
-        ? fastMode
-          ? "desynced"
-          : "synced"
-        : status === "connecting"
-          ? "connecting"
-          : status === "paused"
-            ? "paused"
-            : "offline"}
-    </button>
-  );
+  return <HeaderStatusMode kind="sync" inSync={inSync} />;
 }

--- a/app/(app)/zones/_components/zones-table.tsx
+++ b/app/(app)/zones/_components/zones-table.tsx
@@ -119,6 +119,14 @@ interface ZonesTableProps {
   showLastEdit: boolean;
 }
 
+/** Detail URL for a zone row — cluster-backed zones carry ?cluster=, standalone
+ *  ones carry ?server=. Shared by the name link and the clickable row. */
+function zoneHref(row: ZoneRow): string {
+  return row.backend.clusterSlug
+    ? `/zones/${encodeURIComponent(row.id)}?cluster=${encodeURIComponent(row.backend.clusterSlug)}`
+    : `/zones/${encodeURIComponent(row.id)}?server=${encodeURIComponent(row.backend.serverSlug)}`;
+}
+
 export function ZonesTable({ zones, showLastEdit }: ZonesTableProps) {
   const columns = useMemo<Array<ColumnDef<ZoneRow, unknown>>>(() => {
     const cols: Array<ColumnDef<ZoneRow, unknown>> = [
@@ -127,12 +135,9 @@ export function ZonesTable({ zones, showLastEdit }: ZonesTableProps) {
         header: "Name",
         cell: (ctx) => {
           const row = ctx.row.original;
-          const href = row.backend.clusterSlug
-            ? `/zones/${encodeURIComponent(row.id)}?cluster=${encodeURIComponent(row.backend.clusterSlug)}`
-            : `/zones/${encodeURIComponent(row.id)}?server=${encodeURIComponent(row.backend.serverSlug)}`;
           return (
             <Link
-              href={href}
+              href={zoneHref(row)}
               prefetch={false}
               className="font-medium text-[color:var(--color-accent)] hover:underline"
             >
@@ -287,6 +292,7 @@ export function ZonesTable({ zones, showLastEdit }: ZonesTableProps) {
         sortParam="sort"
         pageSizeParam="pageSize"
         stateKey="zones"
+        rowHref={zoneHref}
         noDataMessage={
           scope === "forward"
             ? "No forward zones across any backend yet."

--- a/app/(app)/zones/_components/zones-table.tsx
+++ b/app/(app)/zones/_components/zones-table.tsx
@@ -17,6 +17,7 @@ import { Lock, Unlock } from "lucide-react";
 import { DataTable } from "@/components/ui/data-table";
 import { freshnessOf, freshnessOfDay } from "@/lib/freshness";
 import { isReverseZone } from "@/lib/dns/zone-kind";
+import { displayZoneName } from "@/lib/dns/zone-name";
 
 type ScopeFilter = "all" | "forward" | "reverse";
 const SCOPE_STORAGE_KEY = "pda.zones.scope";
@@ -135,7 +136,7 @@ export function ZonesTable({ zones, showLastEdit }: ZonesTableProps) {
               prefetch={false}
               className="font-medium text-[color:var(--color-accent)] hover:underline"
             >
-              {ctx.getValue<string>()}
+              {displayZoneName(ctx.getValue<string>())}
             </Link>
           );
         },

--- a/app/(app)/zones/_components/zones-table.tsx
+++ b/app/(app)/zones/_components/zones-table.tsx
@@ -15,6 +15,7 @@ import { useEffect, useMemo, useState } from "react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { Lock, Unlock } from "lucide-react";
 import { DataTable } from "@/components/ui/data-table";
+import { SyncIndicator } from "@/components/ui/sync-indicator";
 import { freshnessOf, freshnessOfDay } from "@/lib/freshness";
 import { isReverseZone } from "@/lib/dns/zone-kind";
 import { displayZoneName } from "@/lib/dns/zone-name";
@@ -384,20 +385,35 @@ function SyncCell({ row }: { row: ZoneRow }) {
     return <span className="text-xs text-[color:var(--color-fg-muted)]">—</span>;
   }
   const worst = row.syncWorst;
-  const tone =
-    worst === "in-sync"
+  const isSynced = worst === "in-sync";
+  const tone: "success" | "warn" | "error" = isSynced
+    ? "success"
+    : worst === "ahead" || worst === "lagging"
+      ? "warn"
+      : "error";
+  const textClass =
+    tone === "success"
       ? "text-[color:var(--color-success)]"
-      : worst === "ahead" || worst === "lagging"
+      : tone === "warn"
         ? "text-[color:var(--color-warn)]"
         : "text-[color:var(--color-error)]";
-  const label = worst === "in-sync" ? "synced" : "desynced";
+  const label = isSynced ? "synced" : "desynced";
+  // Include the row's own backend in the count — `syncStates` enumerates the
+  // OTHER peers (secondaries, or non-anchor cluster peers), so +1 surfaces
+  // the total fleet size the operator is looking at.
+  const total = row.syncStates.length + 1;
   const detail = row.syncStates
     .map((s) => `${s.name}: ${s.state}${s.serial !== null ? ` (serial ${s.serial})` : ""}`)
     .join("\n");
   return (
-    <span className={`text-xs ${tone}`} title={detail}>
-      ● {label}
-      <span className="ml-1 text-[color:var(--color-fg-muted)]">({row.syncStates.length})</span>
+    <span title={detail}>
+      <span
+        className={`pda-sync-chip-pad inline-flex items-center gap-1.5 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-bg)] text-[0.625rem] font-medium tracking-wide uppercase ${textClass}`}
+      >
+        <SyncIndicator state={isSynced ? "synced" : "desynced"} size={14} tone={tone} />
+        {label}
+        <span className="text-[color:var(--color-fg-muted)] tabular-nums">{total}</span>
+      </span>
     </span>
   );
 }

--- a/app/(app)/zones/new/page.tsx
+++ b/app/(app)/zones/new/page.tsx
@@ -68,7 +68,7 @@ export default async function NewZonePage({
   return (
     <div className="mx-auto max-w-3xl space-y-6">
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight">Create zone</h1>
+        <h1 className="text-2xl font-semibold tracking-tight">Add zone</h1>
         <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">
           Add a new zone to a PowerDNS backend. Pick a template to start with a known-good NS set +
           SOA timers, or fill them in by hand.

--- a/app/(app)/zones/page.tsx
+++ b/app/(app)/zones/page.tsx
@@ -221,7 +221,7 @@ export default async function ZonesPage() {
             {errors.length > 0 ? ` · ${errors.length} unreachable` : ""}.
           </p>
         </div>
-        {canCreateZone ? <CreateButton href="/zones/new" label="Create zone" /> : null}
+        {canCreateZone ? <CreateButton href="/zones/new" label="Add zone" /> : null}
       </header>
 
       {errors.length > 0 ? (

--- a/app/(app)/zones/page.tsx
+++ b/app/(app)/zones/page.tsx
@@ -27,6 +27,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { CreateButton } from "@/components/ui/create-button";
 import { requireUserForPage } from "@/lib/auth/require-user";
 import {
   listSelectableBackends,
@@ -220,14 +221,7 @@ export default async function ZonesPage() {
             {errors.length > 0 ? ` · ${errors.length} unreachable` : ""}.
           </p>
         </div>
-        {canCreateZone ? (
-          <Link
-            href="/zones/new"
-            className="rounded-md bg-[color:var(--color-accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95"
-          >
-            Create zone
-          </Link>
-        ) : null}
+        {canCreateZone ? <CreateButton href="/zones/new" label="Create zone" /> : null}
       </header>
 
       {errors.length > 0 ? (

--- a/app/(app)/zones/page.tsx
+++ b/app/(app)/zones/page.tsx
@@ -208,7 +208,7 @@ export default async function ZonesPage() {
 
   return (
     <div className="space-y-6">
-      <header className="flex items-end justify-between">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <div className="flex items-baseline gap-3">
             <h1 className="text-2xl font-semibold tracking-tight">Zones</h1>

--- a/app/api/admin/pdns/zones/[zoneId]/rrsets/route.ts
+++ b/app/api/admin/pdns/zones/[zoneId]/rrsets/route.ts
@@ -34,6 +34,7 @@ import { requireUser } from "@/lib/auth/require-user";
 import { requireCsrf } from "@/lib/auth/csrf";
 import { ForbiddenError, NotFoundError, ValidationError } from "@/lib/errors";
 import { errorResponse } from "@/lib/http/error-response";
+import { newSystemRequestId, withRequestId } from "@/lib/request-context";
 import { logger } from "@/lib/logger";
 import { redact } from "@/lib/errors/redact";
 import { findDefaultPdnsServer, findPdnsServerBySlug } from "@/lib/db/repositories/pdns-servers";
@@ -337,8 +338,15 @@ export async function PATCH(request: Request, context: RouteContext): Promise<Re
     // response returns the moment audits are flushed. The NOTIFY call
     // itself is async telemetry; the operator doesn't need to wait for
     // PDNS to acknowledge it.
+    //
+    // The background runs inside its own request-context frame with a fresh
+    // id so the NOTIFY's PDNS calls + the zone.notify audit row are tagged
+    // to a DISTINCT operation rather than leaking the parent rrset PATCH's
+    // X-Request-Id (which would otherwise attribute every async background
+    // call from this handler to one request id at confusingly varying times).
     if (zoneBefore.kind === "Master" || zoneBefore.kind === "Primary") {
-      void (async () => {
+      const notifyRequestId = newSystemRequestId();
+      void withRequestId(notifyRequestId, async () => {
         let notified = false;
         let notifyError: string | null = null;
         try {
@@ -357,12 +365,14 @@ export async function PATCH(request: Request, context: RouteContext): Promise<Re
             action: "zone.notify",
             resource: { type: "zone", id: `${server.slug}:${zoneName}` },
             after: { kind: zoneBefore.kind, success: notified, error: notifyError },
-            request: reqInfo,
+            // Use the fresh background id (matches the PDNS NOTIFY call's id)
+            // so the operator can pivot from the audit row to its PDNS log.
+            request: { ...reqInfo, requestId: notifyRequestId },
           });
         } catch {
           // audit row best-effort; the NOTIFY already happened
         }
-      })();
+      });
     }
 
     return Response.json({

--- a/app/globals.css
+++ b/app/globals.css
@@ -52,6 +52,13 @@
   --color-orange: oklch(65% 0.18 55);
   --color-error: oklch(55% 0.22 25);
 
+  /* Foreground variants for tinted badges. Yellow/orange at their semantic
+   * lightness are unreadable on top of a /15 tint of themselves — these are
+   * the darker hue used for text in that pairing (CLUSTER works because the
+   * accent indigo is already dark enough; warn/orange aren't). */
+  --color-warn-fg: oklch(38% 0.12 80);
+  --color-orange-fg: oklch(40% 0.13 55);
+
   /* Typography — system stack, zero font downloads, instant render. No CDN. */
   --font-sans:
     ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
@@ -76,6 +83,10 @@
   --color-border: oklch(30% 0 0);
   --color-accent: oklch(65% 0.18 270);
   --color-accent-fg: oklch(15% 0 0);
+  /* On dark bg the warn/orange /15 tint is a dim wash — flip the badge
+   * text to the bright variant so it still reads cleanly. */
+  --color-warn-fg: oklch(85% 0.15 80);
+  --color-orange-fg: oklch(82% 0.15 55);
 }
 
 /* ---------------------------------------------------------------------------

--- a/app/globals.css
+++ b/app/globals.css
@@ -99,6 +99,71 @@
   animation: pda-shake 0.55s cubic-bezier(0.36, 0.07, 0.19, 0.97);
 }
 
+/* Sonar/radar ping used by <SyncIndicator state="synced"/>. Two rings expand
+ * outward + fade with only a mild stroke taper, so they stay solid-line
+ * (not broken/dotted) even at small inline sizes. Second ring uses a
+ * negative animation-delay so the pulse is continuous from the first frame
+ * — no two-stationary-rings warm-up. */
+@keyframes pda-sync-pulse {
+  0% {
+    r: 10;
+    opacity: 0.85;
+    stroke-width: 4;
+  }
+  100% {
+    r: 26;
+    opacity: 0;
+    stroke-width: 3;
+  }
+}
+.pda-sync-pulse-a {
+  animation: pda-sync-pulse 2.4s ease-out infinite;
+}
+.pda-sync-pulse-b {
+  animation: pda-sync-pulse 2.4s ease-out -1.2s infinite;
+}
+
+/* "Actively trying to sync" rotation for <SyncIndicator state="desynced"/>.
+ * Both rings rotate via stroke-dashoffset (counter-direction inner vs outer)
+ * so the pattern reads as motion/search rather than a frozen error. */
+@keyframes pda-desync-spin {
+  to {
+    stroke-dashoffset: -40;
+  }
+}
+@keyframes pda-desync-spin-reverse {
+  to {
+    stroke-dashoffset: 40;
+  }
+}
+.pda-desync-ring-outer {
+  animation: pda-desync-spin 6s linear infinite;
+}
+.pda-desync-ring-inner {
+  animation: pda-desync-spin-reverse 4s linear infinite;
+}
+
+/* Padding override for the zone-list sync chip — asymmetric (tight left, wide
+ * right) so the icon hugs the left edge and the trailing count number sits
+ * comfortably on the right. `!important` wins against any utility class that
+ * might inadvertently re-add padding. */
+.pda-sync-chip-pad {
+  padding: 0 16px 0 6px !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pda-sync-pulse-a,
+  .pda-sync-pulse-b,
+  .pda-desync-ring-outer,
+  .pda-desync-ring-inner {
+    animation: none;
+  }
+  .pda-sync-pulse-a,
+  .pda-sync-pulse-b {
+    opacity: 0.4;
+  }
+}
+
 .dark {
   --color-bg: oklch(15% 0 0);
   --color-bg-subtle: oklch(20% 0 0);

--- a/app/globals.css
+++ b/app/globals.css
@@ -73,6 +73,32 @@
   --radius-lg: 0.75rem;
 }
 
+/* Used by the must-change-password banner when the operator tries to navigate
+ * away — shaken every time a click on a nav link is blocked, so the "you
+ * can't go anywhere until you change this" reason is unmistakable. */
+@keyframes pda-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  10%,
+  30%,
+  50%,
+  70%,
+  90% {
+    transform: translateX(-8px);
+  }
+  20%,
+  40%,
+  60%,
+  80% {
+    transform: translateX(8px);
+  }
+}
+.animate-shake {
+  animation: pda-shake 0.55s cubic-bezier(0.36, 0.07, 0.19, 0.97);
+}
+
 .dark {
   --color-bg: oklch(15% 0 0);
   --color-bg-subtle: oklch(20% 0 0);
@@ -83,10 +109,12 @@
   --color-border: oklch(30% 0 0);
   --color-accent: oklch(65% 0.18 270);
   --color-accent-fg: oklch(15% 0 0);
-  /* On dark bg the warn/orange /15 tint is a dim wash — flip the badge
-   * text to the bright variant so it still reads cleanly. */
-  --color-warn-fg: oklch(85% 0.15 80);
-  --color-orange-fg: oklch(82% 0.15 55);
+  /* On dark bg the warn/orange /15 tint is a dim wash of the same hue, so
+   * same-hue text (even at high lightness) visually blends. Use near-white
+   * with a faint tone instead — max lightness contrast against the dim tint,
+   * still tinted enough to read as "yellow" / "orange". */
+  --color-warn-fg: oklch(96% 0.06 80);
+  --color-orange-fg: oklch(95% 0.07 55);
 }
 
 /* ---------------------------------------------------------------------------

--- a/app/globals.css
+++ b/app/globals.css
@@ -49,6 +49,7 @@
   /* Semantic */
   --color-success: oklch(58% 0.15 145);
   --color-warn: oklch(70% 0.18 80);
+  --color-orange: oklch(65% 0.18 55);
   --color-error: oklch(55% 0.22 25);
 
   /* Typography — system stack, zero font downloads, instant render. No CDN. */

--- a/app/globals.css
+++ b/app/globals.css
@@ -87,16 +87,11 @@
  * `.dark` class lets the toggle win.
  * ------------------------------------------------------------------------- */
 html {
-  /* Bumps every rem-based size (text, padding, gap, border-radius, …)
-   * by 20%. Equivalent to having the browser zoomed to 120% on a
-   * default-16px-root setup, but baked into the page so it lands the
-   * same regardless of the operator's browser zoom. Tables already
-   * use overflow-x-auto inside DataTable, so the wider content stays
-   * scrollable on narrow viewports.
-   *
-   * Multiplicative (not absolute): if a user has bumped their browser
-   * font-size for accessibility, our 120% applies on top of theirs. */
-  font-size: 120%;
+  /* Root stays at the browser default (typically 16px) so rem-based spacing,
+   * gaps, and radii are true to the design. The comfortably-large *text* scale
+   * lives in the Tailwind `fontSize` theme (each utility ≈1.2× default),
+   * replacing the former blanket `font-size: 120%` here — which also inflated
+   * spacing and made the UI feel zoomed, especially on mobile. */
   background-color: var(--color-bg);
   color: var(--color-fg);
   color-scheme: light;

--- a/components/auth/must-change-password-guard.tsx
+++ b/components/auth/must-change-password-guard.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+/**
+ * components/auth/must-change-password-guard.tsx
+ *
+ * When the operator must change their password, they're already shunted to
+ * /profile by the server (`requireUserForPage`). Without help, clicking any nav
+ * link still triggers a Next.js soft-navigation flash (loading shimmer, URL
+ * change, redirect bounce) before the server pulls them back. This guard
+ * intercepts those clicks on the client *before* the navigation starts and
+ * tells the banner to shake — so the operator stays put and the reason is
+ * obvious.
+ *
+ * Composition:
+ *   - <MustChangePasswordProvider blocked={...}/> wraps the app (mounted in
+ *     the (app) layout). Owns the "blocked" flag + a shake counter.
+ *   - The provider mounts a capture-phase document click handler that no-ops
+ *     internal <a> clicks while blocked, except for routes the operator is
+ *     allowed to use (/profile + auth APIs + external links).
+ *   - <MustChangePasswordBanner/> reads the counter; its key changes on each
+ *     blocked attempt, which restarts the shake animation.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+interface ContextValue {
+  blocked: boolean;
+  shakeKey: number;
+  triggerShake: () => void;
+}
+
+const Ctx = createContext<ContextValue>({
+  blocked: false,
+  shakeKey: 0,
+  triggerShake: () => undefined,
+});
+
+/** Paths the operator is allowed to reach while their password is forced. */
+const ALLOW_PREFIXES = ["/profile", "/api/profile/", "/api/auth/", "/login", "/logout"];
+
+function isAllowedHref(href: string): boolean {
+  // External links + anchors aren't navigation we should block.
+  if (
+    href.startsWith("http://") ||
+    href.startsWith("https://") ||
+    href.startsWith("mailto:") ||
+    href.startsWith("#") ||
+    href === ""
+  ) {
+    return true;
+  }
+  return ALLOW_PREFIXES.some(
+    (p) => href === p || href.startsWith(`${p}?`) || href.startsWith(`${p}/`),
+  );
+}
+
+export function MustChangePasswordProvider({
+  blocked,
+  children,
+}: {
+  blocked: boolean;
+  children: ReactNode;
+}) {
+  const [shakeKey, setShakeKey] = useState(0);
+  const triggerShake = useCallback(() => setShakeKey((k) => k + 1), []);
+
+  // Capture-phase click interceptor: catches both <a href> and Next's <Link>
+  // (which renders an <a> too) before its own handler runs. Pointer/key
+  // navigations land here too (browser fires a synthetic click).
+  useEffect(() => {
+    if (!blocked) return;
+    function onClick(e: MouseEvent) {
+      // Honor modified clicks (open in new tab) — those go to a fresh server
+      // page and our `requireUserForPage` gate handles them server-side.
+      if (
+        e.defaultPrevented ||
+        e.button !== 0 ||
+        e.metaKey ||
+        e.ctrlKey ||
+        e.shiftKey ||
+        e.altKey
+      ) {
+        return;
+      }
+      const anchor = (e.target as HTMLElement | null)?.closest?.(
+        "a[href]",
+      ) as HTMLAnchorElement | null;
+      if (!anchor) return;
+      const href = anchor.getAttribute("href") ?? "";
+      if (isAllowedHref(href)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      triggerShake();
+    }
+    document.addEventListener("click", onClick, true);
+    return () => document.removeEventListener("click", onClick, true);
+  }, [blocked, triggerShake]);
+
+  const value = useMemo<ContextValue>(
+    () => ({ blocked, shakeKey, triggerShake }),
+    [blocked, shakeKey, triggerShake],
+  );
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useMustChangePassword(): ContextValue {
+  return useContext(Ctx);
+}
+
+/** The orange banner on /profile that shakes whenever the guard blocks a nav. */
+export function MustChangePasswordBanner() {
+  const { blocked, shakeKey } = useMustChangePassword();
+  if (!blocked) return null;
+  return (
+    // `key={shakeKey}` re-mounts this node on every blocked attempt, which
+    // restarts the CSS animation cleanly (no need to toggle a class).
+    <div
+      key={shakeKey}
+      className="animate-shake rounded-md border border-[color:var(--color-warn)] bg-[color:var(--color-warn)]/10 p-4 text-sm"
+      role="alert"
+    >
+      <strong>Your password must be changed.</strong> Pick a new one below.
+    </div>
+  );
+}

--- a/components/domain/capability-badges.tsx
+++ b/components/domain/capability-badges.tsx
@@ -44,10 +44,13 @@ export function CapabilityBadges({ capabilities }: { capabilities: Capabilities 
   if (capabilities.secondary) flags.push("secondary");
   if (capabilities.autosecondary) flags.push("autosecondary");
   if (flags.length === 0) return <span className={NEUTRAL}>none</span>;
+  // Plain inline <span> wrapper (no flex) so each badge renders exactly like
+  // the CLUSTER badge in the zones list — inherited line-height and no
+  // cross-axis stretching from a flex container.
   return (
-    <span className="inline-flex flex-wrap items-center gap-1">
-      {flags.map((f) => (
-        <span key={f} className={TONE[f]}>
+    <span className="whitespace-nowrap">
+      {flags.map((f, i) => (
+        <span key={f} className={i > 0 ? `${TONE[f]} ml-1` : TONE[f]}>
           {f}
         </span>
       ))}

--- a/components/domain/capability-badges.tsx
+++ b/components/domain/capability-badges.tsx
@@ -21,16 +21,18 @@ interface Capabilities {
   autosecondary: boolean;
 }
 
+// Matches the CLUSTER / DEFAULT badges in the zones + servers lists so every
+// inline role/state badge in the app reads as one family — rounded, mono,
+// tracking-wide, uppercase; the tint colour is the only thing that varies.
 const BASE =
-  "inline-flex items-center rounded border px-1.5 py-0.5 font-mono text-[0.65rem] font-medium";
+  "inline-flex items-center rounded px-1 py-0.5 font-mono text-[0.625rem] tracking-wide uppercase";
 
-const NEUTRAL = `${BASE} border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] text-[color:var(--color-fg-muted)]`;
+const NEUTRAL = `${BASE} bg-[color:var(--color-bg-muted)] text-[color:var(--color-fg-muted)]`;
 
-// Tints use color-mix so they sit on either theme without re-defining.
 const TONE = {
-  primary: `${BASE} border-[color:var(--color-accent)]/40 bg-[color-mix(in_oklch,var(--color-accent)_12%,transparent)] text-[color:var(--color-accent)]`,
-  secondary: `${BASE} border-[color:var(--color-warn)]/40 bg-[color-mix(in_oklch,var(--color-warn)_14%,transparent)] text-[color:var(--color-warn)]`,
-  autosecondary: `${BASE} border-[color:var(--color-orange)]/40 bg-[color-mix(in_oklch,var(--color-orange)_14%,transparent)] text-[color:var(--color-orange)]`,
+  primary: `${BASE} bg-[color:var(--color-accent)]/15 text-[color:var(--color-accent)]`,
+  secondary: `${BASE} bg-[color:var(--color-warn)]/15 text-[color:var(--color-warn)]`,
+  autosecondary: `${BASE} bg-[color:var(--color-orange)]/15 text-[color:var(--color-orange)]`,
 } as const;
 
 export function CapabilityBadges({ capabilities }: { capabilities: Capabilities | null }) {

--- a/components/domain/capability-badges.tsx
+++ b/components/domain/capability-badges.tsx
@@ -21,18 +21,20 @@ interface Capabilities {
   autosecondary: boolean;
 }
 
-// Matches the CLUSTER / DEFAULT badges in the zones + servers lists so every
-// inline role/state badge in the app reads as one family — rounded, mono,
-// tracking-wide, uppercase; the tint colour is the only thing that varies.
-const BASE =
-  "inline-flex items-center rounded px-1 py-0.5 font-mono text-[0.625rem] tracking-wide uppercase";
+// Same recipe as the CLUSTER badge in the zones list and the DEFAULT badge in
+// the servers list — rounded, mono, tracking-wide, uppercase, bg-<tone>/15 —
+// so every inline role/state badge in the app reads as one family. Yellow and
+// orange need a darker -fg variant for the text (their semantic hue is too
+// light to read on top of a /15 tint of itself; accent indigo is dark enough
+// that text-accent works without a separate fg token).
+const BASE = "rounded px-1 py-0.5 font-mono text-[0.625rem] tracking-wide uppercase";
 
 const NEUTRAL = `${BASE} bg-[color:var(--color-bg-muted)] text-[color:var(--color-fg-muted)]`;
 
 const TONE = {
   primary: `${BASE} bg-[color:var(--color-accent)]/15 text-[color:var(--color-accent)]`,
-  secondary: `${BASE} bg-[color:var(--color-warn)]/15 text-[color:var(--color-warn)]`,
-  autosecondary: `${BASE} bg-[color:var(--color-orange)]/15 text-[color:var(--color-orange)]`,
+  secondary: `${BASE} bg-[color:var(--color-warn)]/15 text-[color:var(--color-warn-fg)]`,
+  autosecondary: `${BASE} bg-[color:var(--color-orange)]/15 text-[color:var(--color-orange-fg)]`,
 } as const;
 
 export function CapabilityBadges({ capabilities }: { capabilities: Capabilities | null }) {

--- a/components/domain/capability-badges.tsx
+++ b/components/domain/capability-badges.tsx
@@ -1,0 +1,52 @@
+/**
+ * components/domain/capability-badges.tsx
+ *
+ * Tinted badges for a backend's observed PDNS capabilities — one per role the
+ * daemon reports ON. Colour-coded by role so the page can be skimmed at a glance:
+ *   • primary       → accent (indigo) — write target
+ *   • secondary     → warn   (yellow) — read-only mirror
+ *   • autosecondary → orange — accepts NOTIFY-from-anyone auto-create
+ *
+ * Renders nothing fancy: a small rounded badge per active flag, joined by a
+ * narrow gap. Use anywhere a backend row shows its role (server lists, group
+ * detail, server detail).
+ */
+
+/** Subset of the capability flags this component cares about. Declared locally
+ *  so the UI layer doesn't reach into lib/pdns (the three-layer rule); any
+ *  PdnsDaemonCapabilities value structurally satisfies it. */
+interface Capabilities {
+  primary: boolean;
+  secondary: boolean;
+  autosecondary: boolean;
+}
+
+const BASE =
+  "inline-flex items-center rounded border px-1.5 py-0.5 font-mono text-[0.65rem] font-medium";
+
+const NEUTRAL = `${BASE} border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] text-[color:var(--color-fg-muted)]`;
+
+// Tints use color-mix so they sit on either theme without re-defining.
+const TONE = {
+  primary: `${BASE} border-[color:var(--color-accent)]/40 bg-[color-mix(in_oklch,var(--color-accent)_12%,transparent)] text-[color:var(--color-accent)]`,
+  secondary: `${BASE} border-[color:var(--color-warn)]/40 bg-[color-mix(in_oklch,var(--color-warn)_14%,transparent)] text-[color:var(--color-warn)]`,
+  autosecondary: `${BASE} border-[color:var(--color-orange)]/40 bg-[color-mix(in_oklch,var(--color-orange)_14%,transparent)] text-[color:var(--color-orange)]`,
+} as const;
+
+export function CapabilityBadges({ capabilities }: { capabilities: Capabilities | null }) {
+  if (!capabilities) return <span className={NEUTRAL}>unprobed</span>;
+  const flags: Array<keyof typeof TONE> = [];
+  if (capabilities.primary) flags.push("primary");
+  if (capabilities.secondary) flags.push("secondary");
+  if (capabilities.autosecondary) flags.push("autosecondary");
+  if (flags.length === 0) return <span className={NEUTRAL}>none</span>;
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      {flags.map((f) => (
+        <span key={f} className={TONE[f]}>
+          {f}
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/components/domain/health-bell.tsx
+++ b/components/domain/health-bell.tsx
@@ -99,7 +99,10 @@ export function HealthBell({ advisories }: { advisories: BellAdvisory[] }) {
             className="fixed inset-0 z-10 cursor-default"
             onClick={() => setOpen(false)}
           />
-          <div className="absolute right-0 z-20 mt-2 w-96 max-w-[90vw] overflow-hidden rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] shadow-lg">
+          {/* Mobile: fixed to the viewport with small gutters so the dropdown
+              can't overflow the right edge (the bell sits near it). sm+: back
+              to absolute-anchored under the bell at a fixed 24rem width. */}
+          <div className="fixed inset-x-3 top-14 z-20 mt-2 overflow-hidden rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] shadow-lg sm:absolute sm:inset-x-auto sm:top-auto sm:right-0 sm:w-96">
             <div className="border-b border-[color:var(--color-border)] px-3 py-2 text-xs font-semibold tracking-wide text-[color:var(--color-fg-muted)] uppercase">
               Backend health
             </div>

--- a/components/realtime/header-status-chip.tsx
+++ b/components/realtime/header-status-chip.tsx
@@ -19,6 +19,7 @@
  */
 
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { SyncIndicator } from "@/components/ui/sync-indicator";
 import { useRealtimeAvailable, useRealtimeStatus } from "./realtime-provider";
 
 type Mode = { kind: "live" } | { kind: "sync"; inSync: boolean };
@@ -110,8 +111,10 @@ export function HeaderStatusChip() {
   const showSync = isConnected && mode.kind === "sync";
   const syncLabel = showSync && mode.kind === "sync" ? (mode.inSync ? "synced" : "desynced") : null;
 
-  // The dot reflects the most critical signal — desynced beats synced, and
-  // offline/connecting beat everything.
+  // The dot purely reflects connection state. Sync state has its own glyph
+  // (<SyncIndicator/>) appended next to the synced/desynced label below — so
+  // the dot stays green-pulsing as long as the SSE stream is live, even when
+  // a backend is mid-replication.
   const dotClass =
     status === "paused"
       ? "bg-[color:var(--color-fg-subtle)]"
@@ -119,9 +122,7 @@ export function HeaderStatusChip() {
         ? "bg-[color:var(--color-error)]"
         : status === "connecting"
           ? "bg-[color:var(--color-warn)]"
-          : showSync && mode.kind === "sync" && !mode.inSync
-            ? "animate-pulse bg-[color:var(--color-warn)]"
-            : "animate-pulse bg-[color:var(--color-success)]";
+          : "animate-pulse bg-[color:var(--color-success)]";
 
   const title =
     status === "paused"
@@ -145,8 +146,13 @@ export function HeaderStatusChip() {
     >
       <span className={`inline-block h-2 w-2 rounded-full ${dotClass}`} aria-hidden />
       {connLabel}
-      {syncLabel ? <span className="text-[color:var(--color-fg-subtle)]">·</span> : null}
-      {syncLabel ? <span>{syncLabel}</span> : null}
+      {syncLabel && mode.kind === "sync" ? (
+        <>
+          <span className="text-[color:var(--color-fg-subtle)]">·</span>
+          <SyncIndicator state={mode.inSync ? "synced" : "desynced"} size={14} />
+          <span>{syncLabel}</span>
+        </>
+      ) : null}
     </button>
   );
 }

--- a/components/realtime/header-status-chip.tsx
+++ b/components/realtime/header-status-chip.tsx
@@ -19,7 +19,7 @@
  */
 
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
-import { useRealtimeStatus } from "./realtime-provider";
+import { useRealtimeAvailable, useRealtimeStatus } from "./realtime-provider";
 
 type Mode = { kind: "live" } | { kind: "sync"; inSync: boolean };
 const DEFAULT_MODE: Mode = { kind: "live" };
@@ -62,8 +62,14 @@ export function HeaderStatusMode(props: { kind: "live" } | { kind: "sync"; inSyn
 }
 
 export function HeaderStatusChip() {
+  const available = useRealtimeAvailable();
   const { status, enabled, setEnabled } = useRealtimeStatus();
   const { mode } = useHeaderStatus();
+
+  // When the layout deliberately skips the RealtimeProvider (e.g. a
+  // compliance-redirected user who can't reach /api/realtime) the chip
+  // would otherwise be stuck on "CONNECTING" forever — render nothing.
+  if (!available) return null;
 
   // Map state → { label, dotClass, title }.
   let label: string;

--- a/components/realtime/header-status-chip.tsx
+++ b/components/realtime/header-status-chip.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+/**
+ * components/realtime/header-status-chip.tsx
+ *
+ * The SSE connection chip that lives in the top header (left, just past the
+ * hamburger). One chip for the whole app — its *label* varies per page:
+ *
+ *   • Dashboard (default)         → "Live"
+ *   • Zones, Zone detail, Servers → "Synced" / "Desynced" (replication aware)
+ *
+ * Pages set the label by mounting a tiny <HeaderStatusMode/> client component
+ * (no UI, just pushes the desired mode into context). When the page unmounts
+ * the mode resets to the default "live" label.
+ *
+ * The chip itself reads the connection state from RealtimeProvider, which
+ * already applies a 5 s grace before reporting "offline" — so a Ctrl-R won't
+ * flash offline → connecting → live, only connecting → live.
+ */
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { useRealtimeStatus } from "./realtime-provider";
+
+type Mode = { kind: "live" } | { kind: "sync"; inSync: boolean };
+const DEFAULT_MODE: Mode = { kind: "live" };
+
+interface HeaderStatusContextValue {
+  mode: Mode;
+  setMode: (mode: Mode) => void;
+}
+
+const HeaderStatusContext = createContext<HeaderStatusContextValue | null>(null);
+
+export function HeaderStatusProvider({ children }: { children: ReactNode }) {
+  const [mode, setMode] = useState<Mode>(DEFAULT_MODE);
+  return (
+    <HeaderStatusContext.Provider value={{ mode, setMode }}>
+      {children}
+    </HeaderStatusContext.Provider>
+  );
+}
+
+function useHeaderStatus(): HeaderStatusContextValue {
+  return useContext(HeaderStatusContext) ?? { mode: DEFAULT_MODE, setMode: () => undefined };
+}
+
+/**
+ * Tiny no-UI helper a page mounts to tell the header chip what label/state to
+ * show. Resets back to the default "Live" mode on unmount.
+ */
+export function HeaderStatusMode(props: { kind: "live" } | { kind: "sync"; inSync: boolean }) {
+  const { setMode } = useHeaderStatus();
+  // Stringify the props so the effect only re-runs when something *actually*
+  // changes (object identity changes every render otherwise).
+  const key = props.kind === "sync" ? `sync:${props.inSync}` : "live";
+  useEffect(() => {
+    setMode(props.kind === "sync" ? { kind: "sync", inSync: props.inSync } : { kind: "live" });
+    return () => setMode(DEFAULT_MODE);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, setMode]);
+  return null;
+}
+
+export function HeaderStatusChip() {
+  const { status, enabled, setEnabled } = useRealtimeStatus();
+  const { mode } = useHeaderStatus();
+
+  // Map state → { label, dotClass, title }.
+  let label: string;
+  let dotClass: string;
+  let title: string;
+  if (status === "paused") {
+    label = "paused";
+    dotClass = "bg-[color:var(--color-fg-subtle)]";
+    title = "Live updates paused — click to resume";
+  } else if (status === "offline") {
+    label = "offline";
+    dotClass = "bg-[color:var(--color-error)]";
+    title = "Connection lost — auto-retrying";
+  } else if (status === "connecting") {
+    label = "connecting";
+    dotClass = "bg-[color:var(--color-warn)]";
+    title = "Connecting…";
+  } else if (mode.kind === "sync") {
+    if (mode.inSync) {
+      label = "synced";
+      dotClass = "animate-pulse bg-[color:var(--color-success)]";
+      title = "Synced — click to pause";
+    } else {
+      label = "desynced";
+      dotClass = "animate-pulse bg-[color:var(--color-warn)]";
+      title = "Replication in flight — waiting for AXFR to complete";
+    }
+  } else {
+    label = "live";
+    dotClass = "animate-pulse bg-[color:var(--color-success)]";
+    title = "Live updates streaming — click to pause";
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setEnabled(!enabled)}
+      title={title}
+      className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase hover:bg-[color:var(--color-bg-subtle)]"
+    >
+      <span className={`inline-block h-2 w-2 rounded-full ${dotClass}`} aria-hidden />
+      {label}
+    </button>
+  );
+}

--- a/components/realtime/header-status-chip.tsx
+++ b/components/realtime/header-status-chip.tsx
@@ -22,42 +22,65 @@ import { createContext, useContext, useEffect, useState, type ReactNode } from "
 import { useRealtimeAvailable, useRealtimeStatus } from "./realtime-provider";
 
 type Mode = { kind: "live" } | { kind: "sync"; inSync: boolean };
-const DEFAULT_MODE: Mode = { kind: "live" };
+const FALLBACK_MODE: Mode = { kind: "live" };
 
 interface HeaderStatusContextValue {
   mode: Mode;
-  setMode: (mode: Mode) => void;
+  setOverride: (mode: Mode | null) => void;
 }
 
 const HeaderStatusContext = createContext<HeaderStatusContextValue | null>(null);
 
-export function HeaderStatusProvider({ children }: { children: ReactNode }) {
-  const [mode, setMode] = useState<Mode>(DEFAULT_MODE);
+/**
+ * `initialMode` is the chip's default for pages that don't push their own
+ * sync state via `<HeaderStatusMode/>`. The app shell passes the fleet-wide
+ * verdict from `globalAnyLagging()` here so every page has a meaningful chip,
+ * not a generic "Live" label. Per-page `<HeaderStatusMode/>` sets a transient
+ * override (zone detail's per-zone view, zones-list's amalgamated view); on
+ * unmount the override clears and the chip falls back to whatever the layout
+ * is currently rendering — a router.refresh after a mutation re-runs the
+ * layout, so the global verdict stays fresh without prop-syncing into state.
+ */
+export function HeaderStatusProvider({
+  children,
+  initialMode = FALLBACK_MODE,
+}: {
+  children: ReactNode;
+  initialMode?: Mode;
+}) {
+  const [override, setOverride] = useState<Mode | null>(null);
+  const mode = override ?? initialMode;
   return (
-    <HeaderStatusContext.Provider value={{ mode, setMode }}>
+    <HeaderStatusContext.Provider value={{ mode, setOverride }}>
       {children}
     </HeaderStatusContext.Provider>
   );
 }
 
 function useHeaderStatus(): HeaderStatusContextValue {
-  return useContext(HeaderStatusContext) ?? { mode: DEFAULT_MODE, setMode: () => undefined };
+  return (
+    useContext(HeaderStatusContext) ?? {
+      mode: FALLBACK_MODE,
+      setOverride: () => undefined,
+    }
+  );
 }
 
 /**
  * Tiny no-UI helper a page mounts to tell the header chip what label/state to
- * show. Resets back to the default "Live" mode on unmount.
+ * show. Clears the override on unmount, so leaving the page falls the chip
+ * back to the provider's initialMode (the layout's fleet-wide verdict).
  */
 export function HeaderStatusMode(props: { kind: "live" } | { kind: "sync"; inSync: boolean }) {
-  const { setMode } = useHeaderStatus();
+  const { setOverride } = useHeaderStatus();
   // Stringify the props so the effect only re-runs when something *actually*
   // changes (object identity changes every render otherwise).
   const key = props.kind === "sync" ? `sync:${props.inSync}` : "live";
   useEffect(() => {
-    setMode(props.kind === "sync" ? { kind: "sync", inSync: props.inSync } : { kind: "live" });
-    return () => setMode(DEFAULT_MODE);
+    setOverride(props.kind === "sync" ? { kind: "sync", inSync: props.inSync } : { kind: "live" });
+    return () => setOverride(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key, setMode]);
+  }, [key, setOverride]);
   return null;
 }
 
@@ -67,41 +90,51 @@ export function HeaderStatusChip() {
   const { mode } = useHeaderStatus();
 
   // When the layout deliberately skips the RealtimeProvider (e.g. a
-  // compliance-redirected user who can't reach /api/realtime) the chip
-  // would otherwise be stuck on "CONNECTING" forever — render nothing.
+  // compliance-redirected user who can't reach /api/realtime) the chip would
+  // otherwise be stuck on "CONNECTING" forever — render nothing.
   if (!available) return null;
 
-  // Map state → { label, dotClass, title }.
-  let label: string;
-  let dotClass: string;
-  let title: string;
-  if (status === "paused") {
-    label = "paused";
-    dotClass = "bg-[color:var(--color-fg-subtle)]";
-    title = "Live updates paused — click to resume";
-  } else if (status === "offline") {
-    label = "offline";
-    dotClass = "bg-[color:var(--color-error)]";
-    title = "Connection lost — auto-retrying";
-  } else if (status === "connecting") {
-    label = "connecting";
-    dotClass = "bg-[color:var(--color-warn)]";
-    title = "Connecting…";
-  } else if (mode.kind === "sync") {
-    if (mode.inSync) {
-      label = "synced";
-      dotClass = "animate-pulse bg-[color:var(--color-success)]";
-      title = "Synced — click to pause";
-    } else {
-      label = "desynced";
-      dotClass = "animate-pulse bg-[color:var(--color-warn)]";
-      title = "Replication in flight — waiting for AXFR to complete";
-    }
-  } else {
-    label = "live";
-    dotClass = "animate-pulse bg-[color:var(--color-success)]";
-    title = "Live updates streaming — click to pause";
-  }
+  // Connection state is the first half of the chip and is ALWAYS shown:
+  // connecting / connected / offline / paused. The sync half (synced/desynced)
+  // is appended only when actually connected on a page that pushed sync mode —
+  // never show two stale states (offline AND synced doesn't make sense).
+  const isConnected = status === "live";
+  const connLabel =
+    status === "paused"
+      ? "paused"
+      : status === "offline"
+        ? "offline"
+        : status === "connecting"
+          ? "connecting"
+          : "connected";
+  const showSync = isConnected && mode.kind === "sync";
+  const syncLabel = showSync && mode.kind === "sync" ? (mode.inSync ? "synced" : "desynced") : null;
+
+  // The dot reflects the most critical signal — desynced beats synced, and
+  // offline/connecting beat everything.
+  const dotClass =
+    status === "paused"
+      ? "bg-[color:var(--color-fg-subtle)]"
+      : status === "offline"
+        ? "bg-[color:var(--color-error)]"
+        : status === "connecting"
+          ? "bg-[color:var(--color-warn)]"
+          : showSync && mode.kind === "sync" && !mode.inSync
+            ? "animate-pulse bg-[color:var(--color-warn)]"
+            : "animate-pulse bg-[color:var(--color-success)]";
+
+  const title =
+    status === "paused"
+      ? "Live updates paused — click to resume"
+      : status === "offline"
+        ? "Connection lost — auto-retrying"
+        : status === "connecting"
+          ? "Connecting…"
+          : showSync && mode.kind === "sync" && !mode.inSync
+            ? "Connected — replication in flight (waiting for AXFR)"
+            : showSync
+              ? "Connected — all backends in sync"
+              : "Connected — live updates streaming";
 
   return (
     <button
@@ -111,7 +144,9 @@ export function HeaderStatusChip() {
       className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase hover:bg-[color:var(--color-bg-subtle)]"
     >
       <span className={`inline-block h-2 w-2 rounded-full ${dotClass}`} aria-hidden />
-      {label}
+      {connLabel}
+      {syncLabel ? <span className="text-[color:var(--color-fg-subtle)]">·</span> : null}
+      {syncLabel ? <span>{syncLabel}</span> : null}
     </button>
   );
 }

--- a/components/realtime/realtime-provider.tsx
+++ b/components/realtime/realtime-provider.tsx
@@ -150,6 +150,14 @@ export function RealtimeProvider({ children }: { children: ReactNode }) {
   return <RealtimeContext.Provider value={value}>{children}</RealtimeContext.Provider>;
 }
 
+/** True iff a RealtimeProvider is mounted above the caller. The header chip
+ *  uses this to render nothing when the layout deliberately skips realtime
+ *  (e.g. on the must-change-password compliance redirect where /api/realtime
+ *  would reject with 403 and the chip would be stuck on "connecting"). */
+export function useRealtimeAvailable(): boolean {
+  return useContext(RealtimeContext) !== null;
+}
+
 export function useRealtimeStatus(): {
   status: RealtimeStatus;
   enabled: boolean;

--- a/components/realtime/realtime-provider.tsx
+++ b/components/realtime/realtime-provider.tsx
@@ -39,7 +39,11 @@ export type RealtimeEvent = RealtimeEventBase & Record<string, unknown>;
 type Listener = (event: RealtimeEvent) => void;
 type Predicate = (event: RealtimeEvent) => boolean;
 
-export type RealtimeStatus = "connecting" | "live" | "error" | "paused";
+/** Public connection status — "offline" only fires after a 5s grace so a fresh
+ *  page load (or a transient blip) doesn't flash "offline" before the SSE
+ *  stream has even had a chance to open. */
+export type RealtimeStatus = "connecting" | "live" | "paused" | "offline";
+type RawStatus = "connecting" | "live" | "paused" | "error";
 
 interface ContextValue {
   status: RealtimeStatus;
@@ -59,17 +63,21 @@ interface ListenerEntry {
 
 export function RealtimeProvider({ children }: { children: ReactNode }) {
   const [enabled, setEnabled] = useState(true);
+  // `raw` is the immediate EventSource state; `status` is the public view that
+  // applies a 5 s grace before reporting "offline" — so a Ctrl-R never flashes
+  // offline → connecting → live, only connecting → live.
+  const [raw, setRaw] = useState<RawStatus>("connecting");
   const [status, setStatus] = useState<RealtimeStatus>("connecting");
   const listenersRef = useRef<Set<ListenerEntry>>(new Set());
 
   useEffect(() => {
     if (!enabled) {
-      setStatus("paused");
+      setRaw("paused");
       return;
     }
     const es = new EventSource("/api/realtime", { withCredentials: true });
-    setStatus("connecting");
-    es.onopen = () => setStatus("live");
+    setRaw("connecting");
+    es.onopen = () => setRaw("live");
     es.onmessage = (e) => {
       const data: unknown = e.data;
       if (typeof data !== "string") return;
@@ -82,7 +90,7 @@ export function RealtimeProvider({ children }: { children: ReactNode }) {
       if (!parsed || typeof parsed !== "object") return;
       const event = parsed as RealtimeEvent;
       if (event.type === "ready") {
-        setStatus("live");
+        setRaw("live");
         return;
       }
       for (const entry of listenersRef.current) {
@@ -93,11 +101,33 @@ export function RealtimeProvider({ children }: { children: ReactNode }) {
         }
       }
     };
-    es.onerror = () => setStatus("error");
+    es.onerror = () => setRaw("error");
     return () => {
       es.close();
     };
   }, [enabled]);
+
+  // Derive the public `status` from `raw` with a 5 s grace before "offline":
+  // an erroring connection keeps reading as "connecting" for the first 5 s so a
+  // freshly-loaded page (or a transient blip) never flashes "offline".
+  useEffect(() => {
+    if (raw === "live") {
+      setStatus("live");
+      return;
+    }
+    if (raw === "paused") {
+      setStatus("paused");
+      return;
+    }
+    if (raw === "connecting") {
+      setStatus("connecting");
+      return;
+    }
+    // raw === "error": keep "connecting" for 5 s, then declare "offline".
+    setStatus("connecting");
+    const t = setTimeout(() => setStatus("offline"), 5000);
+    return () => clearTimeout(t);
+  }, [raw]);
 
   const on = useCallback<ContextValue["on"]>((predicate, listener) => {
     const entry: ListenerEntry = { predicate, listener };

--- a/components/ui/app-shell.tsx
+++ b/components/ui/app-shell.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+/**
+ * components/ui/app-shell.tsx
+ *
+ * Responsive chrome for the authenticated app. On `md+` the sidebar is a static
+ * 16rem column (the classic desktop layout); below `md` it becomes an off-canvas
+ * drawer toggled by the hamburger in the top bar, with a tap-to-dismiss backdrop.
+ *
+ * The server layout owns auth + builds the sidebar/header content (RBAC-gated),
+ * then hands it here as props — this component only manages the mobile drawer
+ * state, so the data-fetching stays on the server.
+ */
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { Menu, X } from "lucide-react";
+
+export function AppShell({
+  sidebar,
+  headerControls,
+  children,
+}: {
+  sidebar: React.ReactNode;
+  headerControls: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  // Close the drawer after navigating (tapping a nav link changes the route).
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  // Esc closes the drawer; only matters while it's open on mobile.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  return (
+    <div className="flex h-dvh overflow-hidden">
+      {/* Backdrop — mobile only, fades in with the drawer. */}
+      <div
+        aria-hidden
+        onClick={() => setOpen(false)}
+        className={`fixed inset-0 z-30 bg-black/50 transition-opacity duration-200 md:hidden ${
+          open ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+      />
+
+      {/* Sidebar — off-canvas drawer on mobile, static column on md+. */}
+      <aside
+        className={`fixed inset-y-0 left-0 z-40 flex w-64 flex-col border-r border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] transition-transform duration-200 md:static md:z-auto md:translate-x-0 ${
+          open ? "translate-x-0" : "-translate-x-full"
+        }`}
+      >
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          aria-label="Close navigation"
+          className="absolute top-3 right-2 z-10 rounded-md p-2 text-[color:var(--color-fg-muted)] hover:bg-[color:var(--color-bg)] hover:text-[color:var(--color-fg)] md:hidden"
+        >
+          <X className="h-5 w-5" aria-hidden />
+        </button>
+        {sidebar}
+      </aside>
+
+      {/* Main column. */}
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="flex h-14 shrink-0 items-center gap-3 border-b border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-4">
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            aria-label="Open navigation"
+            aria-expanded={open}
+            className="-ml-1 rounded-md p-2 text-[color:var(--color-fg-muted)] hover:bg-[color:var(--color-bg-subtle)] hover:text-[color:var(--color-fg)] md:hidden"
+          >
+            <Menu className="h-5 w-5" aria-hidden />
+          </button>
+          <div className="ml-auto flex items-center gap-3">{headerControls}</div>
+        </header>
+
+        <main className="flex-1 overflow-y-auto p-4 sm:p-6 lg:p-8">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/app-shell.tsx
+++ b/components/ui/app-shell.tsx
@@ -15,6 +15,7 @@
 import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { Menu, X } from "lucide-react";
+import { HeaderStatusChip } from "@/components/realtime/header-status-chip";
 
 export function AppShell({
   sidebar,
@@ -54,7 +55,7 @@ export function AppShell({
 
       {/* Sidebar — off-canvas drawer on mobile, static column on md+. */}
       <aside
-        className={`fixed inset-y-0 left-0 z-40 flex w-64 flex-col border-r border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] transition-transform duration-200 md:static md:z-auto md:translate-x-0 ${
+        className={`fixed inset-y-0 left-0 z-40 flex w-80 flex-col border-r border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] transition-transform duration-200 md:static md:z-auto md:translate-x-0 ${
           open ? "translate-x-0" : "-translate-x-full"
         }`}
       >
@@ -81,6 +82,9 @@ export function AppShell({
           >
             <Menu className="h-5 w-5" aria-hidden />
           </button>
+          {/* Single SSE chip for the whole app — its label is driven per page
+              via <HeaderStatusMode/> in components that own a "synced" notion. */}
+          <HeaderStatusChip />
           <div className="ml-auto flex items-center gap-3">{headerControls}</div>
         </header>
 

--- a/components/ui/app-shell.tsx
+++ b/components/ui/app-shell.tsx
@@ -14,7 +14,7 @@
 
 import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
-import { Menu, X } from "lucide-react";
+import { Menu } from "lucide-react";
 import { HeaderStatusChip } from "@/components/realtime/header-status-chip";
 
 export function AppShell({
@@ -59,14 +59,6 @@ export function AppShell({
           open ? "translate-x-0" : "-translate-x-full"
         }`}
       >
-        <button
-          type="button"
-          onClick={() => setOpen(false)}
-          aria-label="Close navigation"
-          className="absolute top-3 right-2 z-10 rounded-md p-2 text-[color:var(--color-fg-muted)] hover:bg-[color:var(--color-bg)] hover:text-[color:var(--color-fg)] md:hidden"
-        >
-          <X className="h-5 w-5" aria-hidden />
-        </button>
         {sidebar}
       </aside>
 

--- a/components/ui/clickable-row.tsx
+++ b/components/ui/clickable-row.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * components/ui/clickable-row.tsx
+ *
+ * Tiny client wrappers that make a server-rendered table row (or a card div)
+ * navigate on click — used by bespoke tables that don't go through DataTable
+ * but still want the same "tap anywhere on the row" UX as the DataTable lists.
+ *
+ * Inner links/buttons/form controls keep working: the click handler bails out
+ * if the click target is (or is inside) an interactive element.
+ */
+
+import { useRouter } from "next/navigation";
+import type { MouseEvent, ReactNode } from "react";
+
+const INNER_INTERACTIVE = "a,button,input,select,textarea,label,[role=button]";
+
+function activate(href: string, router: ReturnType<typeof useRouter>) {
+  return (e: MouseEvent<HTMLElement>) => {
+    if ((e.target as HTMLElement).closest(INNER_INTERACTIVE)) return;
+    router.push(href);
+  };
+}
+
+export function ClickableTr({
+  href,
+  className,
+  children,
+}: {
+  href: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  const router = useRouter();
+  return (
+    <tr onClick={activate(href, router)} className={`cursor-pointer ${className ?? ""}`}>
+      {children}
+    </tr>
+  );
+}
+
+export function ClickableDiv({
+  href,
+  className,
+  children,
+}: {
+  href: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  const router = useRouter();
+  return (
+    <div onClick={activate(href, router)} className={`cursor-pointer ${className ?? ""}`}>
+      {children}
+    </div>
+  );
+}

--- a/components/ui/create-button.tsx
+++ b/components/ui/create-button.tsx
@@ -13,7 +13,7 @@ import { Plus } from "lucide-react";
  * (e.g. "Add record", which opens a dialog) rather than links.
  */
 export const createCtaClass =
-  "inline-flex w-full items-center justify-center gap-1.5 rounded-md bg-[color:var(--color-success)] px-4 py-2 text-sm font-medium text-white hover:opacity-95 sm:w-auto";
+  "inline-flex w-full items-center justify-center gap-1.5 rounded-md bg-[color:var(--color-success)] px-4 py-2 text-sm font-medium whitespace-nowrap text-white hover:opacity-95 sm:w-auto";
 
 export function CreateButton({
   href,

--- a/components/ui/create-button.tsx
+++ b/components/ui/create-button.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { Plus } from "lucide-react";
+
+/**
+ * components/ui/create-button.tsx
+ *
+ * Primary "create / add" call-to-action. Green (deliberately distinct from the
+ * indigo accent the app uses for active tabs/links) with a leading plus icon.
+ * Full-width on mobile, auto-width on `sm+` — pairs with the stacked page
+ * headers so the CTA reads as a clear full-width button on a phone.
+ *
+ * `createCtaClass` is exported for the handful of CTAs that are <button>s
+ * (e.g. "Add record", which opens a dialog) rather than links.
+ */
+export const createCtaClass =
+  "inline-flex w-full items-center justify-center gap-1.5 rounded-md bg-[color:var(--color-success)] px-4 py-2 text-sm font-medium text-white hover:opacity-95 sm:w-auto";
+
+export function CreateButton({
+  href,
+  label,
+  className = "",
+}: {
+  href: string;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <Link href={href} className={`${createCtaClass} ${className}`}>
+      <Plus className="h-4 w-4" aria-hidden />
+      {label}
+    </Link>
+  );
+}

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -142,9 +142,22 @@ export interface DataTableProps<TData> {
    * the PDNS-requests viewer to expand a request's full HTTP log in place.
    */
   renderRowDetail?: (row: TData) => React.ReactNode;
+  /**
+   * When set, the whole row (desktop) and card (mobile) become clickable,
+   * navigating to `rowHref(row)`. Clicks that land on an inner link, button, or
+   * form control are left alone, so per-row actions (Edit, Delete, …) and the
+   * name link still work. Pair it with the same href the name cell links to.
+   */
+  rowHref?: (row: TData) => string;
 }
 
 const DEFAULT_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
+/** A column with no header text is an "action" column (View, Edit, …). We size
+ *  those to their content so spare table width lands on the data columns. */
+function isUnlabeledColumn(def: { header?: unknown }): boolean {
+  return def.header == null || def.header === "";
+}
 
 export function DataTable<TData>({
   columns,
@@ -163,6 +176,7 @@ export function DataTable<TData>({
   stateKey,
   layout = "auto",
   renderRowDetail,
+  rowHref,
 }: DataTableProps<TData>) {
   const router = useRouter();
   const pathname = usePathname();
@@ -321,6 +335,15 @@ export function DataTable<TData>({
     return flexRender(def, h.getContext());
   };
 
+  // Row/card click → navigate, unless the click landed on an interactive
+  // element (link, button, form control) so per-row actions keep working.
+  const activateRow = (target: EventTarget | null, original: TData) => {
+    if (!rowHref) return;
+    const el = target as HTMLElement | null;
+    if (el?.closest("a,button,input,select,textarea,label,[role=button]")) return;
+    router.push(rowHref(original));
+  };
+
   return (
     <div className={`space-y-3 ${className}`}>
       {!hideSearch ? (
@@ -363,7 +386,12 @@ export function DataTable<TData>({
             return (
               <div
                 key={row.id}
-                className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-4"
+                onClick={(e) => activateRow(e.target, row.original)}
+                className={`rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-4 ${
+                  rowHref
+                    ? "cursor-pointer transition-colors active:bg-[color:var(--color-bg-subtle)]"
+                    : ""
+                }`}
               >
                 {cells.map((cell, i) => {
                   const label = headerLabel(cell.column.id);
@@ -418,6 +446,12 @@ export function DataTable<TData>({
                         scope="col"
                         className={[
                           "px-4 py-2.5",
+                          // Action columns (no header text) shrink to content so
+                          // the table's spare width spreads across the data
+                          // columns instead of opening a gap before the actions.
+                          layout === "auto" && isUnlabeledColumn(header.column.columnDef)
+                            ? "w-px whitespace-nowrap"
+                            : "",
                           canSort
                             ? "cursor-pointer select-none hover:bg-[color:var(--color-bg-muted)]"
                             : "",
@@ -470,6 +504,7 @@ export function DataTable<TData>({
                   return (
                     <Fragment key={row.id}>
                       <tr
+                        onClick={(e) => activateRow(e.target, row.original)}
                         // Four visually distinct row states, all token-driven so
                         // both themes track automatically:
                         //   header → bg-muted (the strongest neutral, anchors the top)
@@ -481,13 +516,18 @@ export function DataTable<TData>({
                         // it reads identically on odd and even rows. Tailwind emits
                         // the `hover:` variant after `even:`, so hover wins the
                         // cascade on striped rows without needing `!important`.
-                        className="border-t border-[color:var(--color-border)] transition-colors even:bg-[color:var(--color-bg-subtle)] hover:bg-[color-mix(in_oklch,var(--color-accent)_14%,transparent)]"
+                        className={`border-t border-[color:var(--color-border)] transition-colors even:bg-[color:var(--color-bg-subtle)] hover:bg-[color-mix(in_oklch,var(--color-accent)_14%,transparent)] ${
+                          rowHref ? "cursor-pointer" : ""
+                        }`}
                       >
                         {row.getVisibleCells().map((cell) => (
                           <td
                             key={cell.id}
                             className={[
                               "px-4 py-3 align-top",
+                              layout === "auto" && isUnlabeledColumn(cell.column.columnDef)
+                                ? "w-px whitespace-nowrap"
+                                : "",
                               cell.column.columnDef.meta?.className ?? "",
                             ].join(" ")}
                           >

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -539,13 +539,14 @@ export function DataTable<TData>({
                 onClick={() => table.setPageIndex(0)}
                 disabled={!table.getCanPreviousPage()}
                 label="First"
+                className="hidden sm:inline-block"
               />
               <PaginationButton
                 onClick={() => table.previousPage()}
                 disabled={!table.getCanPreviousPage()}
                 label="Prev"
               />
-              <span className="px-2 tabular-nums">
+              <span className="px-2 whitespace-nowrap tabular-nums">
                 {table.getState().pagination.pageIndex + 1} / {Math.max(1, table.getPageCount())}
               </span>
               <PaginationButton
@@ -557,6 +558,7 @@ export function DataTable<TData>({
                 onClick={() => table.setPageIndex(table.getPageCount() - 1)}
                 disabled={!table.getCanNextPage()}
                 label="Last"
+                className="hidden sm:inline-block"
               />
             </div>
           </div>
@@ -570,17 +572,19 @@ function PaginationButton({
   onClick,
   disabled,
   label,
+  className = "",
 }: {
   onClick: () => void;
   disabled: boolean;
   label: string;
+  className?: string;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 text-xs hover:bg-[color:var(--color-bg-subtle)] disabled:opacity-40"
+      className={`rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 text-xs hover:bg-[color:var(--color-bg-subtle)] disabled:opacity-40 ${className}`}
     >
       {label}
     </button>

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -310,6 +310,17 @@ export function DataTable<TData>({
   const showingFrom = rows.length === 0 ? 0 : pagination.pageIndex * pagination.pageSize + 1;
   const showingTo = pagination.pageIndex * pagination.pageSize + rows.length;
 
+  // Leaf header cells, used to label fields in the mobile card view. A column
+  // with no header text (action columns) gets no label — its cell renders
+  // full-width at the foot of the card instead.
+  const leafHeaders = table.getHeaderGroups().at(-1)?.headers ?? [];
+  const headerLabel = (columnId: string): React.ReactNode | null => {
+    const h = leafHeaders.find((hdr) => hdr.column.id === columnId);
+    const def = h?.column.columnDef.header;
+    if (!h || def == null || def === "") return null;
+    return flexRender(def, h.getContext());
+  };
+
   return (
     <div className={`space-y-3 ${className}`}>
       {!hideSearch ? (
@@ -338,7 +349,61 @@ export function DataTable<TData>({
         </div>
       ) : null}
 
-      <div className="overflow-hidden rounded-lg border border-[color:var(--color-border)]">
+      {/* Mobile (< md): a card per row. Avoids horizontal scrolling — each
+          column becomes a labelled field, the first cell is the card title. */}
+      <div className="space-y-3 md:hidden">
+        {rows.length === 0 ? (
+          <div className="rounded-lg border border-[color:var(--color-border)] px-4 py-10 text-center text-sm text-[color:var(--color-fg-muted)]">
+            {totalCount === 0 ? noDataMessage : emptyMessage}
+          </div>
+        ) : (
+          rows.map((row) => {
+            const cells = row.getVisibleCells();
+            const detail = renderRowDetail?.(row.original);
+            return (
+              <div
+                key={row.id}
+                className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-4"
+              >
+                {cells.map((cell, i) => {
+                  const label = headerLabel(cell.column.id);
+                  const content = flexRender(cell.column.columnDef.cell, cell.getContext());
+                  // First cell → card title. Labelled cells → label/value row.
+                  // Unlabelled cells (actions) → full-width.
+                  if (i === 0) {
+                    return (
+                      <div key={cell.id} className="mb-2 text-base font-medium break-words">
+                        {content}
+                      </div>
+                    );
+                  }
+                  if (label == null) {
+                    return (
+                      <div key={cell.id} className="mt-3">
+                        {content}
+                      </div>
+                    );
+                  }
+                  return (
+                    <div
+                      key={cell.id}
+                      className="flex justify-between gap-3 border-t border-[color:var(--color-border)] py-1.5 text-sm first:border-t-0"
+                    >
+                      <span className="shrink-0 text-[color:var(--color-fg-muted)]">{label}</span>
+                      <span className="min-w-0 text-right break-words">{content}</span>
+                    </div>
+                  );
+                })}
+                {detail != null ? <div className="mt-3">{detail}</div> : null}
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      {/* Desktop (md+): the dense table. overflow-x-auto only kicks in when a
+          table genuinely can't fit — the common case stays scroll-free. */}
+      <div className="hidden overflow-hidden rounded-lg border border-[color:var(--color-border)] md:block">
         <div className="overflow-x-auto">
           <table className={`w-full text-sm ${layout === "fixed" ? "table-fixed" : ""}`}>
             <thead className="bg-[color:var(--color-bg-muted)] text-left text-xs font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">

--- a/components/ui/live-feed-subscriber.tsx
+++ b/components/ui/live-feed-subscriber.tsx
@@ -1,29 +1,30 @@
 "use client";
 
 /**
- * Live-feed indicator chip. Subscribes to the app-wide RealtimeProvider
- * stream (one EventSource for the whole app) and triggers
- * router.refresh() whenever an event matching `eventTypes` lands.
- * Coalesces refresh-bursts to one per 500 ms.
+ * Live-feed event subscriber. Subscribes to the app-wide RealtimeProvider
+ * stream (one EventSource for the whole app) and triggers router.refresh()
+ * whenever an event matching `eventTypes` lands. Coalesces refresh-bursts to
+ * one per 500 ms.
+ *
+ * Renders nothing — the visible "LIVE" chip moved to the shared
+ * HeaderStatusChip in the top bar, so every page surfaces realtime status in
+ * one consistent spot.
  */
 
 import { useRef } from "react";
 import { useRouter } from "next/navigation";
-import { useRealtimeEvent, useRealtimeStatus } from "@/components/realtime/realtime-provider";
+import { useRealtimeEvent } from "@/components/realtime/realtime-provider";
 import type { RealtimeEvent } from "@/components/realtime/realtime-provider";
 
 interface Props {
-  /** Compact label shown next to the dot. Defaults to "live". */
-  label?: string;
   /** Restrict to these event types — refresh fires only on matches. */
   eventTypes?: readonly string[];
   /** Optional callback fired on every matching event. */
   onEvent?: (event: RealtimeEvent) => void;
 }
 
-export function LiveFeedSubscriber({ label, eventTypes, onEvent }: Props) {
+export function LiveFeedSubscriber({ eventTypes, onEvent }: Props) {
   const router = useRouter();
-  const { status, enabled, setEnabled } = useRealtimeStatus();
   const lastRefreshAt = useRef<number>(0);
 
   useRealtimeEvent(
@@ -37,39 +38,5 @@ export function LiveFeedSubscriber({ label, eventTypes, onEvent }: Props) {
     },
   );
 
-  return (
-    <button
-      type="button"
-      onClick={() => setEnabled(!enabled)}
-      title={
-        status === "live"
-          ? "Live updates streaming — click to pause"
-          : status === "paused"
-            ? "Live updates paused — click to resume"
-            : status === "connecting"
-              ? "Connecting…"
-              : "Connection lost — auto-retrying"
-      }
-      className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 py-1 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase hover:bg-[color:var(--color-bg-subtle)]"
-    >
-      <span
-        className={`inline-block h-2 w-2 rounded-full ${
-          status === "live"
-            ? "animate-pulse bg-[color:var(--color-success)]"
-            : status === "connecting"
-              ? "bg-[color:var(--color-warn)]"
-              : status === "paused"
-                ? "bg-[color:var(--color-fg-subtle)]"
-                : "bg-[color:var(--color-error)]"
-        }`}
-      />
-      {status === "live"
-        ? (label ?? "live")
-        : status === "connecting"
-          ? "connecting"
-          : status === "paused"
-            ? "paused"
-            : "offline"}
-    </button>
-  );
+  return null;
 }

--- a/components/ui/sync-indicator.tsx
+++ b/components/ui/sync-indicator.tsx
@@ -1,0 +1,92 @@
+/**
+ * components/ui/sync-indicator.tsx
+ *
+ * The concentric-circle glyph used wherever the UI states a replication
+ * verdict ("Synced" / "Desynced"). Defined once so every consumer renders the
+ * same shape + colour pairing — header chip, servers list, zones list all
+ * agree on what "synced" looks like.
+ *
+ * Synced: a solid centre with two outward-pulsing rings (sonar/radar ping
+ * effect via SVG SMIL — staggered 1.2 s apart so one ring is always travelling
+ * outward as the other resets).
+ * Desynced: a hollow centre ring with two static dashed concentric rings —
+ * deliberately quiet, "frozen", to read as "stuck" rather than "active".
+ *
+ * Colour travels via `currentColor`; defaults map synced → `var(--color-success)`,
+ * desynced → `var(--color-error)`. Stroke widths are tuned for the small inline
+ * sizes (12–18 px) the chips render at — thicker than typical SVG defaults so
+ * the rings stay legible without zooming.
+ */
+
+interface Props {
+  state: "synced" | "desynced";
+  /** Render size in pixels (square). 16 fits inline with `text-sm`. */
+  size?: number;
+  /**
+   * Override the colour token. Defaults to `success` for synced and `error`
+   * for desynced; pass `warn` to use the orange "transient AXFR catch-up"
+   * tone (zones list per-row sync cell uses this for the ahead/lagging
+   * states that aren't yet a hard error).
+   */
+  tone?: "success" | "warn" | "error";
+  className?: string;
+}
+
+export function SyncIndicator({ state, size = 18, tone, className }: Props) {
+  const effectiveTone = tone ?? (state === "synced" ? "success" : "error");
+  const colorToken = `var(--color-${effectiveTone})`;
+  return (
+    <span aria-hidden style={{ color: colorToken, display: "inline-flex" }} className={className}>
+      {state === "synced" ? (
+        <svg width={size} height={size} viewBox="0 0 64 64" aria-label="In sync">
+          <circle
+            cx="32"
+            cy="32"
+            r="10"
+            stroke="currentColor"
+            fill="none"
+            className="pda-sync-pulse-a"
+          />
+          <circle
+            cx="32"
+            cy="32"
+            r="10"
+            stroke="currentColor"
+            fill="none"
+            className="pda-sync-pulse-b"
+          />
+          <circle cx="32" cy="32" r="10" fill="currentColor" />
+        </svg>
+      ) : (
+        <svg
+          width={size}
+          height={size}
+          viewBox="0 0 64 64"
+          fill="none"
+          stroke="currentColor"
+          aria-label="Out of sync"
+        >
+          <circle
+            cx="32"
+            cy="32"
+            r="26"
+            strokeWidth="4"
+            opacity="0.4"
+            strokeDasharray="5 5"
+            className="pda-desync-ring-outer"
+          />
+          <circle
+            cx="32"
+            cy="32"
+            r="18"
+            strokeWidth="4"
+            opacity="0.75"
+            strokeDasharray="5 5"
+            className="pda-desync-ring-inner"
+          />
+          <circle cx="32" cy="32" r="10" strokeWidth="6" />
+        </svg>
+      )}
+    </span>
+  );
+}

--- a/components/ui/theme-toggle.tsx
+++ b/components/ui/theme-toggle.tsx
@@ -3,7 +3,10 @@
 /**
  * components/ui/theme-toggle.tsx
  *
- * Three-way light / dark / system theme switch.
+ * Light / dark / system theme switch. One button — the icon mirrors the active
+ * preference (Sun / Moon / Monitor) and clicking cycles light → dark → system →
+ * light. Same persistence + live-listener behaviour as before; only the chrome
+ * collapsed from three buttons to one.
  *
  * Behavior:
  *   - Default is "system" (follows the OS / browser preference).
@@ -13,17 +16,27 @@
  *     this prevents a flash-of-wrong-theme on page load.
  *   - This component just updates the preference + the live class and
  *     listens for OS-level changes when in "system" mode.
- *
- * No external icon CDN — Lucide ships SVGs as React components, fully
- * self-hosted per CONTRIBUTING.md.
  */
 
 import { useEffect, useState } from "react";
-import { Monitor, Moon, Sun } from "lucide-react";
+import { Monitor, Moon, Sun, type LucideIcon } from "lucide-react";
 
 type Theme = "light" | "dark" | "system";
 
 const STORAGE_KEY = "pda-theme";
+const CYCLE: readonly Theme[] = ["light", "dark", "system"];
+
+const ICON_BY_THEME: Record<Theme, LucideIcon> = {
+  light: Sun,
+  dark: Moon,
+  system: Monitor,
+};
+
+const LABEL_BY_THEME: Record<Theme, string> = {
+  light: "light",
+  dark: "dark",
+  system: "system",
+};
 
 /** Resolve a user preference to the *effective* theme (light or dark). */
 function resolveEffective(theme: Theme): "light" | "dark" {
@@ -59,58 +72,30 @@ export function ThemeToggle({ className = "" }: { className?: string }) {
     return () => media.removeEventListener("change", onChange);
   }, [theme]);
 
-  function choose(next: Theme): void {
+  function cycle(): void {
+    const idx = CYCLE.indexOf(theme);
+    const next = CYCLE[(idx + 1) % CYCLE.length] ?? "system";
     setTheme(next);
     localStorage.setItem(STORAGE_KEY, next);
     applyEffective(resolveEffective(next));
   }
 
-  // Render: three icon buttons. The active one is highlighted via aria-pressed.
-  return (
-    <div
-      role="group"
-      aria-label="Theme"
-      className={`inline-flex items-center gap-0.5 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-0.5 ${className}`}
-    >
-      <ToggleButton label="Light" pressed={theme === "light"} onClick={() => choose("light")}>
-        <Sun aria-hidden className="h-4 w-4" />
-      </ToggleButton>
-      <ToggleButton label="System" pressed={theme === "system"} onClick={() => choose("system")}>
-        <Monitor aria-hidden className="h-4 w-4" />
-      </ToggleButton>
-      <ToggleButton label="Dark" pressed={theme === "dark"} onClick={() => choose("dark")}>
-        <Moon aria-hidden className="h-4 w-4" />
-      </ToggleButton>
-    </div>
-  );
-}
+  const Icon = ICON_BY_THEME[theme];
+  const nextTheme = CYCLE[(CYCLE.indexOf(theme) + 1) % CYCLE.length] ?? "system";
+  const tooltip = `Theme: ${LABEL_BY_THEME[theme]} (click for ${LABEL_BY_THEME[nextTheme]})`;
 
-function ToggleButton({
-  label,
-  pressed,
-  onClick,
-  children,
-}: {
-  label: string;
-  pressed: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
   return (
     <button
       type="button"
-      onClick={onClick}
-      aria-pressed={pressed}
-      aria-label={label}
-      title={label}
+      onClick={cycle}
+      aria-label={tooltip}
+      title={tooltip}
       className={[
-        "flex h-7 w-7 items-center justify-center rounded transition-colors",
-        pressed
-          ? "bg-[color:var(--color-bg-muted)] text-[color:var(--color-fg)]"
-          : "text-[color:var(--color-fg-muted)] hover:bg-[color:var(--color-bg-subtle)] hover:text-[color:var(--color-fg)]",
+        "flex h-7 w-7 items-center justify-center rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] text-[color:var(--color-fg-muted)] transition-colors hover:bg-[color:var(--color-bg-subtle)] hover:text-[color:var(--color-fg)]",
+        className,
       ].join(" ")}
     >
-      {children}
+      <Icon aria-hidden className="h-4 w-4" />
     </button>
   );
 }

--- a/lib/auth/require-user.ts
+++ b/lib/auth/require-user.ts
@@ -25,6 +25,17 @@ import { UnauthorizedError, ForbiddenError } from "@/lib/errors";
 import type { Subject } from "@/lib/rbac/ability";
 import { listRoleMfaStatesForUser } from "@/lib/db/repositories/roles";
 import { getCurrentUser, type AuthenticatedRequest } from "./get-current-user";
+
+/** Routes a non-compliant user (forced-MFA-not-enrolled, mustChangePassword) is
+ *  allowed to reach so they can self-remediate. Anything else triggers a
+ *  redirect to /profile. Match by prefix. Mirrors the (app) layout's list — see
+ *  `requireUserForPage` for why we duplicate the gate per page. */
+const COMPLIANCE_ALLOWLIST: readonly string[] = [
+  "/profile",
+  "/api/profile/mfa",
+  "/api/auth/change-password",
+  "/api/auth/logout",
+];
 import { evaluateSessionCompliance } from "./session-compliance";
 
 export interface RequireUserOptions {
@@ -132,10 +143,19 @@ export async function requireUserForPage(
   opts: RequireUserOptions = {},
 ): Promise<AuthenticatedRequest> {
   try {
-    // Pages don't double-gate: the `(app)` layout already enforces compliance
-    // and redirects to /profile (nicer UX than a thrown ForbiddenError). The
-    // permission check still runs.
-    return await requireUser({ ...opts, skipComplianceGate: true });
+    // The (app) layout enforces compliance on the *initial* server render, but
+    // App Router doesn't re-run a sibling layout on soft client navigations —
+    // so without re-checking here, a forced-MFA / must-change-password user
+    // could click around freely until the next full reload. We rerun the same
+    // gate at the page level (cheap; `requireUser` already loaded the user).
+    const result = await requireUser({ ...opts, skipComplianceGate: true });
+    const hdrs = await headers();
+    const pathname = hdrs.get("x-pathname") ?? "/";
+    const allowed = COMPLIANCE_ALLOWLIST.some((p) => pathname.startsWith(p));
+    if (!allowed && result.user.mustChangePassword) {
+      redirect("/profile?must-change-password=1");
+    }
+    return result;
   } catch (err) {
     if (err instanceof UnauthorizedError) {
       // Carry the attempted path so login can return the user there (L-2).

--- a/lib/dns/zone-name.ts
+++ b/lib/dns/zone-name.ts
@@ -1,0 +1,13 @@
+/**
+ * lib/dns/zone-name.ts
+ *
+ * Zone names are stored fully-qualified, with the canonical trailing dot
+ * ("example.com."). The dot is correct on the wire but visually noisy in the
+ * UI, so we strip it *for display only*.
+ *
+ * NEVER use this for anything sent back to PDNS, used as an audit/cache key, or
+ * passed to an API — those need the canonical name. Display surfaces only.
+ */
+export function displayZoneName(name: string): string {
+  return name.replace(/\.$/, "");
+}

--- a/lib/pdns/http.ts
+++ b/lib/pdns/http.ts
@@ -26,6 +26,7 @@ import { PDNS_AGENT_OPTIONS } from "./dispatcher";
 import { recordPdnsLatency } from "./observations";
 import { withBackendLock } from "./backend-lock";
 import { checkPdnsUrlSafe } from "./url-safety";
+import { currentRequestIdOverride, hasRequestIdOverride } from "@/lib/request-context";
 import type { PdnsRequestLogInput } from "./request-log";
 
 // Lazy-loaded to keep the DB layer (and pg) out of module-init for tests that
@@ -99,17 +100,24 @@ export async function pdnsRequest<T>(config: PdnsHttpConfig, init: PdnsRequestIn
   const url = joinUrl(config.baseUrl, init.path);
   const log = logger.child({ server: config.serverSlug, op: init.op });
 
-  // Tie the audit row to the per-HTTP-request correlation id when we're
-  // inside a request scope (route handler / Server Component). Outside
-  // a request scope (background samplers, CLI scripts) `headers()`
+  // Tie the audit row to the per-HTTP-request correlation id. If we're inside
+  // an explicit request-context frame (background NOTIFY, poller tick, …) use
+  // ITS id — `next/headers` would otherwise leak the parent route handler's id
+  // into every async task spawned within the handler's scope, producing the
+  // "single user action shows 60+ unrelated PDNS calls under one request-id"
+  // symptom. Outside both frames (background samplers, CLI scripts) `headers()`
   // throws — fall back to null silently.
   let requestId: string | null;
-  try {
-    const { headers: getHeaders } = await import("next/headers");
-    const h = await getHeaders();
-    requestId = h.get("x-request-id");
-  } catch {
-    requestId = null;
+  if (hasRequestIdOverride()) {
+    requestId = currentRequestIdOverride();
+  } else {
+    try {
+      const { headers: getHeaders } = await import("next/headers");
+      const h = await getHeaders();
+      requestId = h.get("x-request-id");
+    } catch {
+      requestId = null;
+    }
   }
   const logCtx = {
     requestId,

--- a/lib/pdns/sync.ts
+++ b/lib/pdns/sync.ts
@@ -21,8 +21,9 @@ import {
 } from "@/lib/db/repositories/pdns-servers";
 import { canonicalTxtContent } from "@/lib/dns/txt";
 import { getBackendGateway } from "@/lib/realtime/backend-gateway";
-import { readCachedZone } from "@/lib/pdns/zone-state-cache";
+import { readCachedZone, readCachedZones } from "@/lib/pdns/zone-state-cache";
 import { derivedMirrorsForPrimary } from "@/lib/pdns/topology-cache";
+import { isWriteCapable } from "@/lib/pdns/capabilities";
 import { redact } from "@/lib/errors/redact";
 import { logger } from "@/lib/logger";
 
@@ -129,6 +130,45 @@ export async function checkZoneSync(
   return mirrors
     .filter((m) => mirrorsZone(m, zoneName))
     .map((m) => statusFromCache(m, zoneName, primarySerial));
+}
+
+/**
+ * Site-wide rollup of mirror sync state — true when ANY group or derived mirror
+ * of ANY managed primary isn't fully caught up to its primary's serial for at
+ * least one zone. Reads exclusively from the in-process caches the poller
+ * maintains (no PDNS calls, no DB write), so it's cheap enough to call from
+ * the app shell on every page render.
+ *
+ * Used as the default mode for the header sync chip: pages that don't mount
+ * their own `<HeaderStatusMode/>` (i.e. most non-zone pages) inherit this
+ * single fleet-wide verdict. A return value of `false` covers both "every
+ * mirror is in-sync" and "there are no mirrors to compare" — the chip stays
+ * green in either case.
+ *
+ * Note on staleness: the chip is server-rendered, so the verdict only
+ * refreshes on a layout re-execution (navigation or `router.refresh()`).
+ * Pages that need sub-second reactivity push their own state via
+ * `HeaderStatusMode` and a `useRealtimeEvent` listener.
+ */
+export async function globalAnyLagging(): Promise<boolean> {
+  const primaries = (await listAllActiveBackends()).filter((b) => isWriteCapable(b.capabilities));
+  if (primaries.length === 0) return false;
+  for (const primary of primaries) {
+    const cached = readCachedZones(primary.id);
+    if (!cached) continue;
+    const zoneSerials = [...cached.zones.values()].map((z) => ({
+      name: z.name,
+      serial: z.serial,
+    }));
+    if (zoneSerials.length === 0) continue;
+    const sync = await checkZonesSyncBatch(primary, zoneSerials);
+    for (const statuses of sync.values()) {
+      for (const s of statuses) {
+        if (s.state !== "in-sync") return true;
+      }
+    }
+  }
+  return false;
 }
 
 /**

--- a/lib/realtime/zone-poller.ts
+++ b/lib/realtime/zone-poller.ts
@@ -33,6 +33,7 @@
  */
 
 import "server-only";
+import { newSystemRequestId, withRequestId } from "@/lib/request-context";
 import { listAllActiveBackends, markPdnsServersSeen } from "@/lib/db/repositories/pdns-servers";
 import { countActiveSessions } from "@/lib/db/repositories/sessions";
 import { getPdnsProbeClientForRow } from "@/lib/pdns/registry";
@@ -152,7 +153,10 @@ export function ensurePollerRunning(): void {
   // looking — it backs the time-series graphs). `pollOnce()` with no `full`
   // resolves the cycle mode from `subscriberCount` at fire time.
   state.timer = setInterval(() => {
-    void pollOnce().catch((err) => {
+    // Each tick gets a fresh request id so its PDNS calls + any audit rows
+    // are attributed to THIS tick, not to whichever route handler happened to
+    // hold the next/headers AsyncLocalStorage scope when the timer fired.
+    void withRequestId(newSystemRequestId(), () => pollOnce()).catch((err) => {
       logger.warn(
         { err: err instanceof Error ? err.message : "unknown" },
         "pdns.zone-poller.cycle.failed",
@@ -161,7 +165,7 @@ export function ensurePollerRunning(): void {
   }, POLL_INTERVAL_MS);
   // Kick off an immediate first FULL poll — a freshly-started poller was just
   // demanded by a subscriber or page render, so warm everything at once.
-  void pollOnce({ full: true }).catch(() => undefined);
+  void withRequestId(newSystemRequestId(), () => pollOnce({ full: true })).catch(() => undefined);
 }
 
 /**
@@ -185,7 +189,9 @@ export function scheduleImmediatePoll(): void {
     immediatePollPending = false;
     // A mutation just happened — always a FULL cycle so the operator sees the
     // zone/topology/advisory effects, even if no SSE subscriber is attached yet.
-    void pollOnce({ full: true }).catch((err) => {
+    // Fresh request id: this poll was *triggered by* the mutation but is its
+    // own operation (different timestamp, different PDNS call set).
+    void withRequestId(newSystemRequestId(), () => pollOnce({ full: true })).catch((err) => {
       logger.warn(
         { err: err instanceof Error ? err.message : "unknown" },
         "pdns.zone-poller.immediate.failed",
@@ -926,7 +932,7 @@ function scheduleFollowupPoll(): void {
     followupPollPending = false;
     // A follow-up exists to observe an in-flight AXFR catching up — inherently a
     // full-cycle concern (zone serials + drift), so never stats-only.
-    void pollOnce({ full: true }).catch((err) => {
+    void withRequestId(newSystemRequestId(), () => pollOnce({ full: true })).catch((err) => {
       logger.warn(
         { err: err instanceof Error ? err.message : "unknown" },
         "pdns.zone-poller.followup.failed",

--- a/lib/request-context.ts
+++ b/lib/request-context.ts
@@ -1,0 +1,67 @@
+import "server-only";
+
+/**
+ * lib/request-context.ts
+ *
+ * Per-operation request-id context, kept in AsyncLocalStorage. Everything that
+ * lands in `pdns_requests` or `audit_log` is tagged with a `requestId` so the
+ * operator can pivot from "this audit row" → "the exact PDNS calls it made".
+ *
+ * The default source for that id is the `X-Request-Id` header that `proxy.ts`
+ * injects on each incoming HTTP request, read via `next/headers`. But Next's
+ * `next/headers` is itself ALS-backed and INCLUDES async tasks spawned within
+ * the handler — so any `void (async () => { … })()` or background poller call
+ * issued from inside a request keeps reading the *parent* request's id. That
+ * leak produces the "67 PDNS calls under one request id at totally different
+ * timestamps" symptom: a single user action gets attributed every poller tick,
+ * background NOTIFY, and post-response cleanup the runtime happens to spawn.
+ *
+ * Fix: when a piece of work is genuinely a SEPARATE operation (a background
+ * NOTIFY, a poller tick, a scheduled cleanup), wrap it in `withRequestId(...)`
+ * with a fresh id. The PDNS http client (and the audit-append callers inside
+ * the wrap) then read THIS frame's id and ignore the leaking next/headers one.
+ *
+ * Usage:
+ *
+ *   const id = newSystemRequestId();          // fresh uuid for this op
+ *   void withRequestId(id, async () => {
+ *     await client.notifyZone(zone);          // tagged with `id`
+ *     await appendAudit({ …, request: { …, requestId: id } });
+ *   });
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+interface RequestContext {
+  requestId: string;
+}
+
+const als = new AsyncLocalStorage<RequestContext>();
+
+/** Run `fn` inside a request-context frame with `requestId`. Calls to
+ *  `currentRequestIdOverride()` inside `fn` (and any async work it spawns)
+ *  return `requestId`; outside `fn` they return null. */
+export function withRequestId<T>(requestId: string, fn: () => Promise<T> | T): Promise<T> {
+  return Promise.resolve(als.run({ requestId }, fn));
+}
+
+/** Returns the request id from the surrounding ALS frame, or `null` if not
+ *  inside one. Consumers (PDNS http, audit append) should prefer this over
+ *  `next/headers` so background work attributes to its own operation rather
+ *  than leaking the parent route handler's id. */
+export function currentRequestIdOverride(): string | null {
+  return als.getStore()?.requestId ?? null;
+}
+
+/** Whether we're inside an explicit request-context frame. When `false` the
+ *  PDNS http client falls back to `next/headers` (i.e. the current user
+ *  request's X-Request-Id). */
+export function hasRequestIdOverride(): boolean {
+  return als.getStore() !== undefined;
+}
+
+/** Generate a fresh uuid for a system-initiated operation (background NOTIFY,
+ *  poller tick, fire-and-forget cleanup). */
+export function newSystemRequestId(): string {
+  return crypto.randomUUID();
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,7 +20,31 @@ const config: Config = {
   content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./lib/**/*.{ts,tsx}"],
   darkMode: "class",
   theme: {
-    extend: {},
+    extend: {
+      /**
+       * App type scale — Tailwind's default sizes (and their line-heights)
+       * scaled by 1.2×. This replaces the former `html { font-size: 120% }`
+       * hack, which bumped *every* rem (padding, gap, radius) and made the UI
+       * feel zoomed. Scaling only the font-size utilities keeps text at the
+       * same comfortable size while spacing/radius return to true rem.
+       * Pairs are [font-size, line-height].
+       */
+      fontSize: {
+        xs: ["0.9rem", "1.2rem"],
+        sm: ["1.05rem", "1.5rem"],
+        base: ["1.2rem", "1.8rem"],
+        lg: ["1.35rem", "2.1rem"],
+        xl: ["1.5rem", "2.1rem"],
+        "2xl": ["1.8rem", "2.4rem"],
+        "3xl": ["2.25rem", "2.7rem"],
+        "4xl": ["2.7rem", "3rem"],
+        "5xl": ["3.6rem", "1"],
+        "6xl": ["4.5rem", "1"],
+        "7xl": ["5.4rem", "1"],
+        "8xl": ["7.2rem", "1"],
+        "9xl": ["9.6rem", "1"],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
Part 1 of the responsive overhaul (#51). Mobile-first foundation + the surfaces called out so far. Verified at 390px (mobile) and 1920px (desktop), light + dark, against the combined demo stack.

## What's in this PR

**App shell**
- Sidebar → off-canvas drawer below `md` (hamburger, backdrop, dismiss on tap/Esc/navigation); static 16rem column on `md+`.
- Main column `min-w-0` so wide content contains instead of pushing the layout.

**Tables → cards on mobile (no horizontal scroll)**
- `DataTable` renders a card per row below `md` (labelled fields, first cell as title); dense table on `md+`. Fixes every list built on it: zones, users, roles, teams, zone records, request log.
- **Groups** (`/admin/pdns-clusters`) converted from a plain list to the rich searchable/sortable `DataTable` (cards on mobile).
- **Servers** (bespoke grouped table) gets a parallel mobile card list preserving the primary→secondary grouping.

**Typography**
- Replaced the `html { font-size: 120% }` hack (inflated *all* rem — spacing, radius — and felt zoomed) with a proper Tailwind `fontSize` scale (≈1.2× sizes + line-heights). Text keeps its size; spacing returns to true rem.

**Polish**
- Page headers (zones, users, teams, roles, oidc, zone-templates, servers) stack title + actions on mobile.
- Servers "Reachable" status stacks its last-contact label on its own line (no dangling separator when the column is narrow).
- Zone tab strip scrolls horizontally on narrow screens.
- "Metadata" tab renamed **"Metadata & TSIG"**.

## Verification
`npm run build` ✓ · `tsc --noEmit` ✓ · prettier ✓ · eslint (changed files) ✓. Full gate runs in CI.

## Still to come (tracked in #51)
- [ ] Admin/profile **forms** single-column audit on mobile
- [ ] Audit log + Request log control bars
- [ ] Detail pages (server, role, zone settings/SOA/DNSSEC panels) on mobile
- [ ] Smaller-viewport polish (360px floor) + dark-mode pass
- [ ] Profile sub-pages (sessions, MFA, API tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)