### PR TITLE
Release v1.1.5 — security-hygiene patch (defensive pin against MAL-2026-4153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.1.5] — 2026-05-26
+
+A **security-hygiene patch**. No app-code changes; ships only a defensive
+dependency pin to neutralise the **Mini Shai-Hulud** npm supply-chain
+campaign (MAL-2026-4153) at the resolver level. See
+[GHSA-…-…-…](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/security/advisories)
+for the full advisory.
+
+### Security
+
+- **Defensive pin: `size-sensor` → `1.0.3` via package.json `overrides`.**
+  The npm package `size-sensor` (an indirect dependency through
+  `echarts-for-react`) was hijacked on 2026-05-19 — versions `1.0.4`,
+  `1.1.4`, and `1.2.4` were published by an attacker who took over the
+  `atool` npm account and contain a `preinstall` hook that runs an
+  obfuscated Bun script exfiltrating secrets to GitHub via
+  `harkonnen-melange-*` repositories (Mini Shai-Hulud / TeamPCP).
+  Tracked as
+  [MAL-2026-4153](https://osv.dev/vulnerability/MAL-2026-4153) /
+  [GHSA-gx6x-v325-85g4](https://github.com/advisories/GHSA-gx6x-v325-85g4).
+
+  **PowerDNS-AuthAdmin was never affected** — every `1.1.x` release
+  shipped `size-sensor@1.0.3`, the last clean version (published before
+  the takeover). `npm audit` was clean throughout. This release adds an
+  explicit `"size-sensor": "1.0.3"` to `package.json` `overrides` so that
+  no future `npm install --save <…>` can let the resolver pick up
+  `1.0.4`+ from a freshly-resolved subtree. OpenSSF Scorecard's
+  `Vulnerabilities` check, which flags any version inside the OSV
+  advisory's overly-broad SEMVER range, should clear on its next
+  refresh.
+
 ## [1.1.4] — 2026-05-26
 
 A **major operator-UX release**: top-to-bottom responsive overhaul, every table
@@ -446,7 +477,8 @@ First production release.
 - **Distribution** — multi-arch (`linux/amd64` + `linux/arm64`) image published to Docker Hub as
   `jseifeddine/powerdns-authadmin`, plus a one-command minimal-demo stack.
 
-[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.4...HEAD
+[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.5...HEAD
+[1.1.5]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.1...v1.1.2

--- a/docs/08-HARDENING.md
+++ b/docs/08-HARDENING.md
@@ -80,7 +80,7 @@ Each published release is cosign-signed (keyless / Sigstore) by the release
 workflow. Verify before deploying:
 
 ```sh
-cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:1.1.4 \
+cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:1.1.5 \
   --certificate-identity-regexp '^https://github.com/PowerDNS-AuthAdmin/' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```

--- a/docs/09-UPGRADING.md
+++ b/docs/09-UPGRADING.md
@@ -37,6 +37,19 @@ half-migrated schema; fix the cause and restart.
 
 ## Version-specific notes
 
+### Upgrading to 1.1.5 (from 1.1.x)
+
+A **security-hygiene patch.** No app-code changes; no schema, API, or
+config changes. Pull-and-recreate.
+
+Adds a defensive `package.json` `overrides` pin keeping `size-sensor` at
+`1.0.3` (the last clean version) — closes the resolver attack window for
+the **Mini Shai-Hulud** npm campaign that hijacked `size-sensor` `1.0.4`
+/ `1.1.4` / `1.2.4` on 2026-05-19. **PowerDNS-AuthAdmin was never
+shipped with the affected versions**; this release just locks the door.
+See the [Security Advisory](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/security/advisories)
+and `MAL-2026-4153` / `GHSA-gx6x-v325-85g4` for the threat detail.
+
 ### Upgrading to 1.1.4 (from 1.1.x)
 
 A **major operator-UX release** — drop-in upgrade. **No schema migration, no API

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerdns-authadmin",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "@casl/ability": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "private": true,
   "description": "Modern, self-hosted DNS administration UI for PowerDNS — multi-team RBAC, real audit, real SSO. From-scratch rebuild of PowerDNS-Admin in Node.js + TypeScript.",
   "license": "MIT",
@@ -108,6 +108,7 @@
     "@esbuild-kit/core-utils": {
       "esbuild": "0.25.12"
     },
-    "postcss": "$postcss"
+    "postcss": "$postcss",
+    "size-sensor": "1.0.3"
   }
 }


### PR DESCRIPTION
A **security-hygiene patch**. No app-code changes; ships only a defensive dependency pin to neutralise the **Mini Shai-Hulud** npm supply-chain campaign that hijacked `size-sensor` versions `1.0.4` / `1.1.4` / `1.2.4` on 2026-05-19.

## TL;DR

- PowerDNS-AuthAdmin was **never affected** — every `1.1.x` release shipped `size-sensor@1.0.3` (the last clean version, published before the npm-account takeover). `npm audit` was clean throughout.
- This release locks the door: a `package.json` `overrides` entry pins `size-sensor` to `1.0.3` so no future `npm install --save <…>` can let the resolver pick up the malicious versions from a re-walked subtree.
- Also bumps the cosign-verify example to `:1.1.5` and validates the new race-free `release-sign.yml` (`workflow_run` trigger added in `903e296`).

## Background

A threat actor took over the `atool` npm maintainer account and published 631 malicious versions across 314 packages in a 22-minute burst on 2026-05-19 (a.k.a. *Mini Shai-Hulud* / TeamPCP). Each malicious version injects a `preinstall` hook running an obfuscated Bun script that exfiltrates secrets to attacker-controlled GitHub repos (`harkonnen-melange-*` Dune-themed naming). Tracked as [MAL-2026-4153](https://osv.dev/vulnerability/MAL-2026-4153) / [GHSA-gx6x-v325-85g4](https://github.com/advisories/GHSA-gx6x-v325-85g4).

`size-sensor` is a transitive dep through `echarts-for-react` (dashboard charts). Our lockfile and on-disk installs were verified to be `1.0.3` — no `preinstall` hook, no malicious payload. Forensic detail in the upcoming GHSA.

## Why an advisory + pin if we were never exposed?

The OSV advisory's affected-version range is `>=0` (all versions), even though only three specific versions carry the malware. Automated scanners (incl. OpenSSF Scorecard's `Vulnerabilities` check) flag *any* project with `size-sensor` in its dep tree. The defensive `overrides` pin:

1. **Provably** immunises future `npm install` operations.
2. Makes the defensive posture auditable in `package.json` itself.
3. Clears the Scorecard false-positive once OSV narrows the range, and is operationally correct in the meantime.

## What this PR changes

| File | Change |
|---|---|
| `package.json` | `version` 1.1.4 → 1.1.5; `overrides` adds `"size-sensor": "1.0.3"` |
| `package-lock.json` | regenerated; `size-sensor@1.0.3` confirmed stable |
| `CHANGELOG.md` | new `[1.1.5]` Security section + compare-URL anchors |
| `docs/09-UPGRADING.md` | new "Upgrading to 1.1.5 (from 1.1.x)" |
| `docs/08-HARDENING.md` | `cosign verify …:1.1.4` → `…:1.1.5` |

## Validation

- [x] `npm run ci:local` (act static-checks + test) — both jobs green
- [x] `npm audit` — clean
- [x] `npm ls size-sensor` — resolves to 1.0.3 with the override applied
- [x] Verified no app surface touched (no .ts/.tsx/.css changes; integration tests not required)
- [ ] CI green on this PR

## Post-merge

1. Tag `v1.1.5` on the merge commit — triggers CI's docker push to ghcr.io (`:1.1.5`, `:1.1`, `:latest`), which in turn triggers the new `release-sign.yml` via `workflow_run` (race-free signing — see `903e296`).
2. `gh release create v1.1.5` referencing the GHSA.
3. Publish the GHSA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)