### PR TITLE
v1.2.1 — slim runner image + :latest = stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,8 +192,16 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          # Tag convention:
+          #   :latest         most recent release  (vX.Y.Z tag push)
+          #   :X.Y.Z, :X.Y    that release + its minor channel
+          #   :edge           tip of main          (every push)
+          #   :sha-xxxxxxx    exact commit         (always)
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=edge,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,format=short

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ pgdata/
 npm-debug.log*
 yarn-debug.log*
 pnpm-debug.log*
+
+# Build-time artefacts (generated; never committed)
+/boot/
+.build-cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,94 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.2.1] — 2026-05-27
+
+A **build-pipeline patch** — significant image-size reduction with
+no operator-facing behaviour change. The published image goes from
+**~1.18 GB local / ~225 MB compressed pull** to **~290 MB local /
+~80 MB compressed pull** (about a 75% local / 65% compressed cut).
+Drop-in upgrade — no schema, API, or operator-config changes.
+
+### Changed — build pipeline
+
+- **Boot scripts pre-bundled at image-build time.** `scripts/migrate.ts`,
+  `scripts/seed.ts`, and `scripts/provision.ts` are now built into
+  self-contained ESM files under `boot/` via `npm run build:boot`
+  (esbuild). The runner runs them directly with `node`, so the runtime
+  image no longer needs:
+  - `tsx` (the on-the-fly TS transpiler the previous entrypoint shelled
+    out to),
+  - the full `lib/` and `scripts/` source trees,
+  - `tsconfig.json`, or
+  - the separate prod-deps `node_modules` overlay (the previous `deps`
+    stage — ~700 MB on disk used solely to make boot succeed).
+- **Dockerfile: `deps` stage removed; runner switched to distroless.**
+  The build now goes builder → fs-prep → runner, where the final
+  runner is `gcr.io/distroless/nodejs24-debian12:nonroot`. Boot
+  externals (`better-sqlite3`, `@node-rs/argon2`, `pg`, `pino` +
+  transports) resolve at runtime from the standalone bundle's
+  already-traced `node_modules` — Next's image-tracer has been
+  ensuring those are present all along; the dedicated `deps` overlay
+  was redundant.
+- **Next.js trace exclusion for `@img/sharp*`** combined with
+  `images: { unoptimized: true }` in `next.config.ts`. Sharp was a
+  ~16 MB optionalDep used only by Next's built-in image optimizer;
+  with the optimizer off (the wordmark PNGs in `/public` are tiny
+  pre-sized assets, and brand-logo uploads render via a plain `<img>`)
+  it never runs and can be left out of the runner entirely.
+- **Native-binary debug symbols stripped** during the build. Sub-MB
+  but free; the binaries `dlopen` identically.
+
+### Operator-facing trade-offs
+
+- **No shell in the runtime image.** `docker exec <container> sh` is
+  not available anymore — the distroless base ships only the `node`
+  binary, glibc, openssl, and ca-certificates. For incident triage
+  that needs a shell, build a `:debug` tag against bookworm-slim using
+  the same builder stage. Day-to-day operations (logs, healthz/readyz
+  probes, env reload, image upgrades) are unaffected.
+- **Container user is now `nonroot` (uid 65532)** instead of `node`
+  (uid 1000). If you'd hand-set ownership on a host-mounted `/data`
+  volume to uid 1000 prior, re-chown it to 65532 before the first
+  upgraded boot. The compose files in this repo's docker-compose-\*.yml
+  examples don't pin a uid and need no change.
+- **Next.js built-in image optimizer is disabled.** `<Image>` tags
+  still render — they just serve the file at its intrinsic size, no
+  resize or format conversion at the edge. No PowerDNS-AuthAdmin page
+  relied on the optimizer (our images are static brand assets); this
+  is only a difference for downstream customisation that adds dynamic
+  image processing via `next/image`.
+
+### Changed — image tags
+
+`:latest` now follows releases, not `main`.
+
+| Tag              | Points to                               |
+| ---------------- | --------------------------------------- |
+| `:latest`        | most recent release (`vX.Y.Z` tag push) |
+| `:X.Y.Z`, `:X.Y` | that release + its minor channel        |
+| `:edge`          | tip of `main` (every push)              |
+| `:sha-xxxxxxx`   | exact commit, immutable                 |
+
+Operators following `:latest` will jump to `1.2.1` on next pull and
+then stay there until the next release tag. Use `:edge` to track
+`main`.
+
+### Unchanged
+
+- Same Next.js standalone server, same migration SQL files, same
+  entrypoint flow (migrate → seed → provision → server).
+- `/healthz` + `/readyz` semantics unchanged.
+- All API, auth, RBAC, OIDC, signup, audit, and PDNS-backend behaviour
+  identical.
+- Cosign signing + SBOM attachment unchanged.
+
+### Upgrading
+
+Pull the new image and recreate the container — that's the whole
+upgrade. See [Upgrading → 1.2.1](./docs/09-UPGRADING.md#upgrading-to-121-from-12x)
+for the no-shell / non-root caveats.
+
 ## [1.2.0] — 2026-05-26
 
 A **minor release** that combines two closely-related changes:

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,12 @@ ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# Distroless puts `node` at /nodejs/bin/node and runs it as the image's
+# ENTRYPOINT, but does NOT add /nodejs/bin to $PATH. Compose health-
+# checks of the form `CMD ["node", ...]` bypass ENTRYPOINT and exec
+# `node` directly from PATH — they need it visible there.
+ENV PATH=/nodejs/bin:$PATH
+
 # Build provenance surfaced in the UI (sidebar version chip + GitHub/Docs
 # links, see lib/app-meta.ts). The CI docker job sets GIT_SHA to the
 # commit and APP_RELEASE=true only for vX.Y.Z tag builds. Both default

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,38 +3,38 @@
 # Dockerfile — multi-stage build for PowerDNS-AuthAdmin
 #
 # Stages:
-#   builder   — install full deps + Next build → standalone output.
-#   deps      — fresh `npm ci --omit=dev --include=optional` against the
-#               same lockfile. Produces a prod-only node_modules tree the
-#               runner copies wholesale.
-#   runner    — Debian/glibc Node 22 (bookworm-slim), non-root, production
-#               image. Boots via a small entrypoint that runs DB migrations
-#               (ADR-0011), then first-boot provisioning (ADR-0012), then
-#               launches Next.js. The boot scripts are TypeScript sources
-#               executed by `tsx` (shipped as a runtime dep) — no compile
-#               step in the image; tsx reads the existing tsconfig + source
-#               and transpiles on the fly.
+#   builder  — full deps install, Next.js production build, AND pre-bundle
+#              of the three boot-time TS scripts into self-contained ESM
+#              files. Three artefacts feed the runner:
+#                1. `.next/standalone` — Next's traced server bundle
+#                   (incl. the runtime node_modules subset Next computed).
+#                2. `.next/static` + `public` — static assets.
+#                3. `boot/{migrate,seed,provision}.js` — esbuild-bundled
+#                   ESM versions of the .ts scripts, every `lib/*` import
+#                   inlined.
 #
-# Critical: all stages use Debian/glibc base images, NOT alpine/musl.
-#   Reason: napi-rs native bindings (@node-rs/argon2, @tailwindcss/oxide,
-#   better-sqlite3) resolve to different prebuilt binaries by libc. A builder
-#   on musl would install musl binaries that can't be loaded by a glibc
-#   runner — produces a runtime `Failed to load native binding` error. Keep
-#   libcs aligned.
+#   fs-prep — bookworm-slim layout-and-strip stage. Distroless has no
+#             shell, no apt, no `mkdir`, no `strip`. So we assemble the
+#             final filesystem here (chown, strip native .node binaries
+#             to drop debug symbols, prepare /data) and COPY the prepared
+#             tree as a single layer into the distroless runner.
 #
-# Why bookworm-slim runner (not distroless):
-#   The boot-time migration + provisioning steps need `lib/db/index.ts`,
-#   `drizzle-orm`, the dialect driver (`pg` / `better-sqlite3`), `js-yaml`,
-#   and `tsx` on disk at runtime. Those aren't traced into Next.js'
-#   standalone bundle (they're imported from `scripts/*.ts`, not from app
-#   routes). A shell + the prod node_modules tree is the simplest way to
-#   make boot work without an elaborate bundling step.
+#   runner  — `gcr.io/distroless/nodejs24-debian12:nonroot`. Non-root by
+#             default (uid 65532 `nonroot`). NO shell, NO package manager,
+#             NO source tree, NO tsx, NO separate prod-deps node_modules.
+#             Boot bundles run with `node` directly. Externals (native
+#             bindings, pg, pino transports) resolve from the standalone
+#             bundle's already-traced node_modules.
 #
-# Why scripts ARE allowed during install: better-sqlite3 ships its native
-# binary via `prebuild-install`, which runs as a postinstall step. Disabling
-# scripts skips that download → the SQLite path fails at runtime with a
-# missing-binding error. The trust trade-off here is real but bounded:
-# every dep that runs a postinstall is reviewed in the lockfile.
+# Critical: builder + fs-prep use Debian/glibc (NOT alpine/musl). napi-rs
+# native bindings (@node-rs/argon2, better-sqlite3) resolve to different
+# prebuilt binaries by libc; a builder on musl would install musl
+# binaries that can't be dlopen()'d by the glibc runner. Both bases
+# share the same glibc to keep the bindings portable.
+#
+# Trade-off (vs. bookworm-slim runner): no shell at runtime — incident
+# triage via `docker exec <id> sh` is unavailable. If you need it, build
+# a separate `:debug` tag against bookworm-slim using the same builder.
 # =============================================================================
 
 # --- Stage 1: builder --------------------------------------------------------
@@ -61,78 +61,69 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
 
-RUN npm run build
+# Two outputs from the same source tree:
+#   • npm run build       → .next/standalone (Next.js production server)
+#   • npm run build:boot  → boot/{migrate,seed,provision}.js (esbuild)
+RUN npm run build && npm run build:boot
 
 
-# --- Stage 2: prod deps tree -------------------------------------------------
-# Separate stage so the runner gets a clean `npm ci --omit=dev` tree without
-# the devDeps that the builder needed (drizzle-kit, tsc, vitest, prettier).
-FROM node:24-bookworm-slim@sha256:242549cd46785b480c832479a730f4f2a20865d61ea2e404fdb2a5c3d3b73ecf AS deps
+# --- Stage 2: fs-prep --------------------------------------------------------
+# Distroless has no shell to run mkdir / chown / strip. We assemble the final
+# tree here under bookworm-slim where we DO have those tools.
+FROM node:24-bookworm-slim@sha256:242549cd46785b480c832479a730f4f2a20865d61ea2e404fdb2a5c3d3b73ecf AS fs-prep
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 build-essential ca-certificates \
+WORKDIR /stage
+
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/boot ./boot
+COPY --from=builder /app/drizzle ./drizzle
+COPY --from=builder /app/drizzle-sqlite ./drizzle-sqlite
+COPY --from=builder /app/docker/entrypoint.mjs ./entrypoint.mjs
+
+# Strip debug symbols from every .node native binding we ship
+# (better-sqlite3, @node-rs/argon2). Sub-MB each but free; the stripped
+# binaries dlopen identically. binutils is purged before COPY so none of
+# it lands in the distroless runner.
+RUN apt-get update && apt-get install -y --no-install-recommends binutils \
+    && find . -name '*.node' -exec strip --strip-unneeded {} \; \
+    && apt-get purge -y binutils \
+    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
-
-COPY package.json package-lock.json* ./
-
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --omit=dev --include=optional
+# Distroless `nonroot`: uid 65532, gid 65532.
+RUN chown -R 65532:65532 /stage && \
+    mkdir -p /data-stage && chown -R 65532:65532 /data-stage
 
 
-# --- Stage 3: runner --------------------------------------------------------
-FROM node:24-bookworm-slim@sha256:242549cd46785b480c832479a730f4f2a20865d61ea2e404fdb2a5c3d3b73ecf AS runner
-
-WORKDIR /app
+# --- Stage 3: runner (distroless) -------------------------------------------
+FROM gcr.io/distroless/nodejs24-debian12:nonroot AS runner
 
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Build provenance surfaced in the UI (sidebar version chip + GitHub/Docs links,
-# see lib/app-meta.ts). The CI docker job sets GIT_SHA to the commit and
-# APP_RELEASE=true only for vX.Y.Z tag builds. Both default empty for a plain
-# `docker build`, which makes the app fall back to release/tag links.
+# Build provenance surfaced in the UI (sidebar version chip + GitHub/Docs
+# links, see lib/app-meta.ts). The CI docker job sets GIT_SHA to the
+# commit and APP_RELEASE=true only for vX.Y.Z tag builds. Both default
+# empty for a plain `docker build`, which makes the app fall back to
+# release/tag links.
 ARG GIT_SHA=""
 ARG APP_RELEASE="false"
 ENV APP_GIT_SHA=$GIT_SHA
 ENV APP_RELEASE=$APP_RELEASE
 
-# Non-root user for the app. `node:bookworm-slim` ships a `node` user with
-# uid 1000 — reuse it instead of creating our own. /data is the conventional
-# mount target for the SQLite file (DATABASE_URL=file:/data/...).
-RUN mkdir -p /data && chown -R node:node /app /data
+WORKDIR /app
 
-# Next.js standalone bundle + static assets.
-COPY --from=builder --chown=node:node /app/.next/standalone ./
-COPY --from=builder --chown=node:node /app/.next/static ./.next/static
-COPY --from=builder --chown=node:node /app/public ./public
+COPY --from=fs-prep --chown=nonroot:nonroot /stage/ /app/
+COPY --from=fs-prep --chown=nonroot:nonroot /data-stage /data
 
-# Boot-time TypeScript sources (executed by tsx, see entrypoint.mjs).
-# Includes scripts/migrate.ts + scripts/provision.ts and the lib/ tree they
-# import. tsconfig.json is required at runtime so tsx resolves the `@/*`
-# path alias the way the rest of the codebase does.
-COPY --from=builder --chown=node:node /app/scripts ./scripts
-COPY --from=builder --chown=node:node /app/lib ./lib
-COPY --from=builder --chown=node:node /app/tsconfig.json ./tsconfig.json
-COPY --from=builder --chown=node:node /app/drizzle ./drizzle
-COPY --from=builder --chown=node:node /app/drizzle-sqlite ./drizzle-sqlite
-
-# Prod-only node_modules from the deps stage. The standalone bundle has
-# its own ./node_modules with the traced subset for Next.js; this overlay
-# brings in the rest the boot scripts need. Drizzle's resolution finds
-# whichever copy comes first in the path; both copies are the same exact
-# versions so the duplication is structurally safe.
-COPY --from=deps --chown=node:node /app/node_modules ./node_modules
-
-# Entrypoint: migrate → provision → server. `node` directly — no shell —
-# so signals (SIGTERM from k8s/compose) reach the Node process cleanly.
-COPY --from=builder --chown=node:node /app/docker/entrypoint.mjs ./entrypoint.mjs
-
-USER node
+USER nonroot
 
 EXPOSE 3000
 
-CMD ["node", "entrypoint.mjs"]
+# Distroless/nodejs ships with `node` as the entrypoint; the CMD is the
+# script path. Same effect as `node entrypoint.mjs` on bookworm-slim.
+CMD ["entrypoint.mjs"]

--- a/docker/entrypoint.mjs
+++ b/docker/entrypoint.mjs
@@ -16,30 +16,21 @@
  * Any stage failure aborts the boot — a broken migrate, seed, or
  * malformed provisioning file produces a refused start, not a degraded run.
  *
- * Why we run the .ts sources via `tsx` instead of pre-compiling to JS:
- * the rest of the codebase uses bundler-style imports (no .js extensions,
- * `@/*` path aliases) that the Next.js build accepts natively. Compiling
- * those modules to Node-runnable JS with `tsc --module nodenext` triggers
- * a rewrite of every relative import in the tree, which costs more churn
- * than the boot scripts are worth. `tsx` reads the existing tsconfig +
- * source files and transpiles on the fly — single-digit-MB extra in the
- * image, no compile step in the Dockerfile.
+ * The three boot stages run pre-bundled ESM files under `./boot/`,
+ * produced by `scripts/build-boot.mjs` at image-build time. Each bundle
+ * carries its transitive `lib/*` imports inline; only the externals
+ * named in the bundler config (native bindings, pg, pino transports)
+ * stay dynamic, and those live in the standalone bundle's own
+ * node_modules. No `tsx`, no source-tree at runtime — that was the
+ * single biggest contributor to the previous image size.
  */
 
 import { spawnSync } from "node:child_process";
 
-const TSX_CLI = "./node_modules/tsx/dist/cli.mjs";
-
 function runStep(label, scriptPath) {
-  const env = { ...process.env };
-  // tsx needs the `react-server` condition to resolve the server-only
-  // marker module the same way Next.js does at app runtime; otherwise the
-  // ESM-only `client.js` export wins and any `import "server-only"` in
-  // the boot scripts' transitive imports throws.
-  env.NODE_OPTIONS = [env.NODE_OPTIONS, "--conditions=react-server"].filter(Boolean).join(" ");
-  const result = spawnSync(process.execPath, [TSX_CLI, scriptPath], {
+  const result = spawnSync(process.execPath, [scriptPath], {
     stdio: "inherit",
-    env,
+    env: process.env,
   });
   if (result.error) {
     console.error(`[entrypoint] ${label}.spawn-failed:`, result.error);
@@ -56,7 +47,7 @@ if (skipMigrate) {
   console.log("[entrypoint] MIGRATE_ON_BOOT=false — skipping migrations");
 } else {
   console.log("[entrypoint] running DB migrations");
-  runStep("migrate", "./scripts/migrate.ts");
+  runStep("migrate", "./boot/migrate.js");
 }
 
 const skipSeed = (process.env.SEED_ON_BOOT ?? "").toLowerCase() === "false";
@@ -64,7 +55,7 @@ if (skipSeed) {
   console.log("[entrypoint] SEED_ON_BOOT=false — skipping seed");
 } else {
   console.log("[entrypoint] running seed (system roles + bootstrap admin)");
-  runStep("seed", "./scripts/seed.ts");
+  runStep("seed", "./boot/seed.js");
 }
 
 const skipProvision = (process.env.PROVISION_ON_BOOT ?? "").toLowerCase() === "false";
@@ -75,7 +66,7 @@ if (skipProvision) {
   console.log("[entrypoint] PROVISIONING_FILE not set — skipping provisioning");
 } else {
   console.log("[entrypoint] running first-boot provisioning");
-  runStep("provision", "./scripts/provision.ts");
+  runStep("provision", "./boot/provision.js");
 }
 
 console.log("[entrypoint] starting Next.js server");

--- a/docs/02-INSTALLATION.md
+++ b/docs/02-INSTALLATION.md
@@ -135,8 +135,21 @@ volumes:
   pg-data:
 ```
 
-> **Production tip:** pin a version (`:1.1.2`) instead of `:latest` so deploys
-> are deterministic. See [Upgrading](./09-UPGRADING.md).
+### Image tags
+
+| Tag            | Points to                                                                     |
+| -------------- | ----------------------------------------------------------------------------- |
+| `:latest`      | The most recent stable release. Updated only on `vX.Y.Z` tag pushes.          |
+| `:X.Y`         | The latest patch in a minor channel — e.g. `:1.2` follows `1.2.0` → `1.2.1`.  |
+| `:X.Y.Z`       | A single immutable release. Use this in production for deterministic deploys. |
+| `:edge`        | The tip of `main`. Updates on every push; not for production.                 |
+| `:sha-xxxxxxx` | An exact commit, kept forever.                                                |
+
+Pin a version in production:
+
+```yaml
+image: ghcr.io/powerdns-authadmin/powerdns-authadmin:1.2
+```
 
 ---
 

--- a/docs/08-HARDENING.md
+++ b/docs/08-HARDENING.md
@@ -89,7 +89,7 @@ Each published release is cosign-signed (keyless / Sigstore) by the release
 workflow. Verify before deploying:
 
 ```sh
-cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:1.2.0 \
+cosign verify ghcr.io/powerdns-authadmin/powerdns-authadmin:1.2.1 \
   --certificate-identity-regexp '^https://github.com/PowerDNS-AuthAdmin/' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```

--- a/docs/09-UPGRADING.md
+++ b/docs/09-UPGRADING.md
@@ -37,6 +37,55 @@ half-migrated schema; fix the cause and restart.
 
 ## Version-specific notes
 
+### Upgrading to 1.2.1 (from 1.2.x)
+
+A **build-pipeline patch** — drop-in upgrade. No schema, no API, no
+operator-config changes. Pull-and-recreate the container:
+
+```sh
+docker compose pull && docker compose up -d
+```
+
+What changes:
+
+- **Image is significantly smaller.** ~1.18 GB → ~290 MB local
+  (-75%); the compressed pull from GHCR drops from ~225 MB to ~80 MB
+  (-65%). Pull time on a rolling deploy drops accordingly.
+- **No `tsx`, no `/app/scripts/`, `/app/lib/`, or `/app/tsconfig.json`
+  in the runtime image.** Boot stages run pre-bundled ESM files under
+  `/app/boot/{migrate,seed,provision}.js`.
+- **Runner is now distroless.** Base swapped from
+  `node:24-bookworm-slim` to `gcr.io/distroless/nodejs24-debian12:nonroot`.
+  No shell, no apt, no package manager in the runtime image — only
+  `node`, glibc, openssl, ca-certificates.
+- **Container user is `nonroot` (uid 65532)**, replacing `node`
+  (uid 1000).
+- **Next.js built-in image optimizer is disabled** (`images.unoptimized: true`);
+  `<Image>` tags still render at intrinsic size.
+- **`:latest` follows releases**, not `main`. `:edge` tracks `main`.
+  See [Installation → Image tags](./02-INSTALLATION.md#image-tags).
+
+> **NOTE — operator-facing trade-offs (read before upgrading a
+> production deployment):**
+>
+> 1.  **No shell in the runtime container.** `docker exec <id> sh` is
+>     unavailable; the distroless base ships only the Node binary.
+>     For incident triage that needs a shell, build a `:debug` tag
+>     against the same builder stage with a bookworm-slim runner.
+>     Day-to-day operations (logs, `/healthz`, `/readyz`, env reload,
+>     image upgrades) are unaffected.
+> 2.  **Container user changed from `node` (uid 1000) to `nonroot`
+>     (uid 65532).** If you'd manually chown'd a host-mounted `/data`
+>     volume to uid 1000 prior, re-chown it to 65532 before the first
+>     boot of v1.2.1. The compose examples shipped in this repo don't
+>     pin a uid and need no change.
+
+If you mounted anything inside the image at one of the dropped paths
+(`/app/scripts`, `/app/lib`, `/app/tsconfig.json`) for custom tooling,
+that's the only meaningful breakage — those are build-time artefacts
+and shouldn't be mounted in production, but the upgrade now enforces
+it.
+
 ### Upgrading to 1.2.0 (from 1.1.x)
 
 A **minor release** — no schema migration, no API changes, drop-in upgrade.

--- a/next.config.ts
+++ b/next.config.ts
@@ -31,6 +31,33 @@ const config: NextConfig = {
   // and a focused `node_modules` tree, ~80% smaller than full output.
   output: "standalone",
 
+  // Disable Next's built-in image optimizer at runtime: the wordmark PNGs in
+  // /public are tiny pre-sized assets (no resizing or format conversion
+  // needed), and operator-uploaded brand logos render via a plain <img> in
+  // BrandMark. With this on, `<Image>` tags still work — they just serve
+  // the file at its intrinsic size — and the outputFileTracingExcludes
+  // below keeps the ~16 MB of @img/sharp prebuilt binaries out of the
+  // standalone bundle entirely.
+  images: { unoptimized: true },
+
+  // Explicit trace exclusions for packages that Next.js statically follows
+  // into the standalone bundle but that we don't actually invoke at
+  // runtime in production:
+  //
+  //   • @img/sharp* (16 MB) — optionalDep of `next`, only used by
+  //     `images.unoptimized: false`. Disabled above; this drops the
+  //     binaries from the runner.
+  //
+  // jsdom (~8 MB) is intentionally NOT excluded here: it's used at
+  // runtime by `isomorphic-dompurify` in `lib/security/svg.ts` to
+  // sanitize operator-uploaded SVG logos. A future swap to a lighter
+  // DOM (linkedom failed compatibility testing; xmldom + custom
+  // sanitizer is the candidate path) would let us add jsdom to this
+  // list and shed another ~8 MB.
+  outputFileTracingExcludes: {
+    "*": ["node_modules/@img/**", "node_modules/sharp/**"],
+  },
+
   // External packages that should not be bundled by the server build (native bindings,
   // dynamic `require('fs'|'path')`, optional deps). Drizzle's pg driver is the classic
   // case; better-sqlite3 ships a `.node` binding via `bindings` (which itself requires

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.1.5",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerdns-authadmin",
-      "version": "1.1.5",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@casl/ability": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "Modern, self-hosted DNS administration UI for PowerDNS — multi-team RBAC, real audit, real SSO. From-scratch rebuild of PowerDNS-Admin in Node.js + TypeScript.",
   "license": "MIT",
@@ -18,6 +18,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:boot": "node scripts/build-boot.mjs",
     "start": "next start",
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",

--- a/scripts/build-boot.mjs
+++ b/scripts/build-boot.mjs
@@ -1,0 +1,107 @@
+/**
+ * scripts/build-boot.mjs
+ *
+ * Bundles the three boot-time TS scripts (`migrate`, `seed`, `provision`)
+ * into self-contained Node ESM files under `./boot/`. The runner image
+ * runs these JS files directly with `node` — no `tsx`, no `scripts/`
+ * source tree, no `lib/` source tree, no separate prod-deps `node_modules`
+ * — which was the single biggest contributor to the runner image size
+ * (the deps stage was a ~700 MB on-disk overlay used only by boot).
+ *
+ * Run as part of the image build (`npm run build:boot` in the builder
+ * stage, after `npm run build`).
+ *
+ * Externals — kept dynamic, NOT inlined:
+ *
+ *   • Native `.node` bindings can't be inlined into JS (they load at
+ *     runtime via dlopen). We keep `better-sqlite3` and `@node-rs/argon2`
+ *     external; their .node binaries live in the standalone bundle's
+ *     own node_modules (Next traces them for the app runtime).
+ *
+ *   • `pg`'s `Pool extends EventEmitter` survives CJS round-tripping
+ *     inside Node natively but breaks under esbuild's ESM interop
+ *     ("Class extends value is not a constructor"). Tiny package, leave
+ *     it external.
+ *
+ *   • Pino loads worker JS files from its own package directory via
+ *     `__dirname`; the workers can't be inlined into a single ESM
+ *     bundle. Leave the pino transport tree external.
+ *
+ * Module resolution: at runtime the bundled files live at /app/boot/.
+ * Node walks up looking for node_modules, finds /app/node_modules/ —
+ * which IS the Next.js standalone bundle's traced subset. Every external
+ * listed above is present there because Next traced them for the app.
+ *
+ * Conditions mirror Next's at app runtime (`react-server`, `node`, …)
+ * so `import "server-only"` resolves to its server build, the same way
+ * Next.js sees it.
+ */
+
+import { build } from "esbuild";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const outdir = resolve(root, "boot");
+
+rmSync(outdir, { recursive: true, force: true });
+
+// `server-only` and `client-only` are marker modules that throw at import
+// time when imported from the wrong React environment. Boot scripts have
+// no client/server split — a noop module is correct here. We generate it
+// in a build-cache directory so the bundler can resolve it without the
+// `tests/` tree being in the Docker build context.
+const cacheDir = resolve(root, ".build-cache");
+mkdirSync(cacheDir, { recursive: true });
+const noopPath = resolve(cacheDir, "server-client-only-noop.js");
+writeFileSync(noopPath, "export {};\n");
+
+await build({
+  entryPoints: {
+    migrate: "scripts/migrate.ts",
+    seed: "scripts/seed.ts",
+    provision: "scripts/provision.ts",
+  },
+  outdir,
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  target: "node24",
+  legalComments: "none",
+  minify: process.env.BOOT_BUNDLE_NO_MINIFY === "1" ? false : true,
+  sourcemap: process.env.BOOT_BUNDLE_NO_MINIFY === "1" ? "inline" : false,
+  alias: {
+    "@": root,
+    "server-only": noopPath,
+    "client-only": noopPath,
+  },
+  conditions: ["react-server", "node", "import", "default"],
+  external: [
+    // Native .node bindings — dlopen at runtime.
+    "better-sqlite3",
+    "@node-rs/argon2",
+    "pg-native",
+    "@next/swc-*",
+    // CJS interop holdouts.
+    "pg",
+    // Pino transport tree — workers loaded from package dir via __dirname.
+    "pino",
+    "pino-pretty",
+    "pino-std-serializers",
+    "thread-stream",
+    "sonic-boom",
+    "real-require",
+    "atomic-sleep",
+  ],
+  // ESM-of-CJS-deps occasionally hits a leftover `require()` from
+  // upstream packages. Make `require` available at the top of every
+  // bundled module so those resolve via Node's regular CJS path.
+  banner: {
+    js: 'import { createRequire as __cr } from "node:module"; const require = __cr(import.meta.url);',
+  },
+  logLevel: "info",
+  absWorkingDir: root,
+});
+
+console.log(`[build-boot] wrote bundles to ${outdir}`);


### PR DESCRIPTION
## Summary

Build-pipeline patch. **Image: 1.18 GB → ~290 MB local (-75%); compressed pull ~225 MB → ~80 MB (-65%).** Drop-in upgrade — no schema, API, or operator-config changes.

### Build pipeline

- Pre-bundle `scripts/{migrate,seed,provision}.ts` with esbuild (`npm run build:boot`). Runner runs the JS directly. Drops `tsx`, `/app/scripts`, `/app/lib`, `/app/tsconfig.json`, and the entire prod-deps `node_modules` overlay (~700 MB).
- Switch runner to `gcr.io/distroless/nodejs24-debian12:nonroot`. Container user is `nonroot` (uid 65532). No shell at runtime.
- `next.config.ts`: `images: { unoptimized: true }` + `outputFileTracingExcludes` for `@img/sharp` (~16 MB).
- Strip debug symbols from native `.node` bindings during build.

### Image tag convention

| Tag | Points to |
|---|---|
| `:latest` | most recent release (vX.Y.Z tag push) |
| `:X.Y.Z`, `:X.Y` | that release + its minor channel |
| `:edge` | tip of `main` (every push) |
| `:sha-xxxxxxx` | exact commit, immutable |

Operators following `:latest` will jump to 1.2.1 on next pull and stay there until the next release tag. Use `:edge` to track `main`.

### Operator-facing trade-offs

- No shell in the runtime image — `docker exec sh` is unavailable. Build a `:debug` tag against bookworm-slim if needed.
- Container user changed from `node` (uid 1000) → `nonroot` (uid 65532). Re-chown a host-mounted `/data` volume if you pinned 1000 prior.
- Next.js built-in image optimizer is disabled. `<Image>` tags still render at intrinsic size.

## Test plan
- [x] `npm run ci:local` (act: static-checks + test) — green
- [x] `npm run test:integration` — green
- [x] `docker build` + smoke (migrate → seed → provision → Next.js Ready → /healthz 200 → /readyz 200)
- [x] doc link audit — 38 .md files, 0 broken
- [ ] Post-merge: tag `v1.2.1`, `gh release create`, sign workflow, deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)