### PR TITLE
ci(sign): set GH_REPO so gh has a repo context without checkout

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -56,6 +56,9 @@ jobs:
     env:
       IMAGE: ghcr.io/powerdns-authadmin/powerdns-authadmin
       TAG: ${{ github.event.workflow_run.head_branch }}
+      # Without `actions/checkout`, `gh` has no git remote to infer the repo
+      # from. GH_REPO is the documented way to set it explicitly.
+      GH_REPO: ${{ github.repository }}
     steps:
       # No `actions/checkout` here — Scorecard `Dangerous-Workflow` flags any
       # privileged `workflow_run`-triggered job that checks out the


### PR DESCRIPTION
## Summary

- Removing `actions/checkout` from `release-sign.yml` (to satisfy Scorecard `Dangerous-Workflow`) left `gh release view` and `gh release upload` without a git remote to infer the repo from. The v1.1.5 sign run sat on the wait loop and timed out at 5 min.
- `GH_REPO=${{ github.repository }}` is the documented way to tell `gh` which repo to target when it's not running from a checkout.

## Test plan
- [ ] After merge: `gh run rerun 26445790834` (the failed v1.1.5 sign run) — `workflow_run`-triggered workflows execute the file from the default branch, so the rerun picks up this fix without needing to retag.
- [ ] Verify cosign signature + `*.sigstore.json` + SBOM land on the v1.1.5 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)