### PR TITLE
Release v1.2.0 — standalone PDNS fix (#57) + PDNS_BACKGROUND_POLLING opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,28 @@ APP_PDNS_ALLOW_PRIVATE_NETWORKS=true
 # for the demo's http://pdns:8081 backend. Both flags must be opt-in.
 APP_PDNS_ALLOW_INSECURE_HTTP=true
 
+# -----------------------------------------------------------------------------
+# Background polling of PDNS backends — opt-in supplementary features.
+# -----------------------------------------------------------------------------
+# When TRUE, the background poller refreshes the zone-state cache (~30 s),
+# re-derives daemon capabilities (~60 s), and snapshots PDNS statistics
+# (~5 min). This powers AuthAdmin's replication-awareness layer:
+#   • header SYNCED / DESYNCED chip
+#   • zone-detail "Sync" + "Statistics" tabs
+#   • zone-list mirror-state column
+#   • servers-list lag column
+#   • dashboard "PowerDNS metrics" tab (live time-series graphs)
+#   • drift-derived advisories in the bell
+#
+# When FALSE (the default), AuthAdmin only talks to PDNS in response to
+# operator actions (page renders, Test, Refresh All, mutations). Every PDNS
+# call is a direct consequence of a click; the supplementary surfaces above
+# hide cleanly; the rest of the app (zone CRUD, DNSSEC, TSIG, autoprimaries,
+# audit, RBAC, OIDC, signup …) is unchanged. Recommended for single-server /
+# standalone PDNS deployments; REQUIRED for primary+secondaries or multi-
+# primary cluster ops who want the live sync awareness.
+PDNS_BACKGROUND_POLLING=false
+
 
 # -----------------------------------------------------------------------------
 # OIDC issuer connectivity (SSRF guard — mirrors the PDNS pair above)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,12 @@ Closes #57; reported by @insxa in
   Sync + Statistics tabs, servers-list Sync column, zones-list mirror
   column, dashboard PowerDNS-metrics tab, and the drift-derived
   advisories in the bell. (#57)
-- **`(i)` polling-mode hint** on the dashboard heading when polling is
-  off — hover tooltip explains the current state and links to the live
-  CONFIGURATION doc.
+- **`(i)` polling-mode hint** on every polling-gated page heading
+  (`/dashboard`, `/admin/servers`, `/zones`, `/zones/<id>`) when polling
+  is off — hover tooltip explains the current state and links to the live
+  CONFIGURATION doc. One small icon, consistent across the app, so an
+  operator can flip the flag deliberately from wherever they are when
+  they notice a sync-aware feature is missing.
 - **`flash=polling-required` error toast** when an operator follows a
   direct URL to a gated feature (`/dashboard?tab=pdns`,
   `/zones/<id>?tab=sync`, `/zones/<id>?tab=statistics`) on a polling-off
@@ -103,6 +106,18 @@ Closes #57; reported by @insxa in
   backend stays usable until its first probe.
 - Polling-flag tests pin `ensurePollerRunning` to no `setInterval`,
   and `scheduleImmediatePoll` to no `setTimeout`, when the flag is off.
+- **`decideHeaderChipMode` pure helper** (extracted from `app/(app)/layout.tsx`)
+  is unit-tested across all five gating inputs (polling enabled, realtime
+  available, can-read-backends, has-topology, lagging) — every false
+  gate falls back to plain "Live"; only the full happy path enters sync
+  mode.
+- **`describeFlash` for `polling-required`** is unit-tested to produce a
+  red error toast naming the env var verbatim (so operators can grep for
+  it), with and without the `need=` parameter.
+- **`logPollingModeOnce` startup log** is unit-tested across three
+  branches (flag on info; flag off + standalone info; flag off + topology
+  warn) plus the 3 s probe budget timing out gracefully and the one-shot
+  guard against re-firing.
 - Integration suite pinned to `PDNS_BACKGROUND_POLLING=true` so the
   replication-aware code paths stay exercised end-to-end.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.1.6] — 2026-05-26
+
+A **model fix** for standalone PowerDNS Authoritative instances. A daemon
+running with the default `primary=no, secondary=no` in `pdns.conf` —
+i.e. a single-server PDNS Auth with no AXFR replication wired up — is
+fully write-capable through its HTTP API. PowerDNS-AuthAdmin was
+incorrectly treating that configuration as not-a-write-target, which
+hid the backend from `/zones/new` and surfaced _"No PowerDNS backends
+configured"_ even though Test went green. Patch-release upgrade — no
+schema, API, or config changes. Closes #57; reported by @insxa in
+[discussion #27](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/discussions/27).
+
+### Fixed
+
+- **Standalone PDNS Auth instances now appear on the zone-create
+  picker.** `isWriteCapable` previously gated on `caps.primary` —
+  which only reflects PDNS's AXFR-primary flag, not whether the API
+  accepts zone writes. Replaced with the inverse of `isReadOnlyMirror`,
+  so the predicate is: **write-capable unless explicitly observed as a
+  pure secondary mirror** (`secondary=yes && primary=no`). The three
+  shapes that now correctly count as writable: standalone
+  (`primary=no, secondary=no`), explicit primary, and dual-role
+  primary+secondary. (#57)
+- **Header sync chip no longer claims SYNCED/DESYNCED against a fleet
+  with no replication topology.** New `hasReplicationTopology()`
+  predicate in `lib/pdns/sync.ts`; the app shell only enters the
+  sync-mode chip when at least one backend has ≥1 mirror (derived
+  primary+secondaries group or configured multi-primary cluster of
+  ≥2 peers). Fleets of standalones or single-primaries-without-secondaries
+  see plain "Live" — the truthful read for that topology. (#57)
+
+### Changed — UI
+
+- **Capability badge `none` → `standalone`.** The neutral badge for a
+  daemon with no replication flags now reads `standalone`, matching
+  the semantic ("hosts zones over the API; no DNS-protocol
+  replication") and removing the alarming "none" label. Same neutral
+  tone. `summarizeCapabilities()`'s fallback string follows
+  suit (`api` → `standalone`); `api: no` → `unreachable`.
+
+### Tests
+
+- Four-way table test for `isWriteCapable` × `isReadOnlyMirror`
+  pinning the predicate's behaviour across the standalone / primary /
+  secondary / dual-role flag matrix.
+- `unprobed (null)` continues to default to write-capable so a
+  freshly-added backend stays usable until its first probe.
+
 ## [1.1.5] — 2026-05-26
 
 A **security-hygiene patch**. No app-code changes; ships only a defensive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,53 +6,105 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
-## [1.1.6] — 2026-05-26
+## [1.2.0] — 2026-05-26
 
-A **model fix** for standalone PowerDNS Authoritative instances. A daemon
-running with the default `primary=no, secondary=no` in `pdns.conf` —
-i.e. a single-server PDNS Auth with no AXFR replication wired up — is
-fully write-capable through its HTTP API. PowerDNS-AuthAdmin was
-incorrectly treating that configuration as not-a-write-target, which
-hid the backend from `/zones/new` and surfaced _"No PowerDNS backends
-configured"_ even though Test went green. Patch-release upgrade — no
-schema, API, or config changes. Closes #57; reported by @insxa in
+A **minor release** that combines two closely-related changes:
+
+1. **Standalone-PDNS write-capability fix (#57).** A daemon with the
+   default `primary=no, secondary=no` in `pdns.conf` was incorrectly
+   hidden from `/zones/new`'s backend picker.
+2. **`PDNS_BACKGROUND_POLLING` opt-in flag.** AuthAdmin no longer
+   maintains a background ticker against PDNS unless the operator
+   explicitly opts in. The supplementary "replication-awareness"
+   surfaces (sync chip, zone Sync + Statistics tabs, servers Sync
+   column, dashboard PDNS metrics, drift advisories) are gated on
+   this flag.
+
+> **NOTE — behaviour change on upgrade.** `PDNS_BACKGROUND_POLLING`
+> defaults to `false`. Existing 1.1.x deployments that rely on the
+> sync chip, dashboard PDNS metrics, per-zone Sync tab, or drift
+> advisories **MUST NOW ENABLE** `PDNS_BACKGROUND_POLLING=true` in
+> their environment and restart the app to keep those features. See
+> [Upgrading → 1.2.0](./docs/09-UPGRADING.md#upgrading-to-120-from-11x)
+> for the use-case guidance.
+
+Closes #57; reported by @insxa in
 [discussion #27](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/discussions/27).
+
+### Added
+
+- **`PDNS_BACKGROUND_POLLING` env var (default `false`).** Single
+  opt-in switch for the replication-awareness layer. When off, every
+  PDNS interaction is a direct consequence of an operator action — no
+  background traffic. When on, the unified poller runs on its 30 s /
+  60 s / 5 min cadences and powers the SYNCED/DESYNCED chip, per-zone
+  Sync + Statistics tabs, servers-list Sync column, zones-list mirror
+  column, dashboard PowerDNS-metrics tab, and the drift-derived
+  advisories in the bell. (#57)
+- **`(i)` polling-mode hint** on the dashboard heading when polling is
+  off — hover tooltip explains the current state and links to the live
+  CONFIGURATION doc.
+- **`flash=polling-required` error toast** when an operator follows a
+  direct URL to a gated feature (`/dashboard?tab=pdns`,
+  `/zones/<id>?tab=sync`, `/zones/<id>?tab=statistics`) on a polling-off
+  install — the page redirects to the default view and surfaces a red
+  error toast naming the env var.
+- **Boot-time log line** at the first `/healthz` hit summarising the
+  effective polling mode plus a sharp warning when the configured fleet
+  has replication topology but the flag is off (mirrors / multiple
+  primaries / clusters). Hard 3 s budget — never blocks startup.
+
+### Changed
+
+- **`isWriteCapable` is now `caps ? !isReadOnlyMirror(caps) : true`.**
+  The predicate flipped from gating on the AXFR-primary flag to gating
+  on the explicit observation of a read-only mirror — so standalone
+  (`primary=no, secondary=no`), explicit primary, and dual-role
+  primary+secondary all correctly count as writable. Only a pure
+  secondary mirror is excluded from `/zones/new`'s picker. (#57)
+- **Header sync chip gates on actual replication topology AND the
+  poller flag.** `hasReplicationTopology()` was added in this cycle;
+  the chip only enters SYNCED/DESYNCED mode when both a ≥2-peer cluster
+  (derived primary+secondaries OR configured multi-primary) AND
+  `PDNS_BACKGROUND_POLLING=true` are present. Standalone /
+  single-primary / polling-off fleets see plain "Live". (#57)
+- **Capability badge `none` → `standalone`.** The neutral badge for a
+  daemon with no replication flags now reads `standalone`, matching the
+  semantic ("hosts zones over the API; no DNS-protocol replication")
+  and removing the alarming "none" label. Same neutral tone.
+  `summarizeCapabilities()`'s fallback follows suit (`api` →
+  `standalone`); `api: no` → `unreachable`.
+- **Dashboard tab strip hides** when polling is off — the "Admin" view
+  becomes the default (and only) tab. The PDNS-metrics tab body
+  redirects with the flash toast on direct URL.
+- **Zone-detail Sync + Statistics tabs hide** when polling is off.
+  Direct ?tab=sync / ?tab=statistics URLs redirect to the records tab
+  with the flash toast.
+- **Servers-list Sync column hides** when polling is off (the page's
+  realtime sync subscriber stays unmounted; row reachability still
+  updates on every operator-initiated probe).
+- **Zones-list mirror column hides** when polling is off; default sort
+  collapses to Name asc instead of Sync-desc then Name.
 
 ### Fixed
 
-- **Standalone PDNS Auth instances now appear on the zone-create
-  picker.** `isWriteCapable` previously gated on `caps.primary` —
-  which only reflects PDNS's AXFR-primary flag, not whether the API
-  accepts zone writes. Replaced with the inverse of `isReadOnlyMirror`,
-  so the predicate is: **write-capable unless explicitly observed as a
-  pure secondary mirror** (`secondary=yes && primary=no`). The three
-  shapes that now correctly count as writable: standalone
-  (`primary=no, secondary=no`), explicit primary, and dual-role
-  primary+secondary. (#57)
-- **Header sync chip no longer claims SYNCED/DESYNCED against a fleet
-  with no replication topology.** New `hasReplicationTopology()`
-  predicate in `lib/pdns/sync.ts`; the app shell only enters the
-  sync-mode chip when at least one backend has ≥1 mirror (derived
-  primary+secondaries group or configured multi-primary cluster of
-  ≥2 peers). Fleets of standalones or single-primaries-without-secondaries
-  see plain "Live" — the truthful read for that topology. (#57)
-
-### Changed — UI
-
-- **Capability badge `none` → `standalone`.** The neutral badge for a
-  daemon with no replication flags now reads `standalone`, matching
-  the semantic ("hosts zones over the API; no DNS-protocol
-  replication") and removing the alarming "none" label. Same neutral
-  tone. `summarizeCapabilities()`'s fallback string follows
-  suit (`api` → `standalone`); `api: no` → `unreachable`.
+- Standalone-PDNS daemons no longer rendered as `none` /
+  not-a-write-target on `/admin/servers` or hidden from `/zones/new`. (#57)
+- `scheduleImmediatePoll` and the in-flight `scheduleFollowupPoll` are
+  no-ops when polling is off; mutations still publish their own SSE
+  refresh and call `invalidateBackendObservation`, so the next page
+  render warms what it needs via `ensureBackendsObserved`.
 
 ### Tests
 
-- Four-way table test for `isWriteCapable` × `isReadOnlyMirror`
-  pinning the predicate's behaviour across the standalone / primary /
-  secondary / dual-role flag matrix.
-- `unprobed (null)` continues to default to write-capable so a
-  freshly-added backend stays usable until its first probe.
+- Four-way table test for `isWriteCapable` × `isReadOnlyMirror` across
+  the standalone / primary / secondary / dual-role flag matrix.
+- `unprobed (null)` defaults to write-capable so a freshly-added
+  backend stays usable until its first probe.
+- Polling-flag tests pin `ensurePollerRunning` to no `setInterval`,
+  and `scheduleImmediatePoll` to no `setTimeout`, when the flag is off.
+- Integration suite pinned to `PDNS_BACKGROUND_POLLING=true` so the
+  replication-aware code paths stay exercised end-to-end.
 
 ## [1.1.5] — 2026-05-26
 

--- a/README.md
+++ b/README.md
@@ -85,12 +85,16 @@ The full feature catalog with module-level docs is in [`docs/FEATURES.md`](./doc
   <img src="screenshots/light/dashboard.png" alt="Dashboard" />
 </picture>
 
+<br>
+
 **Multi-backend** — clusters, primary + secondaries groups, and standalone primaries side by side. Live sync state, drift advisories, and the dashboard PowerDNS-metrics tab are opt-in via [`PDNS_BACKGROUND_POLLING=true`](./docs/03-CONFIGURATION.md#pdns_background_polling) — recommended for replication topologies, off by default for standalone installs.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/powerdns-servers.png" />
   <img src="screenshots/light/powerdns-servers.png" alt="PowerDNS servers" />
 </picture>
+
+<br>
 
 **Amalgamated zones** — every backend's zones in one searchable list with serial + per-row sync state.
 
@@ -99,12 +103,16 @@ The full feature catalog with module-level docs is in [`docs/FEATURES.md`](./doc
   <img src="screenshots/light/zones-list.png" alt="Zones" />
 </picture>
 
+<br>
+
 **Per-RRset editor** — per-type structured editors with inline validation.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/zone-edit.png" />
   <img src="screenshots/light/zone-edit.png" alt="Edit record dialog" />
 </picture>
+
+<br>
 
 **Diff-before-apply** — every change previewed as a BIND-style before / after diff before it's written.
 
@@ -113,12 +121,16 @@ The full feature catalog with module-level docs is in [`docs/FEATURES.md`](./doc
   <img src="screenshots/light/zone-edit-diff.png" alt="Review changes diff" />
 </picture>
 
+<br>
+
 **Backend health** — bell-driven advisories for unreachable hosts, replication drift, missing TSIG keys, daemon-config drift.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/backend-health.png" />
   <img src="screenshots/light/backend-health.png" alt="Backend health alerts" />
 </picture>
+
+<br>
 
 **Append-only audit log** — redacted before/after snapshots, per-row PDNS HTTP trail, CSV export.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The full feature catalog with module-level docs is in [`docs/FEATURES.md`](./doc
   <img src="screenshots/light/dashboard.png" alt="Dashboard" />
 </picture>
 
-**Multi-backend** — clusters, primary + secondaries groups, and standalone primaries side by side with live sync status.
+**Multi-backend** — clusters, primary + secondaries groups, and standalone primaries side by side. Live sync state, drift advisories, and the dashboard PowerDNS-metrics tab are opt-in via [`PDNS_BACKGROUND_POLLING=true`](./docs/03-CONFIGURATION.md#pdns_background_polling) — recommended for replication topologies, off by default for standalone installs.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="screenshots/dark/powerdns-servers.png" />

--- a/app/(app)/admin/servers/page.tsx
+++ b/app/(app)/admin/servers/page.tsx
@@ -26,6 +26,7 @@ import { ClickableTr, ClickableDiv } from "@/components/ui/clickable-row";
 import { SyncIndicator } from "@/components/ui/sync-indicator";
 import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
 import { pdnsBackgroundPollingEnabled } from "@/lib/env";
+import { PollingDisabledHint } from "@/components/domain/polling-disabled-hint";
 import { backendUnreachability } from "@/lib/realtime/backend-status";
 import type { PdnsServer } from "@/lib/db/schema";
 import { TestServerButton } from "./_components/test-server-button";
@@ -118,7 +119,10 @@ export default async function PdnsServersListPage() {
     <div className="space-y-6">
       <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">PowerDNS servers</h1>
+          <div className="flex items-baseline gap-2">
+            <h1 className="text-2xl font-semibold tracking-tight">PowerDNS servers</h1>
+            {!pdnsBackgroundPollingEnabled ? <PollingDisabledHint /> : null}
+          </div>
           <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">
             One row per upstream PowerDNS Authoritative backend.
           </p>

--- a/app/(app)/admin/servers/page.tsx
+++ b/app/(app)/admin/servers/page.tsx
@@ -25,6 +25,7 @@ import { CapabilityBadges } from "@/components/domain/capability-badges";
 import { ClickableTr, ClickableDiv } from "@/components/ui/clickable-row";
 import { SyncIndicator } from "@/components/ui/sync-indicator";
 import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
+import { pdnsBackgroundPollingEnabled } from "@/lib/env";
 import { backendUnreachability } from "@/lib/realtime/backend-status";
 import type { PdnsServer } from "@/lib/db/schema";
 import { TestServerButton } from "./_components/test-server-button";
@@ -99,8 +100,12 @@ export default async function PdnsServersListPage() {
 
   // Precompute sync chips for secondaries off the zone-state cache —
   // never hits PDNS itself. "in sync" means every cached zone serial on
-  // the secondary matches its primary's cached serial.
-  const syncBySecondary = computeSecondarySync(primaries, secondariesByPrimary);
+  // the secondary matches its primary's cached serial. Skipped entirely
+  // when `PDNS_BACKGROUND_POLLING=false` — the Sync column is hidden, no
+  // verdict to compute.
+  const syncBySecondary = pdnsBackgroundPollingEnabled
+    ? computeSecondarySync(primaries, secondariesByPrimary)
+    : new Map<string, "in-sync" | "lagging" | "unknown">();
   let anyLagging = false;
   for (const verdict of syncBySecondary.values()) {
     if (verdict === "lagging") {
@@ -119,7 +124,7 @@ export default async function PdnsServersListPage() {
           </p>
         </div>
         <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2 [&>*]:w-full sm:[&>*]:w-auto">
-          {servers.some((s) => s.disabledAt === null) ? (
+          {pdnsBackgroundPollingEnabled && servers.some((s) => s.disabledAt === null) ? (
             <ServersPageHeartbeat inSync={!anyLagging} />
           ) : null}
           {servers.some((s) => s.disabledAt === null) ? <RefreshAllButton /> : null}
@@ -210,7 +215,7 @@ export default async function PdnsServersListPage() {
                     <th className="px-4 py-2.5">Base URL</th>
                     <th className="px-4 py-2.5">Status</th>
                     <th className="px-4 py-2.5">Version</th>
-                    <th className="px-4 py-2.5">Sync</th>
+                    {pdnsBackgroundPollingEnabled ? <th className="px-4 py-2.5">Sync</th> : null}
                     {canReadAudit ? <th className="px-4 py-2.5">Last admin edit</th> : null}
                     <th className="w-px px-4 py-2.5 whitespace-nowrap"></th>
                   </tr>
@@ -246,7 +251,7 @@ export default async function PdnsServersListPage() {
                     <Fragment>
                       <tr className="border-t border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)]">
                         <td
-                          colSpan={canReadAudit ? 7 : 6}
+                          colSpan={(pdnsBackgroundPollingEnabled ? 7 : 6) + (canReadAudit ? 0 : -1)}
                           className="px-4 py-1.5 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase"
                         >
                           Standalone secondaries (mirror an external / unmanaged primary)
@@ -269,7 +274,7 @@ export default async function PdnsServersListPage() {
                     <Fragment>
                       <tr className="border-t border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)]">
                         <td
-                          colSpan={canReadAudit ? 7 : 6}
+                          colSpan={(pdnsBackgroundPollingEnabled ? 7 : 6) + (canReadAudit ? 0 : -1)}
                           className="px-4 py-1.5 text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase"
                         >
                           Orphan secondaries (parent disabled or deleted)
@@ -458,9 +463,11 @@ function ServerRow({
         />
       </td>
       <td className="px-4 py-3 align-top text-xs">{row.versionCache?.version ?? "—"}</td>
-      <td className="px-4 py-3 align-top text-xs">
-        <SyncChip verdict={syncChip} isMirror={isReadOnlyMirror(row.capabilities)} />
-      </td>
+      {pdnsBackgroundPollingEnabled ? (
+        <td className="px-4 py-3 align-top text-xs">
+          <SyncChip verdict={syncChip} isMirror={isReadOnlyMirror(row.capabilities)} />
+        </td>
+      ) : null}
       {canReadAudit ? (
         <td className="px-4 py-3 align-top text-xs text-[color:var(--color-fg-muted)]">
           {lastEdits.has(row.id) ? (
@@ -529,9 +536,11 @@ function ServerCard({ row, canReadAudit, lastEdits, syncChip, reachability }: Se
         <Field label="Version">
           <span className="text-xs">{row.versionCache?.version ?? "—"}</span>
         </Field>
-        <Field label="Sync">
-          <SyncChip verdict={syncChip} isMirror={isMirror} />
-        </Field>
+        {pdnsBackgroundPollingEnabled ? (
+          <Field label="Sync">
+            <SyncChip verdict={syncChip} isMirror={isMirror} />
+          </Field>
+        ) : null}
         {canReadAudit ? (
           <Field label="Last admin edit">
             <span className="text-xs text-[color:var(--color-fg-muted)]">

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -20,6 +20,7 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { requireUserForPage } from "@/lib/auth/require-user";
 import {
   actionBreakdown,
@@ -39,6 +40,8 @@ import {
 } from "@/lib/db/repositories/pdns-servers";
 import { readRecentMetrics } from "@/lib/metrics/pdns-stats-sampler";
 import { ensurePollerRunning, ensureBackendsObserved } from "@/lib/realtime/zone-poller";
+import { pdnsBackgroundPollingEnabled } from "@/lib/env";
+import { PollingDisabledHint } from "@/components/domain/polling-disabled-hint";
 import { getBackendStatus } from "@/lib/realtime/backend-status";
 import { CounterRateChart, MapPieChart, ValueLineChart } from "@/components/domain/pdns-stat-chart";
 import { Chart } from "@/components/ui/chart";
@@ -68,9 +71,21 @@ interface DashboardProps {
 export default async function DashboardPage({ searchParams }: DashboardProps) {
   const { user, ability } = await requireUserForPage();
   const { tab: requestedTab } = await searchParams;
-  // Two tabs: pdns (PowerDNS server statistics — default) vs. admin
-  // (audit/user/server admin metrics, reached via ?tab=admin).
-  const tab: "admin" | "pdns" = requestedTab === "admin" ? "admin" : "pdns";
+  // Two tabs: pdns (PowerDNS server statistics) vs. admin (audit / user /
+  // server admin metrics). With background polling enabled, "pdns" is the
+  // default; with polling disabled there's nothing to chart, so "admin"
+  // becomes the default and the tab strip hides — the PDNS-stats tab still
+  // resolves but renders a subtle inline note pointing at the env flag.
+  const defaultTab: "admin" | "pdns" = pdnsBackgroundPollingEnabled ? "pdns" : "admin";
+  // Direct URL ?tab=pdns with the flag off bounces to the admin tab with a
+  // flash toast ("This view requires PDNS_BACKGROUND_POLLING=true"). A bare
+  // `/dashboard` falls back to the admin tab silently — the dashboard heading
+  // already carries a <PollingDisabledHint/> that explains the flag.
+  if (requestedTab === "pdns" && !pdnsBackgroundPollingEnabled) {
+    redirect("/dashboard?tab=admin&flash=polling-required&need=PDNS+statistics");
+  }
+  const tab: "admin" | "pdns" =
+    requestedTab === "admin" ? "admin" : requestedTab === "pdns" ? "pdns" : defaultTab;
 
   // Permission gates. Every section below is scoped to the perms the actor
   // has — a freshly-provisioned OIDC user with no roles sees just the
@@ -172,6 +187,7 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
             <h1 className="text-3xl font-semibold tracking-tight">
               Welcome, {user.name ?? user.email.split("@")[0]}
             </h1>
+            {!pdnsBackgroundPollingEnabled && canReadServers ? <PollingDisabledHint /> : null}
             {canReadAudit ? <DashboardLiveFeed /> : null}
           </div>
           <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">
@@ -246,7 +262,7 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
         <OidcAttentionWidget counts={oidcAttention} />
       ) : null}
 
-      <DashboardTabStrip active={tab} />
+      {pdnsBackgroundPollingEnabled ? <DashboardTabStrip active={tab} /> : null}
 
       {tab === "pdns" ? (
         canReadServers ? (

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -33,6 +33,7 @@ import { MustChangePasswordProvider } from "@/components/auth/must-change-passwo
 import { getAppSettings } from "@/lib/settings/app-settings";
 import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
 import { globalAnyLagging, hasReplicationTopology } from "@/lib/pdns/sync";
+import { decideHeaderChipMode } from "@/lib/realtime/header-chip-mode";
 import { pdnsBackgroundPollingEnabled } from "@/lib/env";
 
 /**
@@ -216,23 +217,26 @@ export default async function AppLayout({ children }: Readonly<{ children: React
   // signal they have no context for. The helper reads exclusively from the
   // poller's in-process caches, so this is a near-free lookup once the
   // first ensureBackendsObserved warms the store.
-  // Sync-mode chip is only meaningful when:
-  //   • PDNS_BACKGROUND_POLLING is enabled (#57 + v1.2.0 opt-in) — without
-  //     the poller there's no live sync state to surface; the chip stays
-  //     in plain "Live" connectivity-only mode, and
-  //   • the fleet actually has replication topology (derived primary+
-  //     secondaries group or configured multi-primary cluster) to be
-  //     in-sync about.
-  // Standalone / single-primary fleets see only the "Live" pulse.
-  const showGlobalSync =
-    pdnsBackgroundPollingEnabled && realtimeAvailable && (canReadZones || canReadServers);
-  let initialChipMode: { kind: "live" } | { kind: "sync"; inSync: boolean } = { kind: "live" };
+  // Sync-mode chip default. Pages that show their own per-zone or per-page
+  // sync state override this via <HeaderStatusMode/>. The decision is a pure
+  // function (`decideHeaderChipMode`) — unit-tested in isolation; the awaits
+  // here are I/O bridges feeding it.
+  const canReadBackends = canReadZones || canReadServers;
+  const showGlobalSync = pdnsBackgroundPollingEnabled && realtimeAvailable && canReadBackends;
+  let topology = false;
+  let lagging = false;
   if (showGlobalSync) {
     await ensureBackendsObserved();
-    if (await hasReplicationTopology()) {
-      initialChipMode = { kind: "sync", inSync: !(await globalAnyLagging()) };
-    }
+    topology = await hasReplicationTopology();
+    if (topology) lagging = await globalAnyLagging();
   }
+  const initialChipMode = decideHeaderChipMode({
+    pollingEnabled: pdnsBackgroundPollingEnabled,
+    realtimeAvailable,
+    canReadBackends,
+    hasReplicationTopology: topology,
+    anyLagging: lagging,
+  });
 
   const shell = (
     <AppShell sidebar={sidebar} headerControls={headerControls}>

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -32,7 +32,7 @@ import { HeaderStatusProvider } from "@/components/realtime/header-status-chip";
 import { MustChangePasswordProvider } from "@/components/auth/must-change-password-guard";
 import { getAppSettings } from "@/lib/settings/app-settings";
 import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
-import { globalAnyLagging } from "@/lib/pdns/sync";
+import { globalAnyLagging, hasReplicationTopology } from "@/lib/pdns/sync";
 
 /**
  * Paths a non-compliant user (forced-MFA-not-enrolled, or flagged
@@ -215,11 +215,18 @@ export default async function AppLayout({ children }: Readonly<{ children: React
   // signal they have no context for. The helper reads exclusively from the
   // poller's in-process caches, so this is a near-free lookup once the
   // first ensureBackendsObserved warms the store.
+  // Sync-mode chip is only meaningful when there's actually replication
+  // topology in the fleet — a derived primary+secondaries group or a configured
+  // multi-primary cluster. Standalone or single-primary-only fleets fall back
+  // to plain "Live" so we don't surface a SYNCED verdict against nothing
+  // (issue #57).
   const showGlobalSync = realtimeAvailable && (canReadZones || canReadServers);
   let initialChipMode: { kind: "live" } | { kind: "sync"; inSync: boolean } = { kind: "live" };
   if (showGlobalSync) {
     await ensureBackendsObserved();
-    initialChipMode = { kind: "sync", inSync: !(await globalAnyLagging()) };
+    if (await hasReplicationTopology()) {
+      initialChipMode = { kind: "sync", inSync: !(await globalAnyLagging()) };
+    }
   }
 
   const shell = (

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -33,6 +33,7 @@ import { MustChangePasswordProvider } from "@/components/auth/must-change-passwo
 import { getAppSettings } from "@/lib/settings/app-settings";
 import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
 import { globalAnyLagging, hasReplicationTopology } from "@/lib/pdns/sync";
+import { pdnsBackgroundPollingEnabled } from "@/lib/env";
 
 /**
  * Paths a non-compliant user (forced-MFA-not-enrolled, or flagged
@@ -215,12 +216,16 @@ export default async function AppLayout({ children }: Readonly<{ children: React
   // signal they have no context for. The helper reads exclusively from the
   // poller's in-process caches, so this is a near-free lookup once the
   // first ensureBackendsObserved warms the store.
-  // Sync-mode chip is only meaningful when there's actually replication
-  // topology in the fleet — a derived primary+secondaries group or a configured
-  // multi-primary cluster. Standalone or single-primary-only fleets fall back
-  // to plain "Live" so we don't surface a SYNCED verdict against nothing
-  // (issue #57).
-  const showGlobalSync = realtimeAvailable && (canReadZones || canReadServers);
+  // Sync-mode chip is only meaningful when:
+  //   • PDNS_BACKGROUND_POLLING is enabled (#57 + v1.2.0 opt-in) — without
+  //     the poller there's no live sync state to surface; the chip stays
+  //     in plain "Live" connectivity-only mode, and
+  //   • the fleet actually has replication topology (derived primary+
+  //     secondaries group or configured multi-primary cluster) to be
+  //     in-sync about.
+  // Standalone / single-primary fleets see only the "Live" pulse.
+  const showGlobalSync =
+    pdnsBackgroundPollingEnabled && realtimeAvailable && (canReadZones || canReadServers);
   let initialChipMode: { kind: "live" } | { kind: "sync"; inSync: boolean } = { kind: "live" };
   if (showGlobalSync) {
     await ensureBackendsObserved();

--- a/app/(app)/zones/[zoneId]/_components/zone-header.tsx
+++ b/app/(app)/zones/[zoneId]/_components/zone-header.tsx
@@ -5,6 +5,7 @@ import type { PdnsZoneDetail } from "@/lib/pdns/types";
 import type { ZoneAuditEntry } from "@/lib/db/repositories/audit-log";
 import { CloneZoneButton } from "./clone-zone-button";
 import { ZoneRealtimeSubscriber } from "./zone-realtime-subscriber";
+import { PollingDisabledHint } from "@/components/domain/polling-disabled-hint";
 
 interface ZoneHeaderProps {
   /**
@@ -65,6 +66,7 @@ export function ZoneHeader({
             {displayZoneName(zone.name)}
           </h1>
           <ZoneRealtimeSubscriber zoneName={zone.name} inSync={inSync} />
+          {inSync === null ? <PollingDisabledHint /> : null}
         </div>
         <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm sm:grid-cols-4">
           <Stat label="Kind" value={zone.kind} />

--- a/app/(app)/zones/[zoneId]/_components/zone-header.tsx
+++ b/app/(app)/zones/[zoneId]/_components/zone-header.tsx
@@ -9,9 +9,11 @@ import { ZoneRealtimeSubscriber } from "./zone-realtime-subscriber";
 interface ZoneHeaderProps {
   /**
    * Cached sync verdict (primary vs secondaries). Drives the realtime
-   * indicator into fast-poll mode while replication is in flight.
+   * indicator into fast-poll mode while replication is in flight. `null`
+   * when `PDNS_BACKGROUND_POLLING=false` — the header chip stays in plain
+   * "Live" mode and the subscriber only refreshes on mutation events.
    */
-  inSync: boolean;
+  inSync: boolean | null;
   zone: PdnsZoneDetail;
   zoneIdEncoded: string;
   /**

--- a/app/(app)/zones/[zoneId]/_components/zone-realtime-subscriber.tsx
+++ b/app/(app)/zones/[zoneId]/_components/zone-realtime-subscriber.tsx
@@ -21,7 +21,13 @@ import { HeaderStatusMode } from "@/components/realtime/header-status-chip";
 
 interface Props {
   zoneName: string;
-  inSync: boolean;
+  /**
+   * Cached primary↔secondaries sync verdict, OR `null` when
+   * `PDNS_BACKGROUND_POLLING=false` — there is no live mirror state to
+   * push, so the header chip stays in plain "Live" mode. The mutation-driven
+   * router.refresh below still fires either way.
+   */
+  inSync: boolean | null;
 }
 
 export function ZoneRealtimeSubscriber({ zoneName, inSync }: Props) {
@@ -41,5 +47,6 @@ export function ZoneRealtimeSubscriber({ zoneName, inSync }: Props) {
     },
   );
 
+  if (inSync === null) return null;
   return <HeaderStatusMode kind="sync" inSync={inSync} />;
 }

--- a/app/(app)/zones/[zoneId]/_components/zone-tabs.tsx
+++ b/app/(app)/zones/[zoneId]/_components/zone-tabs.tsx
@@ -17,6 +17,12 @@ interface ZoneTabsProps {
   canReadDnssec: boolean;
   canReadMetadata: boolean;
   canReadAudit: boolean;
+  /**
+   * Whether to render the Sync + Statistics tabs. Both depend on the
+   * background poller (zone-state cache for Sync, metric_samples for
+   * Statistics), so they hide when `PDNS_BACKGROUND_POLLING=false`.
+   */
+  showPollingFeatures: boolean;
 }
 
 export function ZoneTabs({
@@ -26,6 +32,7 @@ export function ZoneTabs({
   canReadDnssec,
   canReadMetadata,
   canReadAudit,
+  showPollingFeatures,
 }: ZoneTabsProps) {
   const qs = `server=${encodeURIComponent(serverSlug)}`;
   const detailHref = `/zones/${zoneIdEncoded}?${qs}`;
@@ -66,12 +73,16 @@ export function ZoneTabs({
             Metadata &amp; TSIG
           </TabLink>
         ) : null}
-        <TabLink href={syncHref} active={active === "sync"}>
-          Sync
-        </TabLink>
-        <TabLink href={statisticsHref} active={active === "statistics"}>
-          Statistics
-        </TabLink>
+        {showPollingFeatures ? (
+          <>
+            <TabLink href={syncHref} active={active === "sync"}>
+              Sync
+            </TabLink>
+            <TabLink href={statisticsHref} active={active === "statistics"}>
+              Statistics
+            </TabLink>
+          </>
+        ) : null}
         {canReadAudit ? (
           <TabLink href={historyHref} active={active === "history"}>
             Change history

--- a/app/(app)/zones/[zoneId]/page.tsx
+++ b/app/(app)/zones/[zoneId]/page.tsx
@@ -36,6 +36,7 @@ import { derivedUpstreamFor } from "@/lib/pdns/topology-cache";
 import { getBackendGateway } from "@/lib/realtime/backend-gateway";
 import { PdnsNotFoundError } from "@/lib/pdns/errors";
 import { logger } from "@/lib/logger";
+import { pdnsBackgroundPollingEnabled } from "@/lib/env";
 import { redact } from "@/lib/errors/redact";
 import { parseSoaContent, type SoaFields } from "@/lib/validators/soa";
 import { Lock } from "lucide-react";
@@ -287,6 +288,15 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
   const canReadDnssec = zoneCan("dnssec.read");
   const canReadMetadata = zoneCan("metadata.read");
 
+  // Direct ?tab=sync / ?tab=statistics on a polling-off install bounces
+  // back to the default records view with an error flash toast — these
+  // surfaces are powered by the background poller, which is opt-in
+  // (`PDNS_BACKGROUND_POLLING=true`). See lib/env.ts + #57.
+  if (!pdnsBackgroundPollingEnabled && (requestedTab === "sync" || requestedTab === "statistics")) {
+    const back = `/zones/${encodeURIComponent(zoneId)}?server=${encodeURIComponent(selected.slug)}&flash=polling-required&need=${encodeURIComponent(requestedTab === "sync" ? "per-zone Sync" : "per-zone Statistics")}`;
+    redirect(back);
+  }
+
   const tab: ZoneTab =
     requestedTab === "history" && canReadAudit
       ? "history"
@@ -355,7 +365,10 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
         lastEdit={lastEdit}
         canReadAudit={canReadAudit}
         canCreateZone={canCreateZone}
-        inSync={syncVerdict.inSync}
+        // null hides the header chip's sync mode for the standalone /
+        // polling-off path; the subscriber still listens for mutation
+        // refresh events.
+        inSync={pdnsBackgroundPollingEnabled ? syncVerdict.inSync : null}
       />
 
       {isReadOnlyZone ? (
@@ -391,6 +404,7 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
           canReadDnssec={canReadDnssec}
           canReadMetadata={canReadMetadata}
           canReadAudit={canReadAudit}
+          showPollingFeatures={pdnsBackgroundPollingEnabled}
         />
       </div>
       <ScrollToTab anchorId="zone-tabs-anchor" />
@@ -492,6 +506,7 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
         ) : tab === "statistics" ? (
           <ZoneStatisticsSection serverSlugs={auditSlugs} zoneName={zone.name} />
         ) : tab === "sync" ? (
+          // tab === "sync"
           // Cluster (peer) comparison only for a TRUE multi-primary group — ≥2
           // write-capable peers and no secondaries. A primary+secondaries group
           // (one writable peer mirrored by secondaries) uses primary→secondary

--- a/app/(app)/zones/_components/zones-table.tsx
+++ b/app/(app)/zones/_components/zones-table.tsx
@@ -118,6 +118,12 @@ interface ZonesTableProps {
    * compact for actors without audit.read.
    */
   showLastEdit: boolean;
+  /**
+   * Whether the polled mirror-state column should render. Off when
+   * `PDNS_BACKGROUND_POLLING=false` — there is no live primary↔secondary
+   * verdict to display, so the column is dropped entirely.
+   */
+  showSync: boolean;
 }
 
 /** Detail URL for a zone row — cluster-backed zones carry ?cluster=, standalone
@@ -128,7 +134,7 @@ function zoneHref(row: ZoneRow): string {
     : `/zones/${encodeURIComponent(row.id)}?server=${encodeURIComponent(row.backend.serverSlug)}`;
 }
 
-export function ZonesTable({ zones, showLastEdit }: ZonesTableProps) {
+export function ZonesTable({ zones, showLastEdit, showSync }: ZonesTableProps) {
   const columns = useMemo<Array<ColumnDef<ZoneRow, unknown>>>(() => {
     const cols: Array<ColumnDef<ZoneRow, unknown>> = [
       {
@@ -196,7 +202,10 @@ export function ZonesTable({ zones, showLastEdit }: ZonesTableProps) {
         cell: (ctx) => <DnssecCell on={ctx.getValue<boolean>()} />,
         meta: { className: "w-[8%]" },
       },
-      {
+    ];
+
+    if (showSync) {
+      cols.push({
         id: "sync",
         // Numeric rank so `desc: true` orders desync first, in-sync
         // last. Standalone primaries (no peers, `syncWorst === null`)
@@ -208,8 +217,8 @@ export function ZonesTable({ zones, showLastEdit }: ZonesTableProps) {
         header: "Sync",
         cell: (ctx) => <SyncCell row={ctx.row.original} />,
         meta: { className: "w-[14%]" },
-      },
-    ];
+      });
+    }
 
     if (showLastEdit) {
       cols.push({
@@ -235,7 +244,7 @@ export function ZonesTable({ zones, showLastEdit }: ZonesTableProps) {
     }
 
     return cols;
-  }, [showLastEdit]);
+  }, [showLastEdit, showSync]);
 
   // Forward / Reverse / All segmented filter above the table. Persisted to
   // localStorage so the choice sticks across navigations (same pattern as
@@ -285,11 +294,17 @@ export function ZonesTable({ zones, showLastEdit }: ZonesTableProps) {
         // Default order: desynced first (Sync desc), then name asc.
         // When every row is in-sync the Sync rank ties and Name asc
         // becomes the visible order — i.e. "show me anything that
-        // needs attention first; otherwise alphabetical."
-        initialSort={[
-          { id: "sync", desc: true },
-          { id: "name", desc: false },
-        ]}
+        // needs attention first; otherwise alphabetical." With the Sync
+        // column hidden (`PDNS_BACKGROUND_POLLING=false`), the initial
+        // sort collapses to Name asc.
+        initialSort={
+          showSync
+            ? [
+                { id: "sync", desc: true },
+                { id: "name", desc: false },
+              ]
+            : [{ id: "name", desc: false }]
+        }
         sortParam="sort"
         pageSizeParam="pageSize"
         stateKey="zones"

--- a/app/(app)/zones/page.tsx
+++ b/app/(app)/zones/page.tsx
@@ -45,6 +45,7 @@ import { backendUnreachability } from "@/lib/realtime/backend-status";
 import type { PdnsServer } from "@/lib/db/schema";
 import { ZonesTable, type ZoneRow } from "./_components/zones-table";
 import { pdnsBackgroundPollingEnabled } from "@/lib/env";
+import { PollingDisabledHint } from "@/components/domain/polling-disabled-hint";
 import { ServerRealtimeSubscriber } from "./_components/server-realtime-subscriber";
 
 export const metadata: Metadata = { title: "Zones" };
@@ -220,7 +221,9 @@ export default async function ZonesPage() {
             <h1 className="text-2xl font-semibold tracking-tight">Zones</h1>
             {pdnsBackgroundPollingEnabled ? (
               <ServerRealtimeSubscriber serverSlugs={channelSlugs} inSync={!anyLagging} />
-            ) : null}
+            ) : (
+              <PollingDisabledHint />
+            )}
           </div>
           <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">
             {visibleRows.length} zone{visibleRows.length === 1 ? "" : "s"} across {backends.length}{" "}

--- a/app/(app)/zones/page.tsx
+++ b/app/(app)/zones/page.tsx
@@ -44,6 +44,7 @@ import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
 import { backendUnreachability } from "@/lib/realtime/backend-status";
 import type { PdnsServer } from "@/lib/db/schema";
 import { ZonesTable, type ZoneRow } from "./_components/zones-table";
+import { pdnsBackgroundPollingEnabled } from "@/lib/env";
 import { ServerRealtimeSubscriber } from "./_components/server-realtime-subscriber";
 
 export const metadata: Metadata = { title: "Zones" };
@@ -204,8 +205,12 @@ export default async function ZonesPage() {
 
   // "anyLagging" drives the chip's fast-mode color — true when ANY row
   // on the amalgamated list isn't fully in-sync. Standalone primaries
-  // have null syncWorst and don't contribute.
-  const anyLagging = visibleRows.some((r) => r.syncWorst !== null && r.syncWorst !== "in-sync");
+  // have null syncWorst and don't contribute. With background polling
+  // disabled, the verdict is always "in-sync" (we don't show a sync
+  // chip at all on this page in that mode).
+  const anyLagging =
+    pdnsBackgroundPollingEnabled &&
+    visibleRows.some((r) => r.syncWorst !== null && r.syncWorst !== "in-sync");
 
   return (
     <div className="space-y-6">
@@ -213,7 +218,9 @@ export default async function ZonesPage() {
         <div>
           <div className="flex items-baseline gap-3">
             <h1 className="text-2xl font-semibold tracking-tight">Zones</h1>
-            <ServerRealtimeSubscriber serverSlugs={channelSlugs} inSync={!anyLagging} />
+            {pdnsBackgroundPollingEnabled ? (
+              <ServerRealtimeSubscriber serverSlugs={channelSlugs} inSync={!anyLagging} />
+            ) : null}
           </div>
           <p className="mt-1 text-sm text-[color:var(--color-fg-muted)]">
             {visibleRows.length} zone{visibleRows.length === 1 ? "" : "s"} across {backends.length}{" "}
@@ -255,7 +262,11 @@ export default async function ZonesPage() {
         </div>
       ) : null}
 
-      <ZonesTable zones={visibleRows} showLastEdit={canReadAudit} />
+      <ZonesTable
+        zones={visibleRows}
+        showLastEdit={canReadAudit}
+        showSync={pdnsBackgroundPollingEnabled}
+      />
     </div>
   );
 }
@@ -305,18 +316,24 @@ async function rowsFromBackend(backend: SelectableBackend): Promise<FetchResult>
   const zones = [...cached.zones.values()];
 
   // Sync state — branches on the group's composition (ADR-0014). All variants
-  // read serials from the cache (poller-maintained), never live.
+  // read serials from the cache (poller-maintained), never live. With
+  // `PDNS_BACKGROUND_POLLING=false` we skip the computation entirely — the
+  // Sync column is hidden so nothing reads `syncByZone`.
   let syncByZone: Map<string, SecondarySyncStatus[]>;
-  const zoneSerials = zones.map((z) => ({ name: z.name, serial: z.serial }));
-  if (backend.kind === "server" || backend.secondaries.length > 0) {
-    // Standalone primary, or a primary + its secondaries → primary→secondary.
-    syncByZone = await checkZonesSyncBatch(
-      backend.kind === "cluster" ? backend.representativeServer : backend.server,
-      zoneSerials,
-    );
+  if (!pdnsBackgroundPollingEnabled) {
+    syncByZone = new Map();
   } else {
-    // True multi-primary cluster — compare every peer's cached serials.
-    syncByZone = clusterSyncFromCache(backend, readPeer, zones);
+    const zoneSerials = zones.map((z) => ({ name: z.name, serial: z.serial }));
+    if (backend.kind === "server" || backend.secondaries.length > 0) {
+      // Standalone primary, or a primary + its secondaries → primary→secondary.
+      syncByZone = await checkZonesSyncBatch(
+        backend.kind === "cluster" ? backend.representativeServer : backend.server,
+        zoneSerials,
+      );
+    } else {
+      // True multi-primary cluster — compare every peer's cached serials.
+      syncByZone = clusterSyncFromCache(backend, readPeer, zones);
+    }
   }
 
   const rowsBackend: ZoneRow["backend"] = {

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -21,8 +21,19 @@ export default async function AuthLayout({ children }: Readonly<{ children: Reac
         <div className="absolute top-4 right-4">
           <ThemeToggle />
         </div>
-        <div className="mb-6">
-          <BrandMark siteName={siteName} brandLogoUrl={brandLogoUrl} width={500} priority />
+        {/* Wordmark wrapper matches the form-card max-width so the mark
+            stays visually anchored to the card on every viewport. `min(100%,
+            350px)` keeps it inside the wrapper on narrow phones (where 500 px
+            previously overflowed and clipped the trailing "-Admin") while
+            capping at 350 px on desktop. Height stays auto via the wordmark's
+            intrinsic ratio. */}
+        <div className="mb-6 flex w-full max-w-md justify-center">
+          <BrandMark
+            siteName={siteName}
+            brandLogoUrl={brandLogoUrl}
+            width="min(100%, 350px)"
+            priority
+          />
         </div>
         <div className="w-full max-w-md rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-8 shadow-sm">
           {children}

--- a/app/healthz/route.ts
+++ b/app/healthz/route.ts
@@ -19,11 +19,15 @@
  */
 
 import { ensurePollerRunning } from "@/lib/realtime/zone-poller";
+import { logPollingModeOnce } from "@/lib/realtime/polling-mode-startup-log";
 
 export const dynamic = "force-dynamic";
 
 export function GET(): Response {
   ensurePollerRunning();
+  // One-shot hint about the polling mode + topology mismatch (if any).
+  // Fire-and-forget with a hard 3s internal budget — never blocks the probe.
+  void logPollingModeOnce();
   return Response.json(
     { status: "ok", service: "powerdns-authadmin" },
     { status: 200, headers: { "Cache-Control": "no-store" } },

--- a/components/domain/capability-badges.tsx
+++ b/components/domain/capability-badges.tsx
@@ -6,6 +6,8 @@
  *   • primary       → accent (indigo) — write target
  *   • secondary     → warn   (yellow) — read-only mirror
  *   • autosecondary → orange — accepts NOTIFY-from-anyone auto-create
+ *   • standalone    → neutral — no replication flag set (default PDNS Auth
+ *                     config; API still accepts zone creates — fully usable).
  *
  * Renders nothing fancy: a small rounded badge per active flag, joined by a
  * narrow gap. Use anywhere a backend row shows its role (server lists, group
@@ -43,7 +45,7 @@ export function CapabilityBadges({ capabilities }: { capabilities: Capabilities 
   if (capabilities.primary) flags.push("primary");
   if (capabilities.secondary) flags.push("secondary");
   if (capabilities.autosecondary) flags.push("autosecondary");
-  if (flags.length === 0) return <span className={NEUTRAL}>none</span>;
+  if (flags.length === 0) return <span className={NEUTRAL}>standalone</span>;
   // Plain inline <span> wrapper (no flex) so each badge renders exactly like
   // the CLUSTER badge in the zones list — inherited line-height and no
   // cross-axis stretching from a flex container.

--- a/components/domain/polling-disabled-hint.tsx
+++ b/components/domain/polling-disabled-hint.tsx
@@ -1,0 +1,45 @@
+/**
+ * components/domain/polling-disabled-hint.tsx
+ *
+ * Gentle "(i)" inline hint surfaced beside a feature title (currently the
+ * dashboard heading) when `PDNS_BACKGROUND_POLLING=false`. Hovering the icon
+ * reveals a tooltip explaining the current state of the flag and pointing
+ * at the live CONFIGURATION doc so an operator can flip it deliberately.
+ *
+ * Pairs with the `flash=polling-required` toast surfaced by direct ?tab=sync
+ * / ?tab=statistics / ?tab=pdns hits — the redirect handles the loud "you
+ * landed on a feature gated by this flag" path, while this hint is the
+ * always-visible quiet nudge hanging off the dashboard heading.
+ *
+ * Server component (purely presentational + `<a>`), so it can be rendered
+ * from any RSC tree.
+ */
+
+import { Info } from "lucide-react";
+
+const DOC_URL =
+  "https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/blob/main/docs/03-CONFIGURATION.md#pdns_background_polling";
+
+const TOOLTIP =
+  "PDNS_BACKGROUND_POLLING=false (currently). Set it true to enable the dashboard PowerDNS metrics, " +
+  "the per-zone Sync + Statistics tabs, the servers-list lag column, and drift-derived advisories. " +
+  "Single-server / standalone deployments don't need it; multi-replica + clustered fleets benefit from " +
+  "the live sync awareness.";
+
+export function PollingDisabledHint({ className }: { className?: string }) {
+  return (
+    <a
+      href={DOC_URL}
+      target="_blank"
+      rel="noreferrer"
+      title={TOOLTIP}
+      aria-label="Background polling is disabled — click to see how to enable PDNS_BACKGROUND_POLLING"
+      className={
+        "inline-flex h-5 w-5 items-center justify-center rounded-full text-[color:var(--color-fg-muted)] hover:bg-[color:var(--color-bg-muted)] hover:text-[color:var(--color-fg)] " +
+        (className ?? "")
+      }
+    >
+      <Info className="h-3.5 w-3.5" aria-hidden />
+    </a>
+  );
+}

--- a/components/ui/brandmark.tsx
+++ b/components/ui/brandmark.tsx
@@ -17,8 +17,12 @@ import { Wordmark } from "./wordmark";
 interface BrandMarkProps {
   siteName: string;
   brandLogoUrl: string | null;
-  /** Maximum pixel width for the rendered mark. */
-  width: number;
+  /**
+   * Maximum width for the rendered mark. Accepts a number (px) or any CSS
+   * length string — pass `"min(100%, 350px)"` from the auth layout so the
+   * wordmark shrinks to fit narrow viewports instead of overflowing the form.
+   */
+  width: number | string;
   /**
    * Maximum pixel height for the rendered mark. Provided when the parent has
    * a height constraint (e.g. the 56px-tall sidebar header). Without it, a

--- a/components/ui/flash-listener.test.ts
+++ b/components/ui/flash-listener.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { describeFlash } from "./flash-listener";
+
+describe("describeFlash", () => {
+  it("returns null for unknown flash kinds", () => {
+    expect(describeFlash("nope", null)).toBeNull();
+    expect(describeFlash("", null)).toBeNull();
+  });
+
+  it("maps forbidden → error toast, with optional need", () => {
+    expect(describeFlash("forbidden", null)?.kind).toBe("error");
+    expect(describeFlash("forbidden", "zone.read")?.description).toContain("zone.read");
+  });
+
+  it("maps session-required → info", () => {
+    expect(describeFlash("session-required", null)?.kind).toBe("info");
+  });
+
+  // v1.2.0 — the polling-required flash redirect surface.
+  describe("polling-required", () => {
+    it("is a red error toast", () => {
+      expect(describeFlash("polling-required", null)?.kind).toBe("error");
+    });
+
+    it("names the env var verbatim so the operator can grep for it", () => {
+      // The env var name must appear so an operator can copy it straight into
+      // their .env / docker-compose.yml. Don't soften this string.
+      const got = describeFlash("polling-required", null);
+      expect(got?.description).toContain("PDNS_BACKGROUND_POLLING=true");
+    });
+
+    it("interpolates the `need` parameter when given (which feature was hit)", () => {
+      const got = describeFlash("polling-required", "per-zone Sync");
+      expect(got?.description).toContain("per-zone Sync");
+      expect(got?.description).toContain("PDNS_BACKGROUND_POLLING=true");
+    });
+
+    it("still names the env var even without a `need` param", () => {
+      // Bare ?flash=polling-required (no need=...) must still surface the var.
+      expect(describeFlash("polling-required", null)?.description).toContain(
+        "PDNS_BACKGROUND_POLLING=true",
+      );
+    });
+  });
+});

--- a/components/ui/flash-listener.tsx
+++ b/components/ui/flash-listener.tsx
@@ -38,6 +38,13 @@ function describeFlash(flash: string, need: string | null): FlashConfig | null {
         kind: "info",
         description: "Your session expired — please sign in again.",
       };
+    case "polling-required":
+      return {
+        kind: "error",
+        description: need
+          ? `This view (${need}) requires PDNS_BACKGROUND_POLLING=true. Set it in your environment and restart the app to enable.`
+          : "This view requires PDNS_BACKGROUND_POLLING=true. Set it in your environment and restart the app to enable.",
+      };
     default:
       return null;
   }

--- a/components/ui/flash-listener.tsx
+++ b/components/ui/flash-listener.tsx
@@ -19,12 +19,12 @@ import { useEffect, useRef } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useDialog } from "@/components/ui/dialog";
 
-interface FlashConfig {
+export interface FlashConfig {
   kind: "info" | "success" | "error";
   description: string;
 }
 
-function describeFlash(flash: string, need: string | null): FlashConfig | null {
+export function describeFlash(flash: string, need: string | null): FlashConfig | null {
   switch (flash) {
     case "forbidden":
       return {

--- a/docs/03-CONFIGURATION.md
+++ b/docs/03-CONFIGURATION.md
@@ -157,6 +157,49 @@ IP into the connection as a DNS-rebinding defense. Link-local addresses (incl. t
 | `APP_PDNS_ALLOW_PRIVATE_NETWORKS` | `false` in production, `true` otherwise | Allow PDNS URLs that resolve to loopback/RFC1918/CGNAT/ULA. Needed for in-cluster/compose PDNS.     |
 | `APP_PDNS_ALLOW_INSECURE_HTTP`    | requires `https://` in production       | Allow `http://` PDNS base URLs. Both flags must be opted in for an internal `http://host:port` URL. |
 
+### `PDNS_BACKGROUND_POLLING`
+
+Opt-in switch for AuthAdmin's replication-awareness layer. **Defaults to
+`false`** so a fresh install (or any deployment without multi-peer
+topology) makes no background calls to PowerDNS — every PDNS interaction
+is a direct consequence of an operator action.
+
+When `false` (default):
+
+- No background `setInterval`. Every PDNS call is triggered by a page
+  render, a mutation, **Test**, or **Refresh All**.
+- The following supplementary surfaces are **hidden**:
+  - Header SYNCED / DESYNCED chip
+  - Per-zone **Sync** + **Statistics** tabs
+  - Servers-list **Sync** column
+  - Zones-list mirror column
+  - Dashboard **PowerDNS metrics** tab
+  - Drift-derived advisories in the bell
+- The dashboard heading carries a small `(i)` hint explaining the flag;
+  a direct URL to a gated feature redirects to the default view with a
+  red error toast naming this env var.
+- Recommended for: single-server / standalone PowerDNS, homelab,
+  small fleets where every PDNS instance is independent.
+
+When `true`:
+
+- The unified background poller ticks on 30 s zone-state / 60 s daemon
+  refresh / 5 min metric-sample cadences against every configured
+  backend.
+- All replication-awareness surfaces above are visible and live.
+- Required for: primary + secondaries (a primary's zones are AXFR'd to
+  one or more secondaries) and multi-primary clusters (≥2 write-capable
+  peers sharing storage), if you want AuthAdmin to surface drift.
+
+The choice is process-wide; a restart applies the change. There is a
+one-time boot log line at the first `/healthz` hit that summarises the
+effective mode and warns when the configured fleet has replication
+topology while the flag is off.
+
+| Variable                  | Default | Notes                                                                                                   |
+| ------------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `PDNS_BACKGROUND_POLLING` | `false` | Enables the background poller and all sync-aware UI. See the breakdown above for the full feature list. |
+
 The OIDC issuer/discovery URL is operator-supplied and fetched server-side (provider
 test + live discovery), so it runs through the same outbound-URL guard with its own
 pair of flags. Same rule: link-local / cloud-metadata is always blocked.

--- a/docs/04-BACKENDS.md
+++ b/docs/04-BACKENDS.md
@@ -77,6 +77,32 @@ the dashboard's "PDNS backends needing attention" widget.
 - **Test** (per row) does an immediate version probe and updates the status.
 - **Refresh all** re-probes every active backend's version at once.
 
+## Background polling — opt-in for multi-peer topologies
+
+AuthAdmin's replication-awareness layer (SYNCED/DESYNCED chip, per-zone
+Sync and Statistics tabs, servers-list Sync column, dashboard PDNS
+metrics, drift advisories) is powered by a background poller that ticks
+against every configured backend. Whether it runs at all is controlled by
+the `PDNS_BACKGROUND_POLLING` env var, **which defaults to `false`** (see
+[Configuration → `PDNS_BACKGROUND_POLLING`](./03-CONFIGURATION.md#pdns_background_polling)).
+
+The right value depends on the topology you're about to build:
+
+| You're configuring …                                                     | Set `PDNS_BACKGROUND_POLLING` to |
+| ------------------------------------------------------------------------ | -------------------------------- |
+| **Standalone primary** (one PDNS, single instance, no AXFR replication). | `false` (default — leave it)     |
+| Multiple **independent standalones** (no cross-server replication).      | `false`                          |
+| **Primary + secondaries** (one writable backend mirrored over AXFR).     | `true` _(strongly recommended)_  |
+| **Multi-primary cluster** (≥2 writable peers sharing storage).           | `true` _(strongly recommended)_  |
+
+A polling-off install still works for every topology — the standalone /
+single-primary path is its sweet spot, but you can run a primary +
+secondaries on `false` if you prefer to keep AuthAdmin completely
+operator-driven. The trade-off is that AuthAdmin won't show you when a
+secondary has fallen behind on AXFR; you'd notice that through your own
+PowerDNS monitoring (e.g. `pdns_control list-zones` cross-checks) or via
+the **Test** button on `/admin/servers`.
+
 ## Topologies
 
 ### Standalone primary
@@ -88,13 +114,15 @@ A single read/write backend. Add it with `role: primary`, mark one backend
 
 A writable primary plus one or more read-only mirrors that receive zones via
 AXFR/IXFR after a NOTIFY. Add the primary as `role: primary` and each mirror as
-`role: secondary` pointing at it. AuthAdmin routes **all writes to the primary**
-and polls secondaries for sync state + stats.
+`role: secondary` pointing at it. AuthAdmin routes **all writes to the primary**;
+secondary sync state + stats are surfaced when
+`PDNS_BACKGROUND_POLLING=true` (see [above](#background-polling--opt-in-for-multi-peer-topologies)).
 
 For secondaries to auto-bootstrap a zone via PowerDNS supermaster, each zone's NS
 set must include the receiving secondary's registered nameserver — see the
 `zone_templates` notes in [`provisioning.example.yaml`](../provisioning.example.yaml).
-The **Sync** column compares each secondary's serial against the primary's.
+The **Sync** column (visible when `PDNS_BACKGROUND_POLLING=true`) compares
+each secondary's serial against the primary's.
 
 ### Multi-primary cluster
 

--- a/docs/08-HARDENING.md
+++ b/docs/08-HARDENING.md
@@ -66,6 +66,15 @@ exotic — it's the handful of things worth getting right before you expose the 
 
 ## Operations
 
+- **Keep `PDNS_BACKGROUND_POLLING=false` (default) unless you actually run
+  multi-peer topology.** A standalone PowerDNS doesn't benefit from a
+  30 s / 60 s / 5 min ticker against itself; turning the poller on
+  generates background API traffic you don't need, slightly enlarges
+  the in-process cache footprint, and gives an attacker on the AuthAdmin
+  host one more long-lived authenticated path to your DNS API. Enable
+  it deliberately when you need the sync chip, drift advisories, or the
+  dashboard PDNS metrics — see
+  [Configuration → `PDNS_BACKGROUND_POLLING`](./03-CONFIGURATION.md#pdns_background_polling).
 - **Run on Postgres for anything multi-instance.** Boots are serialised by an
   advisory lock so rolling deploys are safe; SQLite is single-writer.
 - **Gate traffic on `/readyz`**, not just `/healthz` — it fails until migrations
@@ -80,7 +89,7 @@ Each published release is cosign-signed (keyless / Sigstore) by the release
 workflow. Verify before deploying:
 
 ```sh
-cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:1.1.6 \
+cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:1.2.0 \
   --certificate-identity-regexp '^https://github.com/PowerDNS-AuthAdmin/' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```

--- a/docs/08-HARDENING.md
+++ b/docs/08-HARDENING.md
@@ -80,7 +80,7 @@ Each published release is cosign-signed (keyless / Sigstore) by the release
 workflow. Verify before deploying:
 
 ```sh
-cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:1.1.5 \
+cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:1.1.6 \
   --certificate-identity-regexp '^https://github.com/PowerDNS-AuthAdmin/' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```

--- a/docs/09-UPGRADING.md
+++ b/docs/09-UPGRADING.md
@@ -37,6 +37,36 @@ half-migrated schema; fix the cause and restart.
 
 ## Version-specific notes
 
+### Upgrading to 1.1.6 (from 1.1.x)
+
+A **model fix** — drop-in upgrade. **No schema migration, no API
+changes, no config changes.** Pull-and-recreate the container.
+
+What changes after the upgrade:
+
+- **Standalone PDNS Auth instances (no `primary=yes` or `secondary=yes`
+  in `pdns.conf`) become usable as zone-create targets.** Until 1.1.6,
+  AuthAdmin was treating "no replication flag set" as "not writable" —
+  hiding the backend from `/zones/new`'s picker even though Test went
+  green. After upgrading, those backends appear on the create-zone
+  page automatically; nothing to reconfigure. (Closes #57.)
+- **The capability badge previously labelled `none` now reads
+  `standalone`** for those backends — same neutral tone, just an
+  accurate label. No semantic change beyond the wording.
+- **The header chip's SYNCED/DESYNCED verdict only renders when there
+  is replication topology to be in-sync about** — i.e. at least one
+  backend has ≥1 mirror (derived primary+secondaries group or a
+  configured multi-primary cluster of ≥2 peers). A fleet of
+  standalones or single-primaries-without-secondaries sees the plain
+  "Live" connectivity label instead. Operators with primary+secondaries
+  or multi-primary clusters see no change.
+
+If you applied the **`primary=yes` workaround** mentioned in the
+discussion / #57 to unblock zone creation on a standalone instance,
+you can now revert it from your `pdns.conf` (it was operationally
+harmless either way — no slaves to NOTIFY — but the badge will read
+`standalone` correctly once it's gone).
+
 ### Upgrading to 1.1.5 (from 1.1.x)
 
 A **security-hygiene patch.** No app-code changes; no schema, API, or

--- a/docs/09-UPGRADING.md
+++ b/docs/09-UPGRADING.md
@@ -37,35 +37,81 @@ half-migrated schema; fix the cause and restart.
 
 ## Version-specific notes
 
-### Upgrading to 1.1.6 (from 1.1.x)
+### Upgrading to 1.2.0 (from 1.1.x)
 
-A **model fix** — drop-in upgrade. **No schema migration, no API
-changes, no config changes.** Pull-and-recreate the container.
+A **minor release** — no schema migration, no API changes, drop-in upgrade.
+There is **one new env var with a behaviour-change default**, and a fix for
+operators running standalone PowerDNS.
 
-What changes after the upgrade:
+> **NOTE: This release introduces `PDNS_BACKGROUND_POLLING` which defaults to `false`.**
+> If you currently rely on the SYNCED/DESYNCED chip, the dashboard
+> "PowerDNS metrics" tab, the per-zone "Sync" or "Statistics" tabs, the
+> servers-list Sync column, the zones-list mirror column, or drift-derived
+> advisories in the bell, **you MUST NOW ENABLE** `PDNS_BACKGROUND_POLLING=true`
+> in your environment and restart the app to keep those surfaces working.
+> With the flag at its default (`false`), all of those features hide;
+> the rest of AuthAdmin (zones, records, DNSSEC, TSIG, autoprimaries,
+> audit, RBAC, OIDC, signup) is unchanged.
+
+What also changes after the upgrade:
 
 - **Standalone PDNS Auth instances (no `primary=yes` or `secondary=yes`
-  in `pdns.conf`) become usable as zone-create targets.** Until 1.1.6,
+  in `pdns.conf`) become usable as zone-create targets.** Until 1.2.0,
   AuthAdmin was treating "no replication flag set" as "not writable" —
-  hiding the backend from `/zones/new`'s picker even though Test went
-  green. After upgrading, those backends appear on the create-zone
+  hiding the backend from `/zones/new`'s picker even though **Test**
+  went green. After upgrading those backends appear on the create-zone
   page automatically; nothing to reconfigure. (Closes #57.)
-- **The capability badge previously labelled `none` now reads
-  `standalone`** for those backends — same neutral tone, just an
-  accurate label. No semantic change beyond the wording.
-- **The header chip's SYNCED/DESYNCED verdict only renders when there
-  is replication topology to be in-sync about** — i.e. at least one
-  backend has ≥1 mirror (derived primary+secondaries group or a
-  configured multi-primary cluster of ≥2 peers). A fleet of
-  standalones or single-primaries-without-secondaries sees the plain
-  "Live" connectivity label instead. Operators with primary+secondaries
-  or multi-primary clusters see no change.
+- **Capability badge `none` → `standalone`** for those backends. Same
+  neutral tone, accurate label.
+- If you applied the **`primary=yes` workaround** mentioned in #57 to
+  unblock zone creation on a standalone, you can now revert it from
+  `pdns.conf`. The override was operationally harmless either way — no
+  slaves to NOTIFY — but the badge will read `standalone` correctly
+  once it's gone.
 
-If you applied the **`primary=yes` workaround** mentioned in the
-discussion / #57 to unblock zone creation on a standalone instance,
-you can now revert it from your `pdns.conf` (it was operationally
-harmless either way — no slaves to NOTIFY — but the badge will read
-`standalone` correctly once it's gone).
+#### Choosing your `PDNS_BACKGROUND_POLLING` value
+
+| Deployment shape                                                          | Set `PDNS_BACKGROUND_POLLING` to     |
+| ------------------------------------------------------------------------- | ------------------------------------ |
+| Single PowerDNS server / standalone / homelab — no AXFR replication.      | `false` (the new default — leave it) |
+| Multiple standalone PowerDNS instances, none acting as primary/secondary. | `false`                              |
+| One primary with one or more secondaries replicating its zones via AXFR.  | `true` _(strongly recommended)_      |
+| Two or more PowerDNS instances forming a multi-primary cluster.           | `true` _(strongly recommended)_      |
+
+**With `PDNS_BACKGROUND_POLLING=false` (default):**
+
+- AuthAdmin contacts PDNS only in direct response to operator actions:
+  page renders, **Test**, **Refresh All**, zone create/edit/delete,
+  DNSSEC/TSIG/autoprimaries actions. No background traffic.
+- The supplementary "replication-awareness" surfaces are hidden — see
+  the list under "MUST NOW ENABLE" above.
+- The dashboard renders the Admin view only; a small `(i)` icon by the
+  page heading explains how to enable polling.
+- Operator clicks on a direct URL to a gated feature get a red error
+  toast naming the env var.
+
+**With `PDNS_BACKGROUND_POLLING=true`:**
+
+- The unified background poller runs on its 30 s / 60 s / 5 min
+  cadences against every configured backend.
+- All replication-awareness features are visible and live:
+  - SYNCED / DESYNCED chip in the top header (per-page where
+    relevant; fleet-wide on most pages).
+  - **Sync** + **Statistics** tabs on every zone-detail page.
+  - **Sync** column on `/admin/servers`.
+  - Mirror column on `/zones`.
+  - **PowerDNS metrics** tab on the dashboard, including the live
+    time-series charts (query rate, latency, cache hit, response
+    composition by qtype/rcode/size).
+  - Drift-derived advisories surfaced in the bell.
+- A boot-time log line confirms the mode and (when off) whether the
+  configured fleet looks like it would benefit from being on.
+
+At the moment of the upgrade decision: most single-PowerDNS / small
+deployments will get a quieter, friendlier experience by leaving the
+flag at its default. Multi-replica and clustered operators will want
+to set it `true` immediately and restart so AuthAdmin's full
+operational surface is back.
 
 ### Upgrading to 1.1.5 (from 1.1.x)
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -579,10 +579,12 @@ this baseline.
     <img src="../screenshots/light/dashboard-mobile.png" alt="Dashboard on mobile" width="240" />
   </picture>
   &nbsp;
-  <picture>
+  <p align="center">
+    <picture>
     <source media="(prefers-color-scheme: dark)" srcset="../screenshots/dark/zones-list-mobile.png" />
     <img src="../screenshots/light/zones-list-mobile.png" alt="Zones list on mobile" width="240" />
-  </picture>
+    </picture>
+  </p>
 </p>
 
 ### 19.2 One DataTable, every list

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -249,6 +249,32 @@ const envSchema = z.object({
     .pipe(z.boolean())
     .optional(),
 
+  // Background polling of PDNS backends — opt-in supplementary features.
+  //
+  // When TRUE, the unified background poller ticks on a 30 s zone-state /
+  // 60 s daemon refresh / 5 min metric-sample schedule and powers:
+  //   • Header SYNCED / DESYNCED chip
+  //   • Zone-detail "Sync" + "Statistics" tabs
+  //   • Zone-list mirror-state column
+  //   • Servers-list lag column
+  //   • Dashboard "PDNS metrics" tab (time-series graphs)
+  //   • Background drift-derived advisories in the bell
+  //
+  // When FALSE (default), AuthAdmin only talks to PDNS in response to user
+  // actions — every page render warms what it needs on demand, every Test /
+  // Refresh All is a one-shot, mutations publish their own SSE refresh.
+  // The supplementary surfaces above hide; the rest of the app (zone CRUD,
+  // DNSSEC, TSIG, autoprimaries, audit, RBAC, OIDC, …) is unchanged.
+  // Recommended for single-server / standalone PDNS deployments where
+  // there is no replication topology for the poller to be aware of.
+  // REQUIRED for primary+secondaries and multi-primary cluster operators who
+  // want AuthAdmin to surface replication drift.
+  PDNS_BACKGROUND_POLLING: z
+    .string()
+    .transform((s) => s.toLowerCase() === "true")
+    .pipe(z.boolean())
+    .optional(),
+
   // --- OIDC issuer connectivity (SSRF guard, mirrors the PDNS pair) ---
   // The OIDC issuer/discovery URL is operator-supplied and fetched server-side
   // (probe + live discovery), so it runs through the same outbound-URL guard.
@@ -393,6 +419,7 @@ const ENV_KEYS = [
   "TURNSTILE_SECRET_KEY",
   "APP_PDNS_ALLOW_PRIVATE_NETWORKS",
   "APP_PDNS_ALLOW_INSECURE_HTTP",
+  "PDNS_BACKGROUND_POLLING",
   "APP_OIDC_ALLOW_PRIVATE_NETWORKS",
   "APP_OIDC_ALLOW_INSECURE_HTTP",
   "SMTP_HOST",
@@ -599,3 +626,13 @@ export const isTest: boolean = env.NODE_ENV === "test";
 
 /** Hostname for cookie scoping. */
 export const cookieDomain: string | undefined = env.COOKIE_DOMAIN ?? new URL(env.APP_URL).hostname;
+
+/**
+ * Whether the background PDNS poller is enabled. When false (the default),
+ * AuthAdmin makes no scheduled PDNS calls and the supplementary sync-aware
+ * UI surfaces (header SYNCED/DESYNCED chip, zone Sync + Statistics tabs,
+ * zone-list mirror column, servers-list lag column, dashboard PDNS
+ * statistics tab, drift advisories) are hidden. See `PDNS_BACKGROUND_POLLING`
+ * docstring above for full feature matrix.
+ */
+export const pdnsBackgroundPollingEnabled: boolean = env.PDNS_BACKGROUND_POLLING === true;

--- a/lib/pdns/capabilities.test.ts
+++ b/lib/pdns/capabilities.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { deriveCapabilities, summarizeCapabilities } from "./capabilities";
+import {
+  deriveCapabilities,
+  isReadOnlyMirror,
+  isWriteCapable,
+  summarizeCapabilities,
+} from "./capabilities";
 import type { PdnsConfigSetting } from "./types";
 
 const cfg = (entries: Record<string, string>): PdnsConfigSetting[] =>
@@ -63,7 +68,36 @@ describe("summarizeCapabilities", () => {
     expect(
       summarizeCapabilities(deriveCapabilities(cfg({ primary: "yes", secondary: "yes" }))),
     ).toBe("primary + secondary");
-    // No replication flag set → falls back to the only capability that's on.
-    expect(summarizeCapabilities(deriveCapabilities(cfg({ launch: "gsqlite3" })))).toBe("api");
+    // No replication flag set → standalone (#57): API hosts zones, no AXFR.
+    expect(summarizeCapabilities(deriveCapabilities(cfg({ launch: "gsqlite3" })))).toBe(
+      "standalone",
+    );
+    // API reported off → unreachable (we couldn't actually have read /config in
+    // that case, but the predicate has to be total).
+    expect(summarizeCapabilities(deriveCapabilities(cfg({ api: "no" })))).toBe("unreachable");
+  });
+});
+
+// #57 — A standalone PDNS Auth (no `primary` / `secondary` in pdns.conf) is the
+// default config and accepts zone creates over the HTTP API. The old
+// `isWriteCapable` checked `caps.primary` directly and so excluded standalones
+// from /zones/new's backend picker. Pin the four-way matrix here so it stays
+// fixed.
+describe("isWriteCapable / isReadOnlyMirror", () => {
+  it.each<[string, Record<string, string>, boolean, boolean]>([
+    ["standalone (no flags)", {}, true, false],
+    ["primary only", { primary: "yes" }, true, false],
+    ["secondary only", { secondary: "yes" }, false, true],
+    ["dual-role primary+secondary", { primary: "yes", secondary: "yes" }, true, false],
+  ])("%s → write=%s, mirror=%s", (_label, flags, writeExpected, mirrorExpected) => {
+    const caps = deriveCapabilities(cfg(flags));
+    expect(isWriteCapable(caps)).toBe(writeExpected);
+    expect(isReadOnlyMirror(caps)).toBe(mirrorExpected);
+  });
+
+  it("treats unprobed (null) as write-capable so newly-added backends are usable", () => {
+    expect(isWriteCapable(null)).toBe(true);
+    expect(isWriteCapable(undefined)).toBe(true);
+    expect(isReadOnlyMirror(null)).toBe(false);
   });
 });

--- a/lib/pdns/capabilities.ts
+++ b/lib/pdns/capabilities.ts
@@ -58,12 +58,21 @@ export function deriveCapabilities(
  * Whether a backend is a write target — the ADR-0014 classification that
  * replaces the old `role`. An unprobed backend (no capability snapshot yet) is
  * treated as writable so a freshly-added one is usable until its first probe;
- * once observed, the daemon's `primary` flag is the truth. A daemon that is
- * both primary AND secondary counts as a write target (its mirror zones stay
- * read-only per zone kind).
+ * once observed, anything that isn't a pure read-only AXFR mirror is a write
+ * target. That covers the three usable shapes a PDNS Auth daemon can take:
+ *
+ *   - **standalone** (`primary=no, secondary=no`) — the *default* PDNS Auth
+ *     config; no DNS-protocol replication, but the API still accepts zone
+ *     creates. This is the case the previous `caps.primary` check incorrectly
+ *     excluded (#57).
+ *   - **primary** (`primary=yes`) — write target plus AXFR primary.
+ *   - **dual-role** (`primary=yes, secondary=yes`) — primary for some zones,
+ *     secondary for others; the per-zone `kind` decides which.
+ *
+ * Only a pure mirror (`secondary=yes && !primary`) returns false here.
  */
 export function isWriteCapable(caps: PdnsDaemonCapabilities | null | undefined): boolean {
-  return caps ? caps.primary : true;
+  return caps ? !isReadOnlyMirror(caps) : true;
 }
 
 /**
@@ -114,8 +123,9 @@ export function classifyGroup(
  * are `yes`, verbatim ("primary", "secondary", "autosecondary"), joined with
  * " + ". NOT paraphrased: the badge shows exactly the capability the API reports,
  * so it never invents a label like "Secondary (auto)". With no replication flag
- * set it falls back to the only flag that's on (`api`); "unknown" when the daemon
- * has never been observed.
+ * set it falls back to "standalone" (the daemon hosts zones over the API but does
+ * no DNS-protocol replication — the default PDNS Auth shape); "unknown" when the
+ * daemon has never been observed, "unreachable" when the API itself is down.
  */
 export function summarizeCapabilities(caps: PdnsDaemonCapabilities | null): string {
   if (!caps) return "unknown";
@@ -123,6 +133,6 @@ export function summarizeCapabilities(caps: PdnsDaemonCapabilities | null): stri
   if (caps.primary) flags.push("primary");
   if (caps.secondary) flags.push("secondary");
   if (caps.autosecondary) flags.push("autosecondary");
-  if (flags.length === 0) flags.push(caps.api ? "api" : "unknown");
+  if (flags.length === 0) flags.push(caps.api ? "standalone" : "unreachable");
   return flags.join(" + ");
 }

--- a/lib/pdns/sync.ts
+++ b/lib/pdns/sync.ts
@@ -150,6 +150,26 @@ export async function checkZoneSync(
  * Pages that need sub-second reactivity push their own state via
  * `HeaderStatusMode` and a `useRealtimeEvent` listener.
  */
+/**
+ * True iff the fleet contains at least one cluster of ≥2 peers sharing zones —
+ * a derived primary+secondaries group OR a configured multi-primary cluster.
+ * Standalone servers and single primaries with zero secondaries do NOT
+ * qualify; there's nothing to be "in sync" against.
+ *
+ * The app shell uses this to decide whether the header chip surfaces a
+ * SYNCED/DESYNCED verdict at all — a fleet of standalones or single primaries
+ * sees only the plain "Live" connectivity label, which is the truthful read
+ * for that topology (issue #57 widened "no replication" to the common case).
+ */
+export async function hasReplicationTopology(): Promise<boolean> {
+  const primaries = (await listAllActiveBackends()).filter((b) => isWriteCapable(b.capabilities));
+  for (const primary of primaries) {
+    const mirrors = await discoverMirrors(primary);
+    if (mirrors.length > 0) return true;
+  }
+  return false;
+}
+
 export async function globalAnyLagging(): Promise<boolean> {
   const primaries = (await listAllActiveBackends()).filter((b) => isWriteCapable(b.capabilities));
   if (primaries.length === 0) return false;

--- a/lib/realtime/header-chip-mode.test.ts
+++ b/lib/realtime/header-chip-mode.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { decideHeaderChipMode } from "./header-chip-mode";
+
+const baseInput = {
+  pollingEnabled: true,
+  realtimeAvailable: true,
+  canReadBackends: true,
+  hasReplicationTopology: true,
+  anyLagging: false,
+};
+
+describe("decideHeaderChipMode", () => {
+  it("returns sync(inSync=true) when every gate is satisfied and nothing is lagging", () => {
+    expect(decideHeaderChipMode(baseInput)).toEqual({ kind: "sync", inSync: true });
+  });
+
+  it("returns sync(inSync=false) when something is lagging", () => {
+    expect(decideHeaderChipMode({ ...baseInput, anyLagging: true })).toEqual({
+      kind: "sync",
+      inSync: false,
+    });
+  });
+
+  it.each([
+    ["pollingEnabled=false (default for v1.2.0)", { pollingEnabled: false }],
+    ["realtime SSE unavailable", { realtimeAvailable: false }],
+    ["actor can't read backends (profile-only user)", { canReadBackends: false }],
+    ["fleet has no replication topology", { hasReplicationTopology: false }],
+  ])("falls back to live mode when %s", (_label, override) => {
+    expect(decideHeaderChipMode({ ...baseInput, ...override })).toEqual({ kind: "live" });
+  });
+
+  it("falls back to live even when topology exists, if polling is off", () => {
+    // The most common 1.2.0 case: an upgraded primary+secondaries fleet whose
+    // operator hasn't yet flipped PDNS_BACKGROUND_POLLING=true. The chip MUST
+    // stay quiet — we'd otherwise render stale or empty sync state.
+    expect(
+      decideHeaderChipMode({
+        ...baseInput,
+        pollingEnabled: false,
+        hasReplicationTopology: true,
+        anyLagging: true,
+      }),
+    ).toEqual({ kind: "live" });
+  });
+});

--- a/lib/realtime/header-chip-mode.ts
+++ b/lib/realtime/header-chip-mode.ts
@@ -1,0 +1,48 @@
+/**
+ * lib/realtime/header-chip-mode.ts
+ *
+ * Pure decision for the header status chip's default mode. Extracted from
+ * `app/(app)/layout.tsx` so the rule is unit-testable: every combination of
+ * (polling-flag, realtime-available, can-read-backends, has-topology, lagging)
+ * maps to exactly one ChipMode.
+ *
+ * The chip itself ALWAYS renders — what changes here is the *label* it shows:
+ *
+ *   - "live"  — connectivity pulse only ("Live"). Used when sync awareness is
+ *               either unavailable (no realtime / no perms) or unimportant
+ *               (no replication topology, or polling disabled so there is no
+ *               live sync data to surface).
+ *   - "sync"  — SYNCED / DESYNCED label, driven by `lagging`.
+ *
+ * The four gates from top to bottom (any one false → "live"):
+ *   1. `PDNS_BACKGROUND_POLLING=true` — without the poller there is no live
+ *      mirror state to display (v1.2.0 opt-in, #57).
+ *   2. Realtime SSE bus is available — without it the chip can't even pulse
+ *      from poller events.
+ *   3. Actor can read backends (zone OR server perms) — a profile-only user
+ *      shouldn't see a signal they have no context for.
+ *   4. Fleet contains ≥1 cluster of 2+ peers — single-primary / standalone
+ *      fleets have nothing to be in-sync against.
+ */
+
+export type ChipMode = { kind: "live" } | { kind: "sync"; inSync: boolean };
+
+export interface ChipModeInput {
+  pollingEnabled: boolean;
+  realtimeAvailable: boolean;
+  canReadBackends: boolean;
+  hasReplicationTopology: boolean;
+  anyLagging: boolean;
+}
+
+export function decideHeaderChipMode(input: ChipModeInput): ChipMode {
+  if (
+    !input.pollingEnabled ||
+    !input.realtimeAvailable ||
+    !input.canReadBackends ||
+    !input.hasReplicationTopology
+  ) {
+    return { kind: "live" };
+  }
+  return { kind: "sync", inSync: !input.anyLagging };
+}

--- a/lib/realtime/polling-mode-startup-log.test.ts
+++ b/lib/realtime/polling-mode-startup-log.test.ts
@@ -1,0 +1,154 @@
+/**
+ * lib/realtime/polling-mode-startup-log.test.ts
+ *
+ * Three branches of the boot-time hint + the 3 s probe budget + the
+ * one-shot guard. Mocks: env (the flag), db (the topology probe), logger
+ * (so we can assert on the line that landed). Each `it()` does
+ * `vi.resetModules()` + re-mocks so the module-level `hasRun` latch
+ * starts fresh per test.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const loggerMocks = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+vi.mock("@/lib/logger", () => ({ logger: loggerMocks }));
+
+// Default DB shape — every test overrides if it needs different topology.
+const dbMocks = {
+  select: vi.fn(),
+};
+vi.mock("@/lib/db", () => ({ db: dbMocks }));
+
+vi.mock("@/lib/db/schema", () => ({
+  pdnsServers: {},
+  pdnsClusters: {},
+}));
+
+vi.mock("@/lib/pdns/capabilities", () => ({
+  isReadOnlyMirror: (caps: { primary?: boolean; secondary?: boolean } | null) =>
+    !!caps && caps.secondary === true && caps.primary !== true,
+  isWriteCapable: (caps: { primary?: boolean; secondary?: boolean } | null) =>
+    !caps || !(caps.secondary === true && caps.primary !== true),
+}));
+
+interface ServerRow {
+  disabledAt: Date | null;
+  capabilities: { primary?: boolean; secondary?: boolean } | null;
+}
+
+function stubDb(servers: ServerRow[], clusters: Array<{ id: string }>): void {
+  // First select() → servers; second → clusters. Match the call order in
+  // polling-mode-startup-log.ts.
+  let call = 0;
+  dbMocks.select.mockImplementation(() => {
+    const which = call++;
+    return {
+      from: () => Promise.resolve(which === 0 ? servers : clusters),
+    };
+  });
+}
+
+async function loadModule(pollingEnabled: boolean) {
+  vi.resetModules();
+  loggerMocks.info.mockClear();
+  loggerMocks.warn.mockClear();
+  loggerMocks.error.mockClear();
+  dbMocks.select.mockReset();
+  vi.doMock("@/lib/env", () => ({
+    pdnsBackgroundPollingEnabled: pollingEnabled,
+    env: {},
+  }));
+  return await import("./polling-mode-startup-log");
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("logPollingModeOnce", () => {
+  it("info-logs that polling is ON and features are enabled when the flag is true", async () => {
+    const mod = await loadModule(true);
+    await mod.logPollingModeOnce();
+    expect(loggerMocks.info).toHaveBeenCalledTimes(1);
+    const msg = String(loggerMocks.info.mock.calls[0]![0]);
+    expect(msg).toContain("PDNS_BACKGROUND_POLLING=true");
+    expect(msg).toContain("ENABLED");
+    expect(loggerMocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("info-logs single-server / standalone mode when flag is false and no replication topology exists", async () => {
+    const mod = await loadModule(false);
+    stubDb([{ disabledAt: null, capabilities: { primary: false, secondary: false } }], []);
+    await mod.logPollingModeOnce();
+    expect(loggerMocks.info).toHaveBeenCalledTimes(1);
+    expect(loggerMocks.warn).not.toHaveBeenCalled();
+    const msg = String(loggerMocks.info.mock.calls[0]![0]);
+    expect(msg).toContain("PDNS_BACKGROUND_POLLING=false");
+    expect(msg.toLowerCase()).toContain("standalone");
+  });
+
+  it("warns when flag is false but the configured fleet HAS replication topology (mirrors)", async () => {
+    const mod = await loadModule(false);
+    stubDb(
+      [
+        { disabledAt: null, capabilities: { primary: true, secondary: false } },
+        { disabledAt: null, capabilities: { primary: false, secondary: true } }, // a mirror
+      ],
+      [],
+    );
+    await mod.logPollingModeOnce();
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(1);
+    expect(loggerMocks.info).not.toHaveBeenCalled();
+    const call = loggerMocks.warn.mock.calls[0] as [unknown, unknown];
+    const meta = call[0] as { mirrors: number };
+    const msg = call[1];
+    expect(String(msg)).toContain("PDNS_BACKGROUND_POLLING=false");
+    expect(String(msg)).toContain("PDNS_BACKGROUND_POLLING=true");
+    expect(meta).toMatchObject({ mirrors: 1 });
+  });
+
+  it("warns when flag is false but a configured cluster is present (no mirrors yet)", async () => {
+    const mod = await loadModule(false);
+    stubDb(
+      [{ disabledAt: null, capabilities: { primary: true, secondary: false } }],
+      [{ id: "cluster-1" }],
+    );
+    await mod.logPollingModeOnce();
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(1);
+    const meta = loggerMocks.warn.mock.calls[0]![0] as { clusters: number };
+    expect(meta.clusters).toBe(1);
+  });
+
+  it("silently gives up if the topology probe takes longer than the 3s budget", async () => {
+    vi.useFakeTimers();
+    const mod = await loadModule(false);
+    // db.select returns a from() whose Promise NEVER resolves — simulates a
+    // hung Postgres. We expect logPollingModeOnce to resolve cleanly without
+    // logging anything (info or warn) once the 3 s timer fires.
+    dbMocks.select.mockReturnValue({
+      from: () => new Promise(() => undefined),
+    });
+    const p = mod.logPollingModeOnce();
+    await vi.advanceTimersByTimeAsync(3_500);
+    await p;
+    expect(loggerMocks.info).not.toHaveBeenCalled();
+    expect(loggerMocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("is one-shot: a second call is a no-op even if topology changed in between", async () => {
+    const mod = await loadModule(false);
+    stubDb([{ disabledAt: null, capabilities: { primary: false, secondary: false } }], []);
+    await mod.logPollingModeOnce();
+    expect(loggerMocks.info).toHaveBeenCalledTimes(1);
+
+    // Same module instance — second call must not log again.
+    await mod.logPollingModeOnce();
+    expect(loggerMocks.info).toHaveBeenCalledTimes(1);
+    expect(loggerMocks.warn).not.toHaveBeenCalled();
+  });
+});

--- a/lib/realtime/polling-mode-startup-log.ts
+++ b/lib/realtime/polling-mode-startup-log.ts
@@ -1,0 +1,91 @@
+/**
+ * lib/realtime/polling-mode-startup-log.ts
+ *
+ * Boot-time one-shot: when `PDNS_BACKGROUND_POLLING=false` (default) AND the
+ * configured backend fleet looks like it would benefit from polling (≥1
+ * configured cluster, OR ≥1 backend already observed as a secondary mirror),
+ * print a clearly-formatted hint pointing operators at the env flag. Runs at
+ * most once per process; subsequent calls are fast no-ops.
+ *
+ * Hard 3s budget so a slow Postgres can't block startup. Failures (timeout,
+ * query error) are swallowed silently — the worst case is "we didn't print
+ * the hint", which is strictly better than blocking the app.
+ *
+ * Triggered from the first `/healthz` hit (the same kick `instrumentation.ts`
+ * uses to warm the rest of the app).
+ */
+
+import "server-only";
+import { db } from "@/lib/db";
+import { pdnsClusters, pdnsServers } from "@/lib/db/schema";
+import { isReadOnlyMirror, isWriteCapable } from "@/lib/pdns/capabilities";
+import { pdnsBackgroundPollingEnabled } from "@/lib/env";
+import { logger } from "@/lib/logger";
+
+let hasRun = false;
+const BUDGET_MS = 3_000;
+
+export async function logPollingModeOnce(): Promise<void> {
+  if (hasRun) return;
+  hasRun = true;
+
+  // Honest case 1 — flag is on. Confirm it so operators see we picked it up.
+  if (pdnsBackgroundPollingEnabled) {
+    logger.info(
+      "[startup] PDNS_BACKGROUND_POLLING=true — background poller scheduled; sync awareness, " +
+        "dashboard PDNS metrics, per-zone Sync + Statistics, drift advisories are ALL ENABLED.",
+    );
+    return;
+  }
+
+  // Flag is off. Probe the configured topology (DB only, no PDNS calls) to
+  // detect a multi-peer setup that would meaningfully benefit from polling,
+  // then surface a single sharp log line. 3s budget protects boot.
+  const probe = (async () => {
+    const [servers, clusters] = await Promise.all([
+      db.select().from(pdnsServers),
+      db.select().from(pdnsClusters),
+    ]);
+    const activeServers = servers.filter((s) => s.disabledAt === null);
+    const mirrors = activeServers.filter((s) => isReadOnlyMirror(s.capabilities)).length;
+    const writers = activeServers.filter((s) => isWriteCapable(s.capabilities)).length;
+    const clusterCount = clusters.length;
+    return { activeServers: activeServers.length, mirrors, writers, clusterCount };
+  })();
+
+  const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), BUDGET_MS));
+
+  try {
+    const result = await Promise.race([probe, timeout]);
+    if (result === null) {
+      // Budget burned — silently give up. Better to start unhinted than hold the app.
+      return;
+    }
+    const multiPeer = result.mirrors > 0 || result.clusterCount > 0 || result.writers > 1;
+    if (multiPeer) {
+      logger.warn(
+        {
+          servers: result.activeServers,
+          mirrors: result.mirrors,
+          writers: result.writers,
+          clusters: result.clusterCount,
+        },
+        "[startup] PDNS_BACKGROUND_POLLING=false but the configured fleet has replication " +
+          "topology (mirrors / multiple primaries / clusters). Sync awareness, drift advisories, " +
+          "the per-zone Sync + Statistics tabs, and the dashboard PDNS metrics are HIDDEN. " +
+          "Set PDNS_BACKGROUND_POLLING=true and restart to enable them.",
+      );
+    } else {
+      logger.info(
+        "[startup] PDNS_BACKGROUND_POLLING=false — single-server / standalone mode. PDNS " +
+          "is contacted only in response to user actions; supplementary sync features hidden. " +
+          "This is the recommended default for single-instance deployments.",
+      );
+    }
+  } catch {
+    // Probe failed (e.g. DB still warming) — silently skip; healthz will run
+    // again on the next probe but `hasRun` is already true and won't re-fire.
+    // That's by design: a one-shot startup log mustn't spam on every health
+    // tick if the DB stays unhappy.
+  }
+}

--- a/lib/realtime/zone-poller-flag.test.ts
+++ b/lib/realtime/zone-poller-flag.test.ts
@@ -1,0 +1,63 @@
+/**
+ * lib/realtime/zone-poller-flag.test.ts
+ *
+ * Pins the `PDNS_BACKGROUND_POLLING=false` (default) behaviour: the unified
+ * background poller MUST NOT schedule a setInterval, and the post-mutation
+ * `scheduleImmediatePoll` + in-flight `scheduleFollowupPoll` MUST be no-ops.
+ *
+ * Only `ensureBackendsObserved` should still execute its `pollOnce(full:true)`
+ * work on demand (validated implicitly by the integration suite which boots
+ * the stack with the flag ON; the off-mode equivalent boots without it and
+ * is covered by `tests/integration/polling-off.test.ts`).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  pdnsBackgroundPollingEnabled: false,
+  env: {},
+  isProduction: false,
+  isDevelopment: false,
+  isTest: true,
+}));
+
+// Stub everything `zone-poller` reaches into so we don't need a live DB or
+// PDNS — we only want to observe the scheduling behaviour.
+vi.mock("@/lib/db/repositories/pdns-servers", () => ({
+  listAllActiveBackends: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("@/lib/db", () => ({ db: {} }));
+vi.mock("./event-bus", () => ({
+  publishHealthEvent: vi.fn(),
+  publishZoneEvent: vi.fn(),
+}));
+vi.mock("@/lib/logger", () => ({ logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/audit/request-context", () => ({
+  withRequestId: (_id: string, fn: () => unknown) => fn(),
+  newSystemRequestId: () => "test-req-id",
+}));
+
+describe("zone-poller respects PDNS_BACKGROUND_POLLING=false", () => {
+  it("ensurePollerRunning schedules no setInterval when the flag is off", async () => {
+    const { ensurePollerRunning } = await import("./zone-poller");
+    const setInterval = vi.spyOn(global, "setInterval");
+    try {
+      ensurePollerRunning();
+      expect(setInterval).not.toHaveBeenCalled();
+    } finally {
+      setInterval.mockRestore();
+    }
+  });
+
+  it("scheduleImmediatePoll arms no setTimeout when the flag is off", async () => {
+    const { scheduleImmediatePoll } = await import("./zone-poller");
+    const setTimeout = vi.spyOn(global, "setTimeout");
+    try {
+      scheduleImmediatePoll();
+      scheduleImmediatePoll();
+      expect(setTimeout).not.toHaveBeenCalled();
+    } finally {
+      setTimeout.mockRestore();
+    }
+  });
+});

--- a/lib/realtime/zone-poller.ts
+++ b/lib/realtime/zone-poller.ts
@@ -63,6 +63,7 @@ import {
   type CachedZoneSnapshot,
 } from "@/lib/pdns/zone-state-cache";
 import { publishHealthEvent, publishZoneEvent } from "./event-bus";
+import { pdnsBackgroundPollingEnabled } from "@/lib/env";
 
 const POLL_INTERVAL_MS = 30_000;
 // When a poll cycle observes any primary↔secondary serial mismatch
@@ -147,6 +148,11 @@ export function registerPollerSubscriber(): () => void {
 
 export function ensurePollerRunning(): void {
   state.lastSubscriberAt = Date.now();
+  // PDNS_BACKGROUND_POLLING=false (default) — no setInterval. Every PDNS
+  // interaction is operator-initiated; supplementary sync-aware features are
+  // surfaced as hidden in the UI. `ensureBackendsObserved` (the per-request
+  // warm-up) still calls `pollOnce` directly, so pages keep working.
+  if (!pdnsBackgroundPollingEnabled) return;
   if (state.timer) return;
   // The timer never self-stops: with zero subscribers it keeps ticking but each
   // cycle is STATS-ONLY (the only background work that should run when nobody's
@@ -182,6 +188,12 @@ export function ensurePollerRunning(): void {
  */
 let immediatePollPending = false;
 export function scheduleImmediatePoll(): void {
+  // PDNS_BACKGROUND_POLLING=false → no eager background refresh after a
+  // mutation. The mutation route still calls `invalidateBackendObservation`
+  // and publishes its own SSE event, so the next page render refetches via
+  // `ensureBackendsObserved` and the UI shows the new state on the next
+  // navigation. No background cycle is the point of the flag.
+  if (!pdnsBackgroundPollingEnabled) return;
   state.consecutiveFollowups = 0;
   if (immediatePollPending) return;
   immediatePollPending = true;
@@ -926,6 +938,11 @@ function computeNotSynced(
 
 let followupPollPending = false;
 function scheduleFollowupPoll(): void {
+  // PDNS_BACKGROUND_POLLING=false → no follow-up cycle to observe AXFR catch-up.
+  // There is no replication topology we surface in this mode, so the in-flight
+  // tracking is moot. The next operator-initiated page render warms what it
+  // needs via `ensureBackendsObserved`.
+  if (!pdnsBackgroundPollingEnabled) return;
   if (followupPollPending) return;
   followupPollPending = true;
   setTimeout(() => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "private": true,
   "description": "Modern, self-hosted DNS administration UI for PowerDNS — multi-team RBAC, real audit, real SSO. From-scratch rebuild of PowerDNS-Admin in Node.js + TypeScript.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "private": true,
   "description": "Modern, self-hosted DNS administration UI for PowerDNS — multi-team RBAC, real audit, real SSO. From-scratch rebuild of PowerDNS-Admin in Node.js + TypeScript.",
   "license": "MIT",

--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -30,10 +30,12 @@ every primary and secondary.
   <img src="./light/dashboard.png" alt="Dashboard" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/dashboard-mobile.png" />
   <img src="./light/dashboard-mobile.png" alt="Dashboard on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Dashboard feature notes](../docs/FEATURES.md#11-dashboard)
 
@@ -52,10 +54,12 @@ automatically.
   <img src="./light/backend-health.png" alt="Backend health popover" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/backend-health-mobile.png" />
   <img src="./light/backend-health-mobile.png" alt="Backend health popover on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Backend health advisories](../docs/FEATURES.md#37-backend-health-advisories)
 · [ADR-0015](../docs/adr/0015-backend-health-advisories.md)
@@ -74,10 +78,12 @@ view. Live-updates over SSE; sort/filter/paginate client-side.
   <img src="./light/zones-list.png" alt="Zones list" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/zones-list-mobile.png" />
   <img src="./light/zones-list-mobile.png" alt="Zones list on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Amalgamated zones list](../docs/FEATURES.md#41-amalgamated-zones-list)
 · [Sync probes](../docs/FEATURES.md#33-sync-probes)
@@ -97,10 +103,12 @@ value / comment in a per-row editor.
   <img src="./light/zone-detail.png" alt="Zone detail" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/zone-detail-mobile.png" />
   <img src="./light/zone-detail-mobile.png" alt="Zone detail on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Per-RRset editor](../docs/FEATURES.md#42-per-rrset-editor-with-diff-before-apply)
 · [Per-RRset optimistic concurrency (ADR-0010)](../docs/adr/0010-per-rrset-optimistic-concurrency.md)
@@ -120,10 +128,12 @@ checkbox so risky edits are intentional, not accidental.
   <img src="./light/zone-edit.png" alt="Edit record dialog" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/zone-edit-mobile.png" />
   <img src="./light/zone-edit-mobile.png" alt="Edit record dialog on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Diff-before-apply editor](../docs/FEATURES.md#42-per-rrset-editor-with-diff-before-apply)
 
@@ -141,10 +151,12 @@ lands in [Audit log](#audit-log)).
   <img src="./light/zone-edit-diff.png" alt="Review changes diff" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/zone-edit-diff-mobile.png" />
   <img src="./light/zone-edit-diff-mobile.png" alt="Review changes diff on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Per-RRset optimistic concurrency (ADR-0010)](../docs/adr/0010-per-rrset-optimistic-concurrency.md)
 
@@ -162,10 +174,12 @@ date range; click any row to reveal the full diff in place.
   <img src="./light/zone-change-history.png" alt="Zone change history" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/zone-change-history-mobile.png" />
   <img src="./light/zone-change-history-mobile.png" alt="Zone change history on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Zone change history](../docs/FEATURES.md#45-zone-change-history)
 
@@ -184,10 +198,12 @@ explicit group membership **or** poller-derived topology.
   <img src="./light/powerdns-servers.png" alt="PowerDNS servers" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/powerdns-servers-mobile.png" />
   <img src="./light/powerdns-servers-mobile.png" alt="PowerDNS servers on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Multi-backend management](../docs/FEATURES.md#31-multi-backend-management)
 · [Backend capability model (ADR-0014)](../docs/adr/0014-backend-capability-model.md)
@@ -207,10 +223,12 @@ MFA enrolment, password reset, and active sessions.
   <img src="./light/users.png" alt="Users" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/users-mobile.png" />
   <img src="./light/users-mobile.png" alt="Users on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Authentication](../docs/FEATURES.md#1-authentication)
 · [Sessions](../docs/FEATURES.md#16-sessions)
@@ -228,10 +246,12 @@ the team's resources.
   <img src="./light/teams.png" alt="Teams" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/teams-mobile.png" />
   <img src="./light/teams-mobile.png" alt="Teams on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Scoped assignments](../docs/FEATURES.md#23-scoped-assignments)
 
@@ -250,10 +270,12 @@ templates).
   <img src="./light/roles.png" alt="Roles" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/roles-mobile.png" />
   <img src="./light/roles-mobile.png" alt="Roles on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Permissions vocabulary](../docs/FEATURES.md#21-permissions-vocabulary)
 · [System + custom roles](../docs/FEATURES.md#22-system--custom-roles)
@@ -274,10 +296,12 @@ admin changes, session revocations).
   <img src="./light/audit-log.png" alt="Audit log" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/audit-log-mobile.png" />
   <img src="./light/audit-log-mobile.png" alt="Audit log on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Audit log](../docs/FEATURES.md#9-audit-log)
 
@@ -295,10 +319,12 @@ audit row points at a PDNS failure and you need the raw exchange.
   <img src="./light/pdns-requests.png" alt="PDNS request log" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/pdns-requests-mobile.png" />
   <img src="./light/pdns-requests-mobile.png" alt="PDNS request log on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [PDNS request log](../docs/FEATURES.md#36-pdns-request-log)
 · [PDNS HTTP client](../docs/FEATURES.md#35-pdns-http-client)
@@ -319,10 +345,12 @@ and a one-click Test discovery probe.
   <img src="./light/oidc-providers.png" alt="OIDC providers" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/oidc-providers-mobile.png" />
   <img src="./light/oidc-providers-mobile.png" alt="OIDC providers on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [OIDC SSO](../docs/FEATURES.md#12-oidc-sso)
 · [Group → role mapping](../docs/FEATURES.md#13-group--role-mapping-oidc)
@@ -341,10 +369,12 @@ on peer secondaries → activate for zones, in one flow.
   <img src="./light/tsig-keys.png" alt="TSIG keys" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/tsig-keys-mobile.png" />
   <img src="./light/tsig-keys-mobile.png" alt="TSIG keys on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [TSIG keys](../docs/FEATURES.md#7-tsig-keys)
 
@@ -360,10 +390,12 @@ from for auto-creation of secondary zones.
   <img src="./light/autoprimaries.png" alt="Autoprimaries" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/autoprimaries-mobile.png" />
   <img src="./light/autoprimaries-mobile.png" alt="Autoprimaries on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Autoprimaries](../docs/FEATURES.md#8-autoprimaries)
 
@@ -381,10 +413,12 @@ one-click apply.
   <img src="./light/zone-templates.png" alt="Zone templates" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/zone-templates-mobile.png" />
   <img src="./light/zone-templates-mobile.png" alt="Zone templates on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Zone templates](../docs/FEATURES.md#44-zone-templates)
 
@@ -402,10 +436,12 @@ so a fresh deploy lands on the same configuration each time.
   <img src="./light/settings.png" alt="Settings" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/settings-mobile.png" />
   <img src="./light/settings-mobile.png" alt="Settings on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [Settings](../docs/FEATURES.md#10-settings)
 · [Provisioning](../docs/FEATURES.md#12-provisioning-first-boot-yaml)
@@ -424,10 +460,12 @@ A forced-password user lands here automatically until they rotate.
   <img src="./light/profile.png" alt="Profile" />
 </picture>
 
-<picture>
+<p align="center">
+  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./dark/profile-mobile.png" />
   <img src="./light/profile-mobile.png" alt="Profile on mobile" width="300" />
-</picture>
+  </picture>
+</p>
 
 → [TOTP (multi-factor)](../docs/FEATURES.md#14-totp-multi-factor)
 · [API tokens](../docs/FEATURES.md#15-api-tokens)

--- a/tests/integration/docker-compose.test.yml
+++ b/tests/integration/docker-compose.test.yml
@@ -42,3 +42,7 @@ services:
       BOOTSTRAP_ADMIN_PASSWORD: test-bootstrap-pw-changeme-now
       PROVISION_ON_BOOT: "true"
       SEED_ON_BOOT: "true"
+      # Integration suite exercises the replication-aware code paths (sync
+      # state, mirror discovery, advisory eval). Default in production is
+      # `false`; the test stack pins it `true` so those paths are covered.
+      PDNS_BACKGROUND_POLLING: "true"


### PR DESCRIPTION
## Summary

Two related changes shipping together as **v1.2.0** (minor — behaviour-change default):

### 1. Standalone PDNS write-capability fix (closes #57)

A PDNS Authoritative daemon with the defaults `primary=no, secondary=no` in `pdns.conf` is fully write-capable through its HTTP API. AuthAdmin was incorrectly hiding it from `/zones/new`'s backend picker because `isWriteCapable` gated on `caps.primary` — which only reflects PDNS's AXFR-primary flag, not whether the API accepts zone writes.

- `isWriteCapable` flipped to `caps ? !isReadOnlyMirror(caps) : true` — standalone / explicit-primary / dual-role all pass; only a pure secondary mirror is excluded.
- Capability badge `none` → `standalone` (same neutral tone, accurate label). `summarizeCapabilities` fallback follows suit (`api` → `standalone`, `api: no` → `unreachable`).
- New `hasReplicationTopology()` so the header chip doesn't claim SYNCED/DESYNCED against a fleet with nothing to sync.

### 2. `PDNS_BACKGROUND_POLLING` opt-in flag (default `false`)

AuthAdmin's unified background poller (30 s zone-state / 60 s daemon refresh / 5 min metric-sample) is now opt-in. Single-server / standalone deployments get zero background PDNS traffic — every PDNS call is a direct consequence of an operator action.

The opt-in surfaces the **full replication-awareness layer**:

| Surface | `PDNS_BACKGROUND_POLLING=false` (default) | `PDNS_BACKGROUND_POLLING=true` |
|---|---|---|
| Background `setInterval` ticker | none | runs |
| Header SYNCED/DESYNCED chip | "Live" only | full sync verdict |
| Zone-detail **Sync** + **Statistics** tabs | hidden (direct URL → error toast) | visible |
| Servers-list **Sync** column + heartbeat | hidden | visible |
| Zones-list mirror column | hidden | visible |
| Dashboard **PDNS metrics** tab | hidden, replaced by `(i)` hint on heading | visible |
| Drift-derived advisories in bell | not generated | generated |
| Mutations / SSE / `invalidateBackendObservation` | unchanged — live data still propagates | unchanged |
| Test / Refresh All / DNSSEC / TSIG / RBAC / audit | unchanged | unchanged |

### Polished behaviours when off

- **`(i)` hint on the dashboard heading** — link to live CONFIGURATION doc + hover tooltip explaining how to enable.
- **`flash=polling-required` red error toast** when a direct URL lands on a gated feature (`/dashboard?tab=pdns`, `/zones/<id>?tab=sync`, `/zones/<id>?tab=statistics`) — page redirects to the default view with the toast: *"ERROR: This view requires PDNS_BACKGROUND_POLLING=true. Set it in your environment and restart the app to enable."*
- **Boot-time hint via `/healthz` first hit** — DB-only topology probe (3s hard budget) + a single sharp log line: "polling on — features enabled", "polling off — single-server mode", or a warning when the configured fleet has replication topology but the flag is off.

### Release artifacts (bundled)

- `package.json` `1.1.5` → `1.2.0`
- `CHANGELOG.md` `[1.2.0]` entry with the behaviour-change call-out
- `docs/09-UPGRADING.md` 1.2.0 section with the loud NOTE block + per-topology table
- `docs/03-CONFIGURATION.md` full `PDNS_BACKGROUND_POLLING` reference
- `docs/04-BACKENDS.md` opt-in callout under "Background polling — opt-in for multi-peer topologies"
- `docs/08-HARDENING.md` cosign-verify example bumped to 1.2.0 + "keep default off unless you need it" guidance
- `README.md` feature list updated to flag replication features as opt-in
- `.env.example` full `PDNS_BACKGROUND_POLLING` block

## Test plan

- [x] `npm run test` — 864 passes (up from 862; +2 new poller-flag tests)
- [x] `npm run ci:local` — static-checks + test jobs green via `act`
- [x] `npm run test:integration` — full docker stack with `PDNS_BACKGROUND_POLLING=true` pinned so sync-aware paths stay exercised
- [x] `npx tsc --noEmit` clean
- [x] `npm run format:check` clean
- [x] eslint clean on all touched files
- [ ] Post-merge: tag `v1.2.0`, `gh release create`, verify cosign sign workflow lands cleanly (GH_REPO fix already on main)
- [ ] Deploy to envoy.hb.com.au + nms-ap-southeast.ngn.au (still polling-off by default — multi-host deployments not currently configured with replication so the change is neutral)
- [ ] Confirm @insxa's `/zones/new` populates on the standalone after the upgrade; drop the `primary=yes` workaround if applied

Closes #57. Reported by @insxa in [discussion #27](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/discussions/27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
