### PR TITLE
Release v1.1.4 — major operator-UX release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,130 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.1.4] — 2026-05-26
+
+A **major operator-UX release**: top-to-bottom responsive overhaul, every table
+unified onto one mobile-friendly recipe, live fleet-wide sync state in the header
+chrome, a new animated sync indicator, full screenshots gallery regen, plus the
+security and supply-chain hardening previously parked in `[Unreleased]`. No
+schema or API breaking changes — drop-in upgrade.
+
+### Added — operator UX
+
+- **Mobile-first responsive shell.** Off-canvas hamburger drawer under `md`,
+  full sidebar from `md+`. The drawer closes on backdrop tap, Esc, and route
+  changes (no in-drawer close button needed). The top bar reflows so every
+  control (hamburger, status chip, bell, theme, avatar) is reachable on a
+  320 px viewport. (#51, #52)
+- **Live header status chip with fleet-wide sync verdict.** Single pill in the
+  top bar shows `CONNECTING / CONNECTED / OFFLINE / PAUSED` (SSE connection
+  state) plus a trailing `· SYNCED / · DESYNCED` whenever the page has a
+  notion of sync state. The off-the-shelf default is the fleet-wide
+  `globalAnyLagging()` verdict computed from the in-process zone-state cache
+  (no extra PDNS hit). Per-page `<HeaderStatusMode/>` overrides on zone
+  detail, the zones list, and the servers page. A 5 s grace prevents
+  "OFFLINE" flashes on Ctrl-R. (#52)
+- **Animated SyncIndicator.** New concentric-ring SVG used everywhere a sync
+  verdict is displayed (header chip, zones list per-row chip, servers table).
+  **Synced** = solid centre + two outward-pulsing rings via staggered CSS
+  keyframes (radar/sonar ping). **Desynced** = hollow centre + two dashed
+  concentric rings that counter-rotate via `stroke-dashoffset` so the icon
+  reads as _actively trying to sync_, not a frozen error. Honours
+  `prefers-reduced-motion`. (#52)
+- **One DataTable everywhere.** The audit log, profile sessions, autoprimaries,
+  OIDC providers, TSIG keys (read-only + manage), dashboard backends + recent
+  activity, role-assignments panel, team-members panel, zone change-history,
+  and the zone-templates / servers / users / roles / teams lists now all use
+  the same `<DataTable>` recipe — `bg-bg-muted` thead, `even:bg-bg-subtle`
+  body stripes, accent-tinted hover wash, mobile auto-reflow to labelled
+  cards. No more bespoke `<table>` markup outside dialog-internal review
+  panels. (#52)
+- **Diff-before-apply for record edits.** The per-RRset editor now insists on
+  a **Review changes** modal between Save and the PATCH; the diff is
+  BIND-style before/after, validation errors are gated behind an explicit
+  _Save anyway_ checkbox so overrides are intentional and audited verbatim.
+  (#52)
+- **One-button theme toggle.** Was three buttons (sun / monitor / moon). Now
+  one button whose icon mirrors the active preference and cycles
+  `light → dark → system → light` on click. Pre-hydration `.dark` class
+  unchanged — no flash of wrong theme. (#52)
+- **Capability badges + clickable rows.** Per-backend badges (`CLUSTER`,
+  `DEFAULT`, `PRIMARY`, `READ-ONLY MIRROR`) standardised across every list.
+  Rows + mobile cards are now click-to-detail; embedded links/buttons (Edit,
+  Delete, Test) intercept so per-row actions still work. (#52)
+- **Compliance hard-stops on every navigation.** Operators with
+  `must_change_password = true` or unmet MFA-per-role requirements are pinned
+  to `/profile` (or an allow-list of self-service routes) on every page nav,
+  not just the initial render. The header status chip is suppressed in that
+  state because the SSE endpoint would 403 anyway. (#52)
+- **Mobile zone-tabs no longer truncate, change history reflows.** Tabs
+  `flex-wrap` on `< sm` so "Change history" (the widest label) never falls
+  off-screen. New `<ScrollToTab/>` auto-scrolls to the tab strip when
+  `?tab=` is set in the URL. Zone change-log gets a mobile-card layout
+  alongside the desktop table — same expand-on-click pattern, but no clipped
+  Resource/Actor columns on a 360 px viewport. (#52)
+- **CTAs no longer wrap their labels.** `whitespace-nowrap` on the shared
+  green "+ Add" button class — fixes the "+ Add role" rendering as
+  "+ Add" / "role" on narrow flex rows. (#52)
+- **PDNS request log documented.** The per-call HTTP audit surface at
+  `/admin/pdns-requests` was undocumented despite shipping since 1.1.0.
+  Filters by server / op / status / `requestId` / time range; every row
+  expands inline to the request + response detail; cross-pivots to / from
+  the audit log via shared `requestId`. ([FEATURES § 3.6](./docs/FEATURES.md#36-pdns-request-log))
+- **Backend health bell documented.** The alert bell + popover that surfaces
+  active advisories (unreachable hosts, API-key rejections, replication
+  drift, missing TSIG keys, mirror zones without `masters`, daemon-config
+  drift between peers) is now an explicit feature in the catalog.
+  ([FEATURES § 3.7](./docs/FEATURES.md#37-backend-health-advisories) · [ADR-0015](./docs/adr/0015-backend-health-advisories.md))
+
+### Added — documentation
+
+- **Visual gallery regen.** Every page is captured at four parities —
+  desktop+light, desktop+dark, mobile+light, mobile+dark — and rendered with
+  `<picture>` so they auto-switch to match the reader's theme. Mobile shots
+  are wrapped in a CSS-rendered iPhone 16 Pro bezel (status bar with Dynamic
+  Island sits above the page; Action Button left, Camera Control right).
+  See [`screenshots/`](./screenshots/README.md). (#53)
+- **`scripts/screenshots.mjs`.** Playwright-driven regen tool. Per-page
+  `prepare(page)` hooks for surfaces that need a click or two (zone-edit,
+  zone-edit-diff, zone-change-history, backend-health). Comma-separated
+  CLI page filter or `PAGES_FILTER` env. Optional `pngquant + oxipng`
+  post-pass shrinks the gallery by ~70 % when both binaries are on PATH.
+  Documented in [`docs/dev-setup.md`](./docs/dev-setup.md#regenerating-screenshots).
+  (#53)
+- **`docs/FEATURES.md` § 19 — Operator UX & responsive design.** Eight
+  sub-sections covering everything new in this release with module pointers.
+  Cross-linked from the screenshots gallery. (#53)
+- **Root README mobile-first showcase.** Three iPhone-framed mobile shots
+  (dashboard, zone detail, audit log) below the desktop grid + a link to the
+  full gallery. (#53)
+- **Inline screenshot embeds** at every feature section in `docs/FEATURES.md`
+  and hero shots in `docs/01-QUICKSTART.md`, `docs/04-BACKENDS.md`,
+  `docs/05-OIDC.md`, `docs/07-RBAC.md`. (#53)
+
 ### Security
 
 - **Patched dev/build dependency CVEs** via `overrides` — the deprecated `@esbuild-kit`
   chain is forced onto `esbuild@0.25.12` (dev-server CORS) and `next`'s pinned `postcss`
   up to `8.5.15` (`</style>` XSS). `npm audit` is clean. (OpenSSF Scorecard: Vulnerabilities.)
+  (#47)
 
-### Added
+### Added — supply-chain
 
 - **Property-based fuzz tests** (`fast-check`) for the DNS parsers — TXT presentation,
   DynDNS request/auth, and every RR-type content validator — running in the unit suite as
   `*.fuzz.test.ts`. Hardens the hand-rolled parsers (which have shipped real bugs) and
-  satisfies the OpenSSF Scorecard Fuzzing check.
+  satisfies the OpenSSF Scorecard Fuzzing check. (#48)
 - **Signed releases + image provenance.** A `release-sign` workflow (on release publish)
   cosign-signs the published multi-arch image (keyless / Sigstore) and attaches an SPDX SBOM
   plus a signed checksums bundle (`*.sigstore.json`) to the GitHub release. Verify the image
-  with `cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:<version>` (see
+  with `cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:1.1.4` (see
   [Hardening → verifying the image](./docs/08-HARDENING.md)). (OpenSSF Scorecard: Signed-Releases.)
+  (#49)
+
+### Fixed
+
+- **Stale CODEOWNERS path** (`middleware.ts` → `proxy.ts`). (#50)
 
 ## [1.1.3] — 2026-05-26
 
@@ -339,7 +446,8 @@ First production release.
 - **Distribution** — multi-arch (`linux/amd64` + `linux/arm64`) image published to Docker Hub as
   `jseifeddine/powerdns-authadmin`, plus a one-command minimal-demo stack.
 
-[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.3...HEAD
+[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.4...HEAD
+[1.1.4]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.0...v1.1.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,12 @@ proxy.ts              per-request CSP nonce + security headers (Next 16 proxy co
 docker/               entrypoint that runs migrations then boots the server
 drizzle/              generated PG migrations
 drizzle-sqlite/       generated SQLite migrations
-scripts/              migrate.ts, seed.ts, provision.ts
+scripts/              migrate.ts, seed.ts, provision.ts, screenshots.mjs
 tests/                vitest unit + integration (the latter wants a real Postgres on $TEST_DB_URL)
 docs/                 ADRs, FEATURES, dev-setup
+screenshots/          gallery of every page in 4 variants — desktop+light, desktop+dark,
+                      mobile+light, mobile+dark; regen with `npm run screenshots`
+                      (Playwright + iPhone-frame CSS, optional pngquant+oxipng post-pass)
 ```
 
 ## Working conventions
@@ -142,6 +145,36 @@ the code embodies a constraint a future reader would otherwise have to reverse-e
 `npm run test` runs the vitest unit suite (no external deps). Integration tests under
 `tests/integration/` need a Postgres instance — the runner skips them when `TEST_DATABASE_URL`
 isn't set. CI runs both.
+
+### Responsive UI (v1.1.4+)
+
+Every page is **mobile-first responsive**. Lists use the shared `<DataTable>`
+(`components/ui/data-table.tsx`) which reflows to labelled cards under `md`;
+chrome (app-shell, header chip, theme toggle, capability badges) is built to
+operate at 320 px. Sync state is communicated by `<SyncIndicator>` (animated
+concentric rings, honours `prefers-reduced-motion`); fleet-wide verdict is
+`globalAnyLagging()` from `lib/pdns/sync.ts`.
+
+When adding a new list view, use `<DataTable>`. When showing replication
+status, use `<SyncIndicator>` — don't roll a new dot/badge. See
+[`docs/FEATURES.md` § 19](./docs/FEATURES.md#19-operator-ux--responsive-design)
+for the full vocabulary.
+
+### Screenshots
+
+Every page lives in `screenshots/<light|dark>/<name>{-mobile}.png` and is
+referenced from `screenshots/README.md` with `<picture>` for auto theme
+switching. When you add a page or change a major surface, regen the relevant
+shot:
+
+```sh
+node scripts/screenshots.mjs <page-name>          # one page, all 4 variants
+SKIP_MOBILE=1 node scripts/screenshots.mjs <name> # desktop only
+```
+
+The runner expects the combined demo stack up + `must_change_password`
+cleared on `admin@example.com` — full prereqs in
+[`docs/dev-setup.md` → Regenerating screenshots](./docs/dev-setup.md#regenerating-screenshots).
 
 ## When working in this repo
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@
 5. **Conventional Commits** for PR titles: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, `test:`,
    `perf:`, `build:`, `ci:`. The PR body is the changelog entry — write it for humans.
 6. **Milestones track releases.** Every issue and PR targeting a release is tagged with that
-   release's milestone (e.g. `v1.1.3`). The milestone is closed when that version ships — its
+   release's milestone (e.g. `v1.1.4`). The milestone is closed when that version ships — its
    issues/PRs are the release's scope and map to the `CHANGELOG` section.
 
 ---

--- a/README.md
+++ b/README.md
@@ -78,63 +78,54 @@ The full feature catalog with module-level docs is in [`docs/FEATURES.md`](./doc
 
 ## Screenshots
 
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/dashboard.png" />
-    <img src="screenshots/light/dashboard.png" alt="Dashboard — live PowerDNS stats and operator attention surfaces" width="900" />
-  </picture>
-</p>
+**Dashboard** — live PowerDNS stats, active sessions, and operator-attention surfaces.
 
-<table>
-  <tr>
-    <td width="50%">
-      <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/powerdns-servers.png" />
-        <img src="screenshots/light/powerdns-servers.png" alt="PowerDNS servers" />
-      </picture>
-      <br /><sub><b>Multi-backend</b> — clusters, primary + secondaries, and standalone primaries side by side with live sync status.</sub>
-    </td>
-    <td width="50%">
-      <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/zones-list.png" />
-        <img src="screenshots/light/zones-list.png" alt="Zones" />
-      </picture>
-      <br /><sub><b>Amalgamated zones</b> — every backend's zones in one searchable list with serial + sync state.</sub>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/zone-edit.png" />
-        <img src="screenshots/light/zone-edit.png" alt="Edit record dialog" />
-      </picture>
-      <br /><sub><b>Per-RRset editor</b> — per-type structured editors with inline validation.</sub>
-    </td>
-    <td>
-      <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/zone-edit-diff.png" />
-        <img src="screenshots/light/zone-edit-diff.png" alt="Review changes diff" />
-      </picture>
-      <br /><sub><b>Diff-before-apply</b> — every change previewed as a before/after diff before save.</sub>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/backend-health.png" />
-        <img src="screenshots/light/backend-health.png" alt="Backend health alerts" />
-      </picture>
-      <br /><sub><b>Backend health</b> — bell-driven advisories for unreachable hosts, replication drift, missing TSIG keys.</sub>
-    </td>
-    <td>
-      <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/audit-log.png" />
-        <img src="screenshots/light/audit-log.png" alt="Audit log" />
-      </picture>
-      <br /><sub><b>Append-only audit log</b> with redacted before/after snapshots + per-row PDNS HTTP trail.</sub>
-    </td>
-  </tr>
-</table>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/dashboard.png" />
+  <img src="screenshots/light/dashboard.png" alt="Dashboard" />
+</picture>
+
+**Multi-backend** — clusters, primary + secondaries groups, and standalone primaries side by side with live sync status.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/powerdns-servers.png" />
+  <img src="screenshots/light/powerdns-servers.png" alt="PowerDNS servers" />
+</picture>
+
+**Amalgamated zones** — every backend's zones in one searchable list with serial + per-row sync state.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/zones-list.png" />
+  <img src="screenshots/light/zones-list.png" alt="Zones" />
+</picture>
+
+**Per-RRset editor** — per-type structured editors with inline validation.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/zone-edit.png" />
+  <img src="screenshots/light/zone-edit.png" alt="Edit record dialog" />
+</picture>
+
+**Diff-before-apply** — every change previewed as a BIND-style before / after diff before it's written.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/zone-edit-diff.png" />
+  <img src="screenshots/light/zone-edit-diff.png" alt="Review changes diff" />
+</picture>
+
+**Backend health** — bell-driven advisories for unreachable hosts, replication drift, missing TSIG keys, daemon-config drift.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/backend-health.png" />
+  <img src="screenshots/light/backend-health.png" alt="Backend health alerts" />
+</picture>
+
+**Append-only audit log** — redacted before/after snapshots, per-row PDNS HTTP trail, CSV export.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/audit-log.png" />
+  <img src="screenshots/light/audit-log.png" alt="Audit log" />
+</picture>
 
 ### Mobile-first
 
@@ -343,4 +334,4 @@ contributions welcome, read [`CONTRIBUTING.md`](./CONTRIBUTING.md) first.
 
 ## License
 
-[![License: MIT](https://img.shields.io/github/license/PowerDNS-AuthAdmin/powerdns-authadmin)](./LICENSE) — copy, modify, distribute, or sell with attribution.
+[![License: MIT](https://img.shields.io/github/license/PowerDNS-AuthAdmin/powerdns-authadmin)](./LICENSE)

--- a/docs/08-HARDENING.md
+++ b/docs/08-HARDENING.md
@@ -80,7 +80,7 @@ Each published release is cosign-signed (keyless / Sigstore) by the release
 workflow. Verify before deploying:
 
 ```sh
-cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:1.1.3 \
+cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:1.1.4 \
   --certificate-identity-regexp '^https://github.com/PowerDNS-AuthAdmin/' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```

--- a/docs/09-UPGRADING.md
+++ b/docs/09-UPGRADING.md
@@ -37,6 +37,34 @@ half-migrated schema; fix the cause and restart.
 
 ## Version-specific notes
 
+### Upgrading to 1.1.4 (from 1.1.x)
+
+A **major operator-UX release** — drop-in upgrade. **No schema migration, no API
+changes, no config changes.** Pull-and-recreate the container and you're done.
+
+What changes when operators sign in:
+
+- **Mobile-first responsive shell.** Every page is usable on a phone now.
+  Drawer-style navigation under `md`; full sidebar from `md+`.
+- **Live status chip in the top bar** — connection state plus a fleet-wide
+  sync verdict (`SYNCED` / `DESYNCED`) on every page, with the per-page
+  override on zone-detail / zones-list / servers preserved.
+- **New animated SyncIndicator** — concentric-ring glyph used everywhere a
+  sync state is displayed. Honours `prefers-reduced-motion`.
+- **Diff-before-apply on every record edit.** Save is now two clicks: an
+  inline edit, then a **Review changes** modal with the BIND-style diff,
+  then Save.
+- **One-button theme toggle** cycles light → dark → system.
+- **Every list is one DataTable.** Mobile reflows to labelled cards; the
+  desktop chrome is uniform across audit / zones / users / roles / teams /
+  PDNS requests / OIDC / TSIG / autoprimaries / zone templates.
+- **CSS-only changes** — no client-side breaking changes; saved theme
+  preferences, sessions, MFA enrolments, API tokens all carry over.
+
+If you've embedded our screenshots in your own docs, note that several
+filenames changed in this release — the canonical set is now
+[`screenshots/README.md`](../screenshots/README.md).
+
 ### Upgrading to 1.1.3 (from 1.1.x)
 
 A maintenance release — **no schema migration**, a plain pull-and-recreate, and

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -129,6 +129,81 @@ For exercising multi-backend topologies side-by-side:
 - `docker-compose-combined.yml` — all three topologies in one stack, plus generated demo zones
   via the provisioning file.
 
+## Regenerating screenshots
+
+Every page in [`screenshots/`](../screenshots/README.md) is shot four ways —
+desktop+light, desktop+dark, mobile+light, mobile+dark — by
+[`scripts/screenshots.mjs`](../scripts/screenshots.mjs). Mobile shots are
+wrapped in a CSS-rendered iPhone 16 Pro bezel; pure Playwright, no extra
+deps.
+
+### One-time prep
+
+```sh
+# Optional but recommended: PNG optimizers (~70 % shrink at the end of the run).
+brew install pngquant oxipng           # macOS
+# or: sudo apt-get install pngquant && cargo install oxipng   (Linux)
+
+npx playwright install chromium
+```
+
+### Bring up the demo stack the script needs
+
+```sh
+APP_SECRET_KEY="$(openssl rand -base64 32)" \
+APP_ENCRYPTION_KEY="$(openssl rand -base64 32)" \
+  docker compose -f docker-compose-combined.yml up -d --build
+
+# Demo admin is locked behind `must_change_password=true` on first boot —
+# clear it so the script can navigate freely:
+docker exec powerdns-authadmin-combined-postgres-1 \
+  psql -U pdns -d powerdns_authadmin \
+  -c "UPDATE users SET must_change_password=false WHERE email='admin@example.com';"
+```
+
+### Shoot
+
+```sh
+npm run screenshots                              # full sweep — every page × 4 variants
+node scripts/screenshots.mjs zones-list audit    # subset (positional)
+node scripts/screenshots.mjs --pages=dashboard,profile
+PAGES_FILTER=audit-log npm run screenshots       # subset (env)
+SKIP_MOBILE=1 npm run screenshots                # desktop only
+SKIP_DESKTOP=1 npm run screenshots               # mobile only
+SHOWCASE_ZONE="ps-6.demo." SHOWCASE_CLUSTER=ps-group \
+  node scripts/screenshots.mjs zone-detail zone-change-history zone-edit zone-edit-diff
+```
+
+Output lands in `screenshots/{light,dark}/<page>{-mobile}.png`. The post-pass
+runs `pngquant` + `oxipng` if both are on PATH and shrinks the gallery by
+~70 %; `SKIP_OPTIMIZE=1` bypasses it.
+
+### Adding a new page
+
+Edit the `PAGES` array in `scripts/screenshots.mjs`:
+
+```js
+{ name: "my-new-page", path: "/admin/my-new-page" },
+
+// Or with a click / scroll / dialog-open before the shot:
+{
+  name: "my-new-page",
+  path: "/admin/my-new-page",
+  async prepare(page) {
+    await page.getByRole("button", { name: "Add thing" }).click();
+    await page.getByRole("heading", { name: "Add thing" }).waitFor();
+  },
+},
+```
+
+Then add a section to [`screenshots/README.md`](../screenshots/README.md) with
+the `<picture>` block (auto dark/light) + a cross-link into `docs/FEATURES.md`.
+
+If your `prepare` clicks elements that share a generic selector with chrome
+controls (hamburger, alert bell — both use `aria-expanded`), add a scoped
+`data-…` attribute on the target component and use it in the selector — see
+how `data-change-entry-toggle` is used by the change-log shot.
+
 ## What's where
 
 - `app/` — Next.js routes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerdns-authadmin",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "@casl/ability": "7.0.0",
@@ -3556,6 +3556,72 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": true,
   "description": "Modern, self-hosted DNS administration UI for PowerDNS — multi-team RBAC, real audit, real SSO. From-scratch rebuild of PowerDNS-Admin in Node.js + TypeScript.",
   "license": "MIT",


### PR DESCRIPTION
Closes #51.

The coordinating release PR for **v1.1.4**, which lands on top of:

- #52 — responsive UI overhaul + mobile polish (merged)
- #53 — screenshots gallery regen + feature catalog updates (merged)

This PR carries the version bump, the comprehensive CHANGELOG entry, the operator UPGRADING notes, the cosign-tag bump, the screenshots dev-doc, and the CLAUDE.md update for the new conventions. Closes the responsive overhaul tracking issue (#51) — every milestone listed there ships in this release.

## Headline

- **Mobile-first responsive shell** — every page reflows to a phone viewport; off-canvas hamburger; full sidebar from `md+`.
- **Live header status chip with fleet-wide sync verdict** — `globalAnyLagging()` over the in-process zone-state cache; no extra PDNS hit; per-page override preserved for the screens that own a more specific sync notion.
- **Animated SyncIndicator** — sonar pulse for synced, counter-rotating dashed rings for desynced; `prefers-reduced-motion` honored.
- **One DataTable everywhere** — audit log, profile sessions, autoprimaries, OIDC, TSIG, dashboard sub-tables, role-assignments panel, team-members panel, zone change-history → all on one recipe with mobile card reflow.
- **Diff-before-apply** on every record edit, *Save anyway* gated behind an explicit checkbox.
- **One-button theme toggle** (light → dark → system).
- **Compliance hard-stops** on every page nav for `must_change_password` / unmet MFA-per-role.
- **Backend health bell + PDNS request log** newly documented in FEATURES.
- **Visual gallery regen** at four parities (desktop / mobile × light / dark) with iPhone-16-Pro mobile bezels.
- **Security + supply-chain hardening** — dev-dep CVE patches, property-based fuzz tests, cosign-signed releases + SPDX SBOM + signed checksums (Scorecard `Signed-Releases`).

## What this commit changes

| File | Change |
|---|---|
| `package.json` + `package-lock.json` | `1.1.3` → `1.1.4` |
| `CHANGELOG.md` | New `[1.1.4]` section with the full narrative + PR cross-refs; `[Unreleased]` content rolled in; compare-URL anchors added |
| `docs/09-UPGRADING.md` | New "Upgrading to 1.1.4 (from 1.1.x)" — drop-in upgrade, no schema/API/config changes |
| `docs/08-HARDENING.md` | `cosign verify …:1.1.3` → `…:1.1.4` |
| `docs/dev-setup.md` | New "Regenerating screenshots" section (prereqs, filters, optimizer, adding pages, selector scoping) |
| `CONTRIBUTING.md` | Milestone example `v1.1.3` → `v1.1.4` |
| `CLAUDE.md` | v1.1.4 responsive-UI conventions, shared primitives (`<DataTable>` / `<SyncIndicator>`), screenshots dir + regen pointer, scripts listing |
| `README.md` | Full-width stacked screenshots (no grid); License section trimmed to badge |

## Test plan

- [x] `npm run validate` — typecheck + lint + format + unit
- [x] `npm run ci:local` (act static-checks + test) — both jobs green
- [x] `npm run test:integration` — 39 files / 203 tests / 6 skipped — green
- [x] Every PNG path + FEATURES.md anchor referenced in docs verified to resolve
- [ ] CI green on this PR

## Post-merge

1. Tag `v1.1.4` on the merge commit — triggers the docker publish + the `release-sign` workflow (cosign + SPDX SBOM + signed checksums).
2. `gh release create v1.1.4 --notes "..."` to draft the GitHub release.
3. Deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)