### PR TITLE
fix(auth+docs): APP_URL mismatch banner, MFA enforcement parity, role descriptions, install-doc split

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,11 @@
 
 NODE_ENV=production
 # PORT=3000
-# Public URL the app is served from. Used in emails, OAuth redirect URIs, and
-# CSP origin checks. Absolute URL, no trailing slash.
+# Public URL the app is served from. MUST exactly match the URL operators type
+# in their browser (scheme + host + port). Session and CSRF cookies are scoped
+# to this host; a mismatch makes the browser silently reject `pda_csrf` and
+# sign-in fails with no useful error. Also drives email links, OAuth redirect
+# URIs, and the CSP origin. Absolute URL, no trailing slash.
 APP_URL=http://localhost:3000
 # Log level: trace | debug | info | warn | error | fatal. Default: info.
 LOG_LEVEL=info
@@ -262,6 +265,9 @@ PDNS_BACKGROUND_POLLING=false
 # OTEL_EXPORTER_OTLP_ENDPOINT=
 # Expose GET /metrics (Prometheus). Default true; set false to disable.
 # METRICS_ENABLED=true
-# Optional bearer token gating /metrics (≥16 chars). Unset = open (rely on
-# network ACLs). Generate with: openssl rand -hex 32
+# Bearer token gating /metrics (≥16 chars). When unset (and METRICS_ENABLED is
+# true), the app generates a random 32-char token on every boot and logs it
+# once — set this in .env to keep your scrape config stable, or set
+# METRICS_ENABLED=false to opt out of /metrics entirely. Generate with:
+#   openssl rand -hex 32
 # METRICS_TOKEN=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+
+- **Login: inline APP_URL mismatch banner.** Detects when the request host
+  doesn't match `env.APP_URL` (the classic "copy-pasted `http://localhost:3000`
+  but I'm browsing the LAN host" foot-gun) and surfaces it on the sign-in page
+  with the actual + expected origin, so operators don't have to crack open
+  DevTools to find out why their session cookie was silently rejected. Helper
+  is unit-tested (`lib/auth/app-url-check.ts`).
+- **Compliance guard now covers MFA enforcement, not just must-change-password.**
+  The shake-banner-on-blocked-nav behaviour is reused for forced TOTP enrolment;
+  `requireUserForPage` re-checks both gates on every soft navigation
+  (mirrors what was already there for password change).
+- **Roles list: description column** + the description renders on both system
+  and custom-role detail pages. Wraps cleanly, never truncates.
+- **METRICS_TOKEN auto-generation.** When `/metrics` is enabled but no token is
+  pinned in env, the app generates a random 32-char bearer on boot and logs it
+  once — keeps the endpoint from being accidentally open on a shared LAN.
+
+### Changed
+
+- **Force-MFA + OIDC users.** SSO-only accounts (no local password) are now
+  always exempt from MFA enforcement: the IdP is the second-factor authority
+  and the in-app TOTP enroll flow is read-only for them. The admin user-detail
+  page hides the per-user MFA override for SSO accounts, and the PATCH
+  endpoint rejects setting `mfaRequired=true` on them. `checkMfaCompliance`
+  defends against legacy rows that already carried that flag.
+- **Installation docs** split into two paths (Docker / from-source) with a
+  systemd unit + tested nginx and HAProxy reverse-proxy examples that get the
+  `X-Forwarded-*` headers right for the APP_URL mismatch detector.
+- **APP_URL guidance** elevated to its own install step + `.env.example`
+  comment, with the cookie-domain reasoning spelled out (operators copy-pasting
+  `http://localhost:3000` from the example hit a silent cookie rejection).
+
+### Fixed
+
+- **Login page "preload was not used" warnings.** The wordmark rendered both
+  light + dark PNGs with Next.js `priority`, emitting two `<link rel="preload">`
+  tags while CSS hid one — browsers warned every page load. Dropped `priority`;
+  the visible image still loads eagerly above the fold.
+
 ## [1.2.1] — 2026-05-27
 
 A **build-pipeline patch** — significant image-size reduction with

--- a/app/(app)/admin/roles/[id]/page.tsx
+++ b/app/(app)/admin/roles/[id]/page.tsx
@@ -67,8 +67,8 @@ export default async function RoleDetailPage({ params }: PageProps) {
             </span>
           )}
         </p>
-        {role.description && role.isSystem ? (
-          <p className="mt-3 text-sm">{role.description}</p>
+        {role.description ? (
+          <p className="mt-3 max-w-prose text-sm whitespace-pre-line">{role.description}</p>
         ) : null}
       </header>
 

--- a/app/(app)/admin/roles/_components/roles-table.tsx
+++ b/app/(app)/admin/roles/_components/roles-table.tsx
@@ -17,6 +17,7 @@ export interface RoleRow {
   id: string;
   name: string;
   slug: string;
+  description: string | null;
   kind: "System" | "Custom";
   permissionCount: number;
   requiresMfa: boolean;
@@ -43,6 +44,22 @@ export function RolesTable({
         accessorKey: "slug",
         header: "Slug",
         cell: (ctx) => <span className="font-mono text-xs">{ctx.getValue<string>()}</span>,
+      },
+      {
+        accessorKey: "description",
+        header: "Description",
+        // Wrap, never truncate — short blurbs are the whole point of the column.
+        // `whitespace-normal` overrides the table's default `nowrap`; the cap on
+        // length lives in the schema (`text` column) and the form's UX.
+        cell: (ctx) => {
+          const v = ctx.getValue<string | null>();
+          if (!v) return <span className="text-xs text-[color:var(--color-fg-muted)]">—</span>;
+          return (
+            <span className="block max-w-prose text-xs whitespace-normal text-[color:var(--color-fg-muted)]">
+              {v}
+            </span>
+          );
+        },
       },
       {
         accessorKey: "kind",

--- a/app/(app)/admin/roles/page.tsx
+++ b/app/(app)/admin/roles/page.tsx
@@ -46,6 +46,7 @@ export default async function RolesListPage() {
             id: r.id,
             name: r.name,
             slug: r.slug,
+            description: r.description,
             kind: r.isSystem ? "System" : "Custom",
             permissionCount: r.permissions.length,
             requiresMfa: r.requiresMfa,

--- a/app/(app)/admin/users/[id]/page.tsx
+++ b/app/(app)/admin/users/[id]/page.tsx
@@ -104,7 +104,13 @@ export default async function UserDetailPage({ params }: PageProps) {
         isSelf={isSelf}
       />
 
-      {canUpdate ? <MfaRequiredOverride userId={id} initial={target.mfaRequired} /> : null}
+      {/* SSO-only users can't enroll TOTP in this app — the IdP is the
+          second-factor authority. The override is hidden for them: forcing it
+          would only deadlock the account. See lib/auth/mfa-compliance.ts for
+          the matching policy on the enforcement side. */}
+      {canUpdate && target.passwordHash !== null ? (
+        <MfaRequiredOverride userId={id} initial={target.mfaRequired} />
+      ) : null}
 
       <RoleAssignmentsPanel
         userId={id}

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -29,7 +29,7 @@ import { FlashListener } from "@/components/ui/flash-listener";
 import { NavLink } from "@/components/ui/nav-link";
 import { RealtimeProvider } from "@/components/realtime/realtime-provider";
 import { HeaderStatusProvider } from "@/components/realtime/header-status-chip";
-import { MustChangePasswordProvider } from "@/components/auth/must-change-password-guard";
+import { ComplianceGuardProvider } from "@/components/auth/compliance-guard";
 import { getAppSettings } from "@/lib/settings/app-settings";
 import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
 import { globalAnyLagging, hasReplicationTopology } from "@/lib/pdns/sync";
@@ -146,7 +146,6 @@ export default async function AppLayout({ children }: Readonly<{ children: React
             brandLogoUrl={appSettings.brandLogoUrl}
             width={280}
             maxHeight={56}
-            priority
           />
         </Link>
       </div>
@@ -246,7 +245,10 @@ export default async function AppLayout({ children }: Readonly<{ children: React
 
   return (
     <DialogProvider>
-      <MustChangePasswordProvider blocked={current.user.mustChangePassword}>
+      <ComplianceGuardProvider
+        mfaRequired={!compliance.compliant}
+        passwordChangeRequired={current.user.mustChangePassword}
+      >
         {realtimeAvailable ? (
           <RealtimeProvider>
             <HeaderStatusProvider initialMode={initialChipMode}>
@@ -260,7 +262,7 @@ export default async function AppLayout({ children }: Readonly<{ children: React
             {shell}
           </>
         )}
-      </MustChangePasswordProvider>
+      </ComplianceGuardProvider>
     </DialogProvider>
   );
 }

--- a/app/(app)/profile/page.tsx
+++ b/app/(app)/profile/page.tsx
@@ -17,7 +17,7 @@ import { NameEdit } from "./_components/name-edit";
 import { SessionsList } from "./_components/sessions-list";
 import { TotpSection } from "./_components/totp-section";
 import { ProfileTabsContainer, ProfileTabPanel } from "./_components/profile-tabs";
-import { MustChangePasswordBanner } from "@/components/auth/must-change-password-guard";
+import { ComplianceBanner } from "@/components/auth/compliance-guard";
 import { env } from "@/lib/env";
 
 export const metadata: Metadata = { title: "Profile" };
@@ -74,7 +74,7 @@ export default async function ProfilePage({
       </header>
 
       <ProfileTabsContainer tabs={tabs} defaultTab="account">
-        <MustChangePasswordBanner />
+        <ComplianceBanner />
 
         <ProfileTabPanel id="account">
           <div className="space-y-3 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] p-5">

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -28,12 +28,7 @@ export default async function AuthLayout({ children }: Readonly<{ children: Reac
             capping at 350 px on desktop. Height stays auto via the wordmark's
             intrinsic ratio. */}
         <div className="mb-6 flex w-full max-w-md justify-center">
-          <BrandMark
-            siteName={siteName}
-            brandLogoUrl={brandLogoUrl}
-            width="min(100%, 350px)"
-            priority
-          />
+          <BrandMark siteName={siteName} brandLogoUrl={brandLogoUrl} width="min(100%, 350px)" />
         </div>
         <div className="w-full max-w-md rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-8 shadow-sm">
           {children}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -10,14 +10,16 @@
  */
 
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { env } from "@/lib/env";
+import { env, isProduction } from "@/lib/env";
 import { getCurrentUser } from "@/lib/auth/get-current-user";
 import { listEnabledOidcProviders } from "@/lib/db/repositories/oidc-providers";
 import { envOidcProviderSummary } from "@/lib/auth/providers/oidc";
 import { getAppSettings } from "@/lib/settings/app-settings";
 import { safeNextPath } from "@/lib/auth/safe-redirect";
+import { detectAppUrlMismatch } from "@/lib/auth/app-url-check";
 import { LoginForm } from "./login-form";
 
 export const metadata: Metadata = { title: "Sign in" };
@@ -45,6 +47,16 @@ export default async function LoginPage({
     "force-local": forceLocal,
   } = await searchParams;
   const { loginIntro, allowPasswordReset } = await getAppSettings();
+
+  // APP_URL misconfig — the browser silently rejects pda_session / pda_csrf
+  // when the cookie host doesn't match the address bar, and sign-in just
+  // looks "stuck" with no console message unless DevTools is open. Surface
+  // it inline so operators see it before the first failed submit.
+  const appUrlCheck = detectAppUrlMismatch(
+    await headers(),
+    env.APP_URL,
+    isProduction ? "https" : "http",
+  );
 
   // Validate the attempted-destination param once (open-redirect guard, L-2).
   // Carried through the local + OIDC flows; empty when it's just the default.
@@ -94,6 +106,38 @@ export default async function LoginPage({
           Use your team credentials to continue.
         </p>
       </header>
+
+      {appUrlCheck?.mismatch ? (
+        <div
+          role="alert"
+          className="mb-4 rounded-md border border-[color:var(--color-error)] bg-[color:var(--color-error)]/10 p-3 text-sm"
+        >
+          <strong className="text-[color:var(--color-error)]">
+            APP_URL mismatch — sign-in will fail.
+          </strong>
+          <p className="mt-1 text-[color:var(--color-fg)]">
+            You opened this page at <code className="font-mono">{appUrlCheck.actualOrigin}</code>{" "}
+            but the app is configured with{" "}
+            <code className="font-mono">APP_URL={appUrlCheck.expectedOrigin}</code>. Session and
+            CSRF cookies are scoped to{" "}
+            <code className="font-mono">{appUrlCheck.expectedOrigin}</code>, so your browser will
+            silently reject them.
+          </p>
+          <p className="mt-2 text-[color:var(--color-fg-muted)]">
+            Fix: set <code className="font-mono">APP_URL</code> to the exact scheme + host + port
+            you typed in the address bar and restart the app. See{" "}
+            <a
+              href="https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/blob/main/docs/02-INSTALLATION.md#2-set-app_url"
+              className="underline"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              Installation → Set APP_URL
+            </a>
+            .
+          </p>
+        </div>
+      ) : null}
 
       {loginIntro ? (
         <div className="mb-4 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] p-3 text-sm whitespace-pre-line">

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -55,6 +55,16 @@ export async function PATCH(request: Request, context: RouteContext): Promise<Re
       throw new ValidationError("You cannot disable your own account.");
     }
 
+    // SSO-only users have no way to enroll TOTP from the app — the IdP is the
+    // second-factor authority. Forcing MFA on them would only deadlock the
+    // account. Refuse the policy override here as defense-in-depth; the UI
+    // already hides the control for SSO-only users.
+    if (input.mfaRequired === true && existing.passwordHash === null) {
+      throw new ValidationError(
+        "Cannot force MFA on an SSO-only user — they have no way to enroll TOTP in this app. MFA is the responsibility of the identity provider.",
+      );
+    }
+
     const patch: Parameters<typeof updateUser>[1] = {};
     if (input.name !== undefined) patch.name = input.name;
     if (input.mustChangePassword !== undefined) patch.mustChangePassword = input.mustChangePassword;

--- a/app/metrics/route.ts
+++ b/app/metrics/route.ts
@@ -7,9 +7,12 @@
  *
  * Gating:
  *   - `env.METRICS_ENABLED` (default true) — when false, returns 404.
- *   - `env.METRICS_TOKEN` (optional) — when set, requires
- *     `Authorization: Bearer <token>`. Constant-time compare via
- *     timingSafeEqual to avoid leaking the token shape.
+ *   - `env.METRICS_TOKEN` — required `Authorization: Bearer <token>`.
+ *     Always present at runtime: the operator pins one in env, or
+ *     `lib/env.ts` auto-generates a random 32-char token on every boot
+ *     (logged once at startup) so /metrics is never accidentally open
+ *     on a shared LAN. To opt out of the endpoint entirely, set
+ *     `METRICS_ENABLED=false`. Constant-time compare via timingSafeEqual.
  *
  * Cache control: `no-store`. Prometheus scrapers won't honor it
  * either way, but reverse proxies caching `/metrics` is a known

--- a/components/auth/compliance-guard.tsx
+++ b/components/auth/compliance-guard.tsx
@@ -1,24 +1,31 @@
 "use client";
 
 /**
- * components/auth/must-change-password-guard.tsx
+ * components/auth/compliance-guard.tsx
  *
- * When the operator must change their password, they're already shunted to
- * /profile by the server (`requireUserForPage`). Without help, clicking any nav
- * link still triggers a Next.js soft-navigation flash (loading shimmer, URL
- * change, redirect bounce) before the server pulls them back. This guard
+ * A non-compliant operator (forced-MFA-not-enrolled, or flagged
+ * `mustChangePassword`) is already shunted to /profile by the server gate in
+ * `lib/auth/require-user.ts` + `app/(app)/layout.tsx`. Without help, clicking
+ * any nav link still triggers a Next.js soft-navigation flash (loading shimmer,
+ * URL change, redirect bounce) before the server pulls them back. This guard
  * intercepts those clicks on the client *before* the navigation starts and
- * tells the banner to shake — so the operator stays put and the reason is
+ * tells the banner to shake — the operator stays put and the reason is
  * obvious.
  *
+ * One guard handles both reasons (MFA-enrollment-required and password-must-
+ * change). The banner copy switches on the reason; the shake animation and
+ * click-interception behaviour are shared so the two flows feel identical to
+ * the operator.
+ *
  * Composition:
- *   - <MustChangePasswordProvider blocked={...}/> wraps the app (mounted in
- *     the (app) layout). Owns the "blocked" flag + a shake counter.
+ *   - <ComplianceGuardProvider mfaRequired={...} passwordChangeRequired={...}/>
+ *     wraps the app (mounted in the (app) layout). Owns the two flags + a
+ *     shake counter.
  *   - The provider mounts a capture-phase document click handler that no-ops
  *     internal <a> clicks while blocked, except for routes the operator is
  *     allowed to use (/profile + auth APIs + external links).
- *   - <MustChangePasswordBanner/> reads the counter; its key changes on each
- *     blocked attempt, which restarts the shake animation.
+ *   - <ComplianceBanner/> reads the counter; its key changes on each
+ *     blocked attempt, which restarts the CSS animation.
  */
 
 import {
@@ -31,19 +38,23 @@ import {
   type ReactNode,
 } from "react";
 
+export type ComplianceReason = "mfa" | "password";
+
 interface ContextValue {
-  blocked: boolean;
+  /** Set of reasons currently blocking the operator (empty when compliant). */
+  reasons: ReadonlySet<ComplianceReason>;
+  /** Increments on every blocked-navigation attempt to restart the shake. */
   shakeKey: number;
   triggerShake: () => void;
 }
 
 const Ctx = createContext<ContextValue>({
-  blocked: false,
+  reasons: new Set(),
   shakeKey: 0,
   triggerShake: () => undefined,
 });
 
-/** Paths the operator is allowed to reach while their password is forced. */
+/** Paths the operator is allowed to reach while non-compliant. */
 const ALLOW_PREFIXES = ["/profile", "/api/profile/", "/api/auth/", "/login", "/logout"];
 
 function isAllowedHref(href: string): boolean {
@@ -62,15 +73,26 @@ function isAllowedHref(href: string): boolean {
   );
 }
 
-export function MustChangePasswordProvider({
-  blocked,
+export function ComplianceGuardProvider({
+  mfaRequired,
+  passwordChangeRequired,
   children,
 }: {
-  blocked: boolean;
+  mfaRequired: boolean;
+  passwordChangeRequired: boolean;
   children: ReactNode;
 }) {
   const [shakeKey, setShakeKey] = useState(0);
   const triggerShake = useCallback(() => setShakeKey((k) => k + 1), []);
+
+  const reasons = useMemo(() => {
+    const set = new Set<ComplianceReason>();
+    if (mfaRequired) set.add("mfa");
+    if (passwordChangeRequired) set.add("password");
+    return set;
+  }, [mfaRequired, passwordChangeRequired]);
+
+  const blocked = reasons.size > 0;
 
   // Capture-phase click interceptor: catches both <a href> and Next's <Link>
   // (which renders an <a> too) before its own handler runs. Pointer/key
@@ -105,20 +127,41 @@ export function MustChangePasswordProvider({
   }, [blocked, triggerShake]);
 
   const value = useMemo<ContextValue>(
-    () => ({ blocked, shakeKey, triggerShake }),
-    [blocked, shakeKey, triggerShake],
+    () => ({ reasons, shakeKey, triggerShake }),
+    [reasons, shakeKey, triggerShake],
   );
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
 }
 
-export function useMustChangePassword(): ContextValue {
+export function useComplianceGuard(): ContextValue {
   return useContext(Ctx);
 }
 
-/** The orange banner on /profile that shakes whenever the guard blocks a nav. */
-export function MustChangePasswordBanner() {
-  const { blocked, shakeKey } = useMustChangePassword();
-  if (!blocked) return null;
+/**
+ * The orange banner shown on /profile that shakes whenever the guard blocks a
+ * nav. Picks copy by reason. When both reasons are active we lead with MFA
+ * (matches the server-side priority in `evaluateSessionCompliance`).
+ */
+export function ComplianceBanner() {
+  const { reasons, shakeKey } = useComplianceGuard();
+  if (reasons.size === 0) return null;
+
+  const mfa = reasons.has("mfa");
+  const password = reasons.has("password");
+
+  let title: string;
+  let detail: string;
+  if (mfa && password) {
+    title = "Two-factor enrollment and password change required.";
+    detail = "Enroll TOTP below, then change your password to continue.";
+  } else if (mfa) {
+    title = "Two-factor enrollment required.";
+    detail = "Enroll TOTP below to continue using the app.";
+  } else {
+    title = "Your password must be changed.";
+    detail = "Pick a new one below.";
+  }
+
   return (
     // `key={shakeKey}` re-mounts this node on every blocked attempt, which
     // restarts the CSS animation cleanly (no need to toggle a class).
@@ -127,7 +170,7 @@ export function MustChangePasswordBanner() {
       className="animate-shake rounded-md border border-[color:var(--color-warn)] bg-[color:var(--color-warn)]/10 p-4 text-sm"
       role="alert"
     >
-      <strong>Your password must be changed.</strong> Pick a new one below.
+      <strong>{title}</strong> {detail}
     </div>
   );
 }

--- a/components/ui/brandmark.tsx
+++ b/components/ui/brandmark.tsx
@@ -32,18 +32,9 @@ interface BrandMarkProps {
   maxHeight?: number;
   /** Optional className for the wrapper. */
   className?: string;
-  /** Above-the-fold? Forwarded to Wordmark for the LCP boost. */
-  priority?: boolean;
 }
 
-export function BrandMark({
-  siteName,
-  brandLogoUrl,
-  width,
-  maxHeight,
-  className,
-  priority,
-}: BrandMarkProps) {
+export function BrandMark({ siteName, brandLogoUrl, width, maxHeight, className }: BrandMarkProps) {
   if (brandLogoUrl) {
     return (
       // eslint-disable-next-line @next/next/no-img-element
@@ -68,12 +59,5 @@ export function BrandMark({
       />
     );
   }
-  return (
-    <Wordmark
-      width={width}
-      height={maxHeight ?? "auto"}
-      priority={priority}
-      className={className}
-    />
-  );
+  return <Wordmark width={width} height={maxHeight ?? "auto"} className={className} />;
 }

--- a/components/ui/wordmark.tsx
+++ b/components/ui/wordmark.tsx
@@ -10,6 +10,14 @@
  * Both versions ship with the app (no external CDN per CONTRIBUTING.md).
  * The Tailwind `dark:` class on <html> picks which one is visible — there's
  * no JS hop, so the right variant appears before hydration completes.
+ *
+ * Both images render in the DOM (so the swap is paint-time, no JS hop), but
+ * we deliberately do NOT pass `priority` to next/image: priority emits a
+ * `<link rel="preload">` per Image, and with two images where CSS hides one,
+ * the preloaded hidden variant fires a "preload was not used within a few
+ * seconds" browser warning every page load. The visible image loads eagerly
+ * anyway because it's above the fold; the wordmark is small enough that the
+ * extra preload buys no measurable LCP gain.
  */
 
 import Image from "next/image";
@@ -26,8 +34,6 @@ interface WordmarkProps {
   className?: string;
   /** Inline style overrides merged onto the wrapper. */
   style?: React.CSSProperties;
-  /** Whether the asset is above the fold — controls eager loading. */
-  priority?: boolean;
 }
 
 /**
@@ -35,13 +41,7 @@ interface WordmarkProps {
  * variants based on the active theme. Sizing is controlled by the parent
  * span — pass width / height / style as you would on any block element.
  */
-export function Wordmark({
-  width,
-  height = "auto",
-  className = "",
-  style,
-  priority = false,
-}: WordmarkProps) {
+export function Wordmark({ width, height = "auto", className = "", style }: WordmarkProps) {
   const alt = "PowerDNS-AuthAdmin";
 
   return (
@@ -56,7 +56,6 @@ export function Wordmark({
         alt=""
         width={INTRINSIC_WIDTH}
         height={INTRINSIC_HEIGHT}
-        priority={priority}
         className="block h-auto w-full object-contain dark:hidden"
       />
       <Image
@@ -64,7 +63,6 @@ export function Wordmark({
         alt=""
         width={INTRINSIC_WIDTH}
         height={INTRINSIC_HEIGHT}
-        priority={priority}
         className="hidden h-auto w-full object-contain dark:block"
       />
     </span>

--- a/docs/02-INSTALLATION.md
+++ b/docs/02-INSTALLATION.md
@@ -1,15 +1,38 @@
 # Installation
 
-Run PowerDNS-AuthAdmin in production with Docker Compose. The app is one image —
-[`ghcr.io/powerdns-authadmin/powerdns-authadmin`](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/pkgs/container/powerdns-authadmin) —
-and runs on **SQLite** or **Postgres**. Database migrations and the first-run
-admin seed happen automatically on boot, so the container comes up ready to use.
+Two supported install paths:
 
-Four steps: **pick a database → create `.env` → write `docker-compose.yml` → start.**
+| Path                                       | Use when                                                                                | Skip to                                          |
+| ------------------------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **A — Docker** (recommended for prod)      | You want a single image, scheduler-friendly health checks, auto-migrate on boot.        | [§ Docker install](#a--docker-install)           |
+| **B — From source** (build & run natively) | You can't (or won't) run Docker, you're packaging for systemd/PM2, or doing first dive. | [§ From-source install](#b--from-source-install) |
+
+Either path runs on **SQLite** (one file, single instance) or **Postgres**
+(any number of replicas + Redis). Database migrations + the first-run admin
+seed happen automatically — the install comes up ready to use.
+
+> The two database backends do **not** share a migration history — switching
+> later is a fresh install. Pick one now.
+
+|              | **SQLite**                                     | **Postgres**                                                                                    |
+| ------------ | ---------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Use when     | one instance — homelab, evaluation, small team | multiple instances, or you want a managed DB                                                    |
+| Storage      | one file in a Docker volume / on the host      | a `postgres` service (or your own DB)                                                           |
+| Replicas > 1 | ❌                                             | ✅ (also set `REDIS_URL` — see [High availability](../README.md#high-availability-replicas--1)) |
+
+After install, both paths land at [§ First login](#first-login) and
+[§ Behind a reverse proxy](#behind-a-reverse-proxy).
 
 ---
 
-## Before you start
+## A — Docker install
+
+Production-recommended. The app is one image —
+[`ghcr.io/powerdns-authadmin/powerdns-authadmin`](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/pkgs/container/powerdns-authadmin) —
+booted from a single `docker-compose.yml`. Five steps:
+**create `.env` secrets → set `APP_URL` → write `docker-compose.yml` → start → first login.**
+
+### Before you start
 
 - **Docker** with the Compose plugin — `docker compose version` must be **v2+**.
 - A directory to hold your two files (`.env` + `docker-compose.yml`). Everything
@@ -19,20 +42,7 @@ Four steps: **pick a database → create `.env` → write `docker-compose.yml` �
   mkdir powerdns-authadmin && cd powerdns-authadmin
   ```
 
-### Which database?
-
-|              | **SQLite**                                     | **Postgres**                                                                                    |
-| ------------ | ---------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| Use when     | one instance — homelab, evaluation, small team | multiple instances, or you want a managed DB                                                    |
-| Storage      | one file in a Docker volume                    | a `postgres` service (or your own DB)                                                           |
-| Replicas > 1 | ❌                                             | ✅ (also set `REDIS_URL` — see [High availability](../README.md#high-availability-replicas--1)) |
-
-> The two database backends do **not** share a migration history — switching
-> later is a fresh install. Pick one now.
-
----
-
-## 1. Create `.env` (secrets)
+### 1. Create `.env` (secrets)
 
 Two secrets are **required** and must be unique to your deployment. This command
 generates them, picks a bootstrap admin password, and writes `.env`. **Run it
@@ -42,7 +52,6 @@ once.**
 {
   echo "APP_SECRET_KEY=$(openssl rand -base64 32)"
   echo "APP_ENCRYPTION_KEY=$(openssl rand -base64 32)"
-  echo "APP_URL=https://dns.example.com"
   echo "BOOTSTRAP_ADMIN_EMAIL=admin@example.com"
   echo "BOOTSTRAP_ADMIN_PASSWORD=$(openssl rand -base64 18)"
   # Postgres only — delete this line if you chose SQLite:
@@ -51,17 +60,15 @@ once.**
 chmod 600 .env
 ```
 
-Then edit `.env`: set **`APP_URL`** to your real public URL and
-**`BOOTSTRAP_ADMIN_EMAIL`** to your address. Note the generated
-`BOOTSTRAP_ADMIN_PASSWORD` — you'll use it for the first login (and change it
-immediately).
+Edit `.env` and set **`BOOTSTRAP_ADMIN_EMAIL`** to your address. Note the
+generated `BOOTSTRAP_ADMIN_PASSWORD` — you'll use it for the first login (and
+change it immediately).
 
-| Variable                              | Purpose                                                      | Constraint                     |
-| ------------------------------------- | ------------------------------------------------------------ | ------------------------------ |
-| `APP_SECRET_KEY`                      | Signs sessions, CSRF tokens, API-token HMACs                 | ≥ 32 characters                |
-| `APP_ENCRYPTION_KEY`                  | Encrypts stored PowerDNS API keys, OIDC secrets, MFA secrets | base64 decoding to ≥ 32 bytes  |
-| `APP_URL`                             | Public, browser-visible URL (no trailing slash)              | e.g. `https://dns.example.com` |
-| `BOOTSTRAP_ADMIN_EMAIL` / `_PASSWORD` | The first admin account (set together)                       | password ≥ 12 chars            |
+| Variable                              | Purpose                                                      | Constraint                    |
+| ------------------------------------- | ------------------------------------------------------------ | ----------------------------- |
+| `APP_SECRET_KEY`                      | Signs sessions, CSRF tokens, API-token HMACs                 | ≥ 32 characters               |
+| `APP_ENCRYPTION_KEY`                  | Encrypts stored PowerDNS API keys, OIDC secrets, MFA secrets | base64 decoding to ≥ 32 bytes |
+| `BOOTSTRAP_ADMIN_EMAIL` / `_PASSWORD` | The first admin account (set together)                       | password ≥ 12 chars           |
 
 > ⚠️ **Generate the two keys once and never change them.** Rotating
 > `APP_ENCRYPTION_KEY` makes every stored PowerDNS API key, OIDC secret, and MFA
@@ -74,11 +81,42 @@ Compose loads `.env` automatically, so the same values are reused on every `up`,
 
 ---
 
-## 2. Write `docker-compose.yml`
+### 2. Set `APP_URL`
+
+**`APP_URL` must match the URL the browser uses to reach the app — exact scheme,
+host, and port.** Append it to `.env`:
+
+```sh
+echo "APP_URL=https://dns.example.com" >> .env   # ← your real public URL
+```
+
+| You access the app at…                 | Set `APP_URL` to          |
+| -------------------------------------- | ------------------------- |
+| `https://dns.example.com`              | `https://dns.example.com` |
+| `http://10.0.0.5:3000` (LAN, no TLS)   | `http://10.0.0.5:3000`    |
+| `http://localhost:3000` (local docker) | `http://localhost:3000`   |
+
+No trailing slash. If you sit behind a reverse proxy, this is the **public**
+URL, not the upstream `app:3000`.
+
+> ⚠️ **Why this matters.** The session and CSRF cookies are scoped to
+> `APP_URL`'s host. If it doesn't match the URL in your browser's address bar,
+> the browser **silently rejects** the cookie (DevTools shows
+> `Cookie "pda_csrf" has been rejected for invalid domain`) and sign-in fails
+> with no useful error. The same value also builds OIDC redirect URIs,
+> password-reset email links, and the CSP origin allowlist — getting it wrong
+> breaks all three.
+>
+> The login page detects a mismatch on render and shows an inline error, so you
+> won't have to hunt the DevTools console.
+
+---
+
+### 3. Write `docker-compose.yml`
 
 Pick the block matching your database choice.
 
-### Option A — SQLite
+#### Option A — SQLite
 
 ```yaml
 # docker-compose.yml
@@ -100,7 +138,7 @@ volumes:
   app-data:
 ```
 
-### Option B — Postgres
+#### Option B — Postgres
 
 ```yaml
 # docker-compose.yml
@@ -135,7 +173,7 @@ volumes:
   pg-data:
 ```
 
-### Image tags
+#### Image tags
 
 | Tag            | Points to                                                                     |
 | -------------- | ----------------------------------------------------------------------------- |
@@ -153,7 +191,7 @@ image: ghcr.io/powerdns-authadmin/powerdns-authadmin:1.2
 
 ---
 
-## 3. Start
+### 4. Start
 
 ```sh
 docker compose up -d
@@ -165,7 +203,134 @@ Later, `docker compose down` then `up -d` reuses the same `.env` and data.
 
 ---
 
-## 4. First login
+## B — From-source install
+
+Build the app from a checkout and run it under plain `node`. Same migrations,
+same seed — just no Docker. Suitable for a VM / bare-metal install behind a
+reverse proxy.
+
+### Prerequisites
+
+- **Node.js 24 LTS** — the `.nvmrc` pins the version; `nvm use` picks it up.
+- **npm 10+** (ships with Node 24).
+- **Build toolchain** for the native bindings (`better-sqlite3`, `@node-rs/argon2`):
+  Debian/Ubuntu `apt-get install -y python3 build-essential`, macOS `xcode-select --install`,
+  Alpine `apk add python3 make g++`.
+- **Postgres 14+** if you picked that backend. (Skip for SQLite.)
+
+### 1. Clone and install
+
+```sh
+git clone https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin.git
+cd powerdns-authadmin
+
+nvm use            # reads .nvmrc → Node 24
+npm ci             # exact-pin install (incl. dev deps needed for the build)
+```
+
+### 2. Create `.env`
+
+```sh
+{
+  echo "NODE_ENV=production"
+  echo "APP_SECRET_KEY=$(openssl rand -base64 32)"
+  echo "APP_ENCRYPTION_KEY=$(openssl rand -base64 32)"
+  echo "BOOTSTRAP_ADMIN_EMAIL=admin@example.com"
+  echo "BOOTSTRAP_ADMIN_PASSWORD=$(openssl rand -base64 18)"
+  # SQLite (single-file backend):
+  echo "DATABASE_URL=file:./data/powerdns_authadmin.db"
+  # OR Postgres (replace with your real connection string):
+  # echo "DATABASE_URL=postgres://pdns:CHANGEME@127.0.0.1:5432/powerdns_authadmin"
+} > .env
+chmod 600 .env
+mkdir -p data        # only for SQLite
+```
+
+The two secrets follow the same rules as the Docker path: generate once,
+never rotate, back up alongside the DB.
+
+### 3. Set `APP_URL`
+
+Same critical step as the Docker path — see [§ A.2 Set `APP_URL`](#2-set-app_url)
+for the full reasoning. Append the exact browser-visible URL:
+
+```sh
+echo "APP_URL=https://dns.example.com" >> .env   # ← match your address bar exactly
+```
+
+If you're running behind nginx/HAProxy on the same host with TLS terminated by
+the proxy, set `APP_URL` to the public `https://` URL, not `http://localhost:3000`.
+
+### 4. Build
+
+```sh
+set -a; . ./.env; set +a       # export every var in .env into the shell
+npm run build                  # produces .next/standalone + .next/static
+```
+
+`npm run build` runs `next build` against the schema-typed source tree. It's
+the same command Docker runs in the builder stage.
+
+### 5. Migrate, seed, run
+
+```sh
+set -a; . ./.env; set +a
+npm run db:migrate             # applies pending Drizzle migrations
+npm run db:seed                # upserts system roles + bootstrap admin
+
+npm run start                  # → http://localhost:3000
+```
+
+`npm run start` runs `next start` against the `production` build. For an
+unattended install, drop it into systemd (sample unit below).
+
+#### systemd unit
+
+```ini
+# /etc/systemd/system/powerdns-authadmin.service
+[Unit]
+Description=PowerDNS-AuthAdmin
+After=network.target postgresql.service
+Wants=postgresql.service
+
+[Service]
+Type=simple
+User=pda
+WorkingDirectory=/opt/powerdns-authadmin
+EnvironmentFile=/opt/powerdns-authadmin/.env
+# Adjust if node/npm aren't at /usr/bin (e.g. nvm: /home/pda/.nvm/versions/node/v24.x/bin).
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+# Migrations + seed are idempotent — running on every start is safe.
+ExecStartPre=/usr/bin/npm run db:migrate --silent
+ExecStartPre=/usr/bin/npm run db:seed --silent
+ExecStart=/usr/bin/npm run start --silent
+Restart=on-failure
+RestartSec=5s
+# Hardening (see man systemd.exec):
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/opt/powerdns-authadmin/data
+PrivateTmp=true
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```sh
+sudo useradd -r -s /usr/sbin/nologin pda
+sudo chown -R pda:pda /opt/powerdns-authadmin
+sudo systemctl daemon-reload
+sudo systemctl enable --now powerdns-authadmin
+sudo journalctl -fu powerdns-authadmin    # tail logs
+```
+
+Upgrade later with `git pull && npm ci && npm run build && systemctl restart
+powerdns-authadmin` — migrations run on the next start.
+
+---
+
+## First login
 
 Open `APP_URL`, sign in as `BOOTSTRAP_ADMIN_EMAIL` with the bootstrap password,
 and set a new password when prompted (the bootstrap admin is flagged
@@ -183,22 +348,129 @@ ensures that account exists and never clobbers an existing one.
 
 ### Behind a reverse proxy
 
-Terminate TLS at your proxy (nginx, Caddy, Traefik, a cloud LB) and forward to
-the app's port 3000. Two things matter:
+Terminate TLS at your proxy (nginx, HAProxy, Caddy, Traefik, a cloud LB) and
+forward to the app's port 3000. Three things must line up:
 
-1. **`APP_URL` is the public URL** — it builds OIDC redirect URIs, email links,
-   and cookie/CSP origins. A wrong value breaks SSO and cookies.
-2. **The proxy must set `X-Forwarded-For` / `X-Real-IP`** to the real client IP
-   (and _overwrite_ any client-supplied value, never append). The app always
-   trusts these for audit + rate limiting — there is no `TRUST_PROXY` toggle.
+1. **`APP_URL` is the public, browser-visible URL** — `https://dns.example.com`,
+   not the upstream `http://app:3000`. It builds OIDC redirect URIs, email
+   links, cookie scope, and the CSP origin. The login page shows an inline
+   error if it doesn't match the address bar (see [§ A.2](#2-set-app_url)).
+2. **`X-Forwarded-Proto` and `X-Forwarded-Host`** so the app reconstructs the
+   real public origin (and the APP_URL mismatch detector doesn't false-positive
+   on the upstream hostname).
+3. **`X-Forwarded-For` / `X-Real-IP` must be the real client IP** — the proxy
+   sets/overwrites them, never appends. The app trusts these for audit + rate
+   limiting; there is no `TRUST_PROXY` toggle.
 
-Minimal Caddy example:
+#### nginx
+
+```nginx
+# /etc/nginx/sites-available/powerdns-authadmin
+upstream pda_upstream {
+    server 127.0.0.1:3000;
+    keepalive 32;
+}
+
+# HTTP → HTTPS redirect.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name dns.example.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name dns.example.com;
+
+    # TLS — Let's Encrypt via certbot, or your own cert chain.
+    ssl_certificate     /etc/letsencrypt/live/dns.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/dns.example.com/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+    # Modest upload cap — zone imports + uploaded brand logos.
+    client_max_body_size 4m;
+
+    location / {
+        proxy_pass http://pda_upstream;
+        proxy_http_version 1.1;
+
+        # Public-URL reconstruction (see §3 above).
+        proxy_set_header Host                $host;
+        proxy_set_header X-Forwarded-Host    $host;
+        proxy_set_header X-Forwarded-Proto   $scheme;
+
+        # Client IP for audit + rate limiting (§3 above).
+        # nginx automatically overwrites X-Real-IP — that's the secure default;
+        # don't `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;`
+        # because $proxy_add_x_forwarded_for APPENDS to any client-sent value.
+        proxy_set_header X-Real-IP           $remote_addr;
+        proxy_set_header X-Forwarded-For     $remote_addr;
+
+        # SSE health/realtime endpoints — disable buffering and long timeouts.
+        proxy_buffering    off;
+        proxy_read_timeout 5m;
+        proxy_send_timeout 5m;
+
+        # WebSocket / HTTP upgrade headers (future-proofing; harmless today).
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+```
+
+`sudo nginx -t && sudo systemctl reload nginx` and you're live. With this in
+place, set `APP_URL=https://dns.example.com` (not `http://localhost:3000`).
+
+#### HAProxy
+
+```haproxy
+# /etc/haproxy/haproxy.cfg (excerpt — slot into your global/defaults)
+frontend pda_https
+    bind *:443 ssl crt /etc/haproxy/certs/dns.example.com.pem alpn h2,http/1.1
+    bind *:80
+    http-request redirect scheme https code 301 unless { ssl_fc }
+
+    # Set the headers the app uses to reconstruct the public origin.
+    http-request set-header X-Forwarded-Proto https if { ssl_fc }
+    http-request set-header X-Forwarded-Proto http  if !{ ssl_fc }
+    http-request set-header X-Forwarded-Host  %[req.hdr(host)]
+
+    # Overwrite client IP headers — never trust the caller's value.
+    http-request del-header  X-Forwarded-For
+    http-request del-header  X-Real-IP
+    http-request set-header  X-Forwarded-For %[src]
+    http-request set-header  X-Real-IP       %[src]
+
+    default_backend pda_app
+
+backend pda_app
+    option forwardfor      # disabled — we already set X-Forwarded-For above
+    server pda 127.0.0.1:3000 check
+    timeout server  5m     # generous: SSE realtime streams stay open
+```
+
+HAProxy expects the cert as a combined PEM (`cat fullchain.pem privkey.pem >
+/etc/haproxy/certs/dns.example.com.pem`). `haproxy -c -f /etc/haproxy/haproxy.cfg`
+checks the config; `systemctl reload haproxy` applies it.
+
+#### Caddy (minimal)
 
 ```caddy
 dns.example.com {
-    reverse_proxy app:3000
+    reverse_proxy 127.0.0.1:3000 {
+        header_up X-Forwarded-Proto {scheme}
+        header_up X-Forwarded-Host  {host}
+        # Caddy already sets X-Forwarded-For / X-Real-IP correctly.
+    }
 }
 ```
+
+Caddy auto-provisions Let's Encrypt certs on first hit — no `ssl_certificate`
+plumbing needed.
 
 ### Secrets from files (Docker / Kubernetes secrets)
 

--- a/docs/07-RBAC.md
+++ b/docs/07-RBAC.md
@@ -11,18 +11,25 @@ permission set is the union of a user's assignments that apply in context.
 
 ## The five system roles
 
-Seeded on first boot and protected from deletion. Each builds on the previous:
+Seeded on first boot and protected from deletion. Each builds on the previous —
+the description shown here is the one seeded into the `roles.description`
+column, surfaced verbatim on the Roles list and detail pages.
 
-| Role            | For                 | Can, in addition to the role above…                                                                                         |
-| --------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| **Read Only**   | Auditors, observers | View zones, records, DNSSEC, metadata, teams, users, roles, servers, settings; use templates; manage own API tokens (read). |
-| **Zone Editor** | Record editors      | Create/update/delete **records**; create/delete own API tokens.                                                             |
-| **Operator**    | Day-to-day admins   | Create/update/delete/import/export **zones**; write metadata; manage templates.                                             |
-| **Team Owner**  | Team leads          | Configure DNSSEC; manage TSIG + autoprimaries; update team + manage members.                                                |
-| **Super Admin** | Platform admins     | Everything: users, roles, teams, servers, settings, audit, OIDC, all API tokens.                                            |
+| Role            | Seeded description                                                                          | Permissions, in addition to the role above…                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **Read Only**   | View access to assigned zones. No changes. Useful for auditors and observers.               | View zones, records, DNSSEC, metadata, teams, users, roles, servers, settings; use templates; manage own API tokens (read). |
+| **Zone Editor** | Edit records on assigned zones. Cannot create or delete zones.                              | Create/update/delete **records**; create/delete own API tokens.                                                             |
+| **Operator**    | Day-to-day zone and record administration within a team. No DNSSEC or member management.    | Create/update/delete/import/export **zones**; write metadata; manage templates.                                             |
+| **Team Owner**  | Full control of a team's zones and members. Cannot manage other teams or app-wide settings. | Configure DNSSEC; manage TSIG + autoprimaries; update team + manage members.                                                |
+| **Super Admin** | Full access to everything: users, roles, servers, settings, audit.                          | Everything: users, roles, teams, servers, settings, audit, OIDC, all API tokens.                                            |
 
 The seed asserts Super Admin contains every permission, so a new permission added
-to the codebase is always held by Super Admin.
+to the codebase is always held by Super Admin. The seeded descriptions are owned
+by `lib/rbac/default-roles.ts`; edits there apply on next boot via `upsertRole`.
+
+Custom roles carry an optional free-text description too — set it on the create
+or edit form. It's shown verbatim on the Roles list and detail pages and surfaces
+naturally as "what does this role do?" context for newer operators.
 
 ## Permission vocabulary
 

--- a/docs/10-TROUBLESHOOTING.md
+++ b/docs/10-TROUBLESHOOTING.md
@@ -40,6 +40,18 @@ the runtime env, or the deploy didn't override the secrets. Generate real
 - **Reachable but no zones** — confirm `api=yes` and that the API key has access to
   the `server_id` you configured (almost always `localhost`).
 
+## Sign-in does nothing / browser DevTools shows "Cookie pda_csrf has been rejected for invalid domain"
+
+`APP_URL`'s host doesn't match the URL you have in the address bar. The session
+and CSRF cookies are scoped to `APP_URL`'s host, so the browser silently drops
+them on a mismatch and every login submit looks like it just reloads the page.
+
+The login page renders an inline error when this happens. To fix it: set
+`APP_URL` to the **exact** scheme + host + port operators type in their browser
+(e.g. `http://192.168.1.10:3000` if that's how you reach the LAN host, not the
+`http://localhost:3000` from `.env.example`). Restart the app and reload the
+sign-in page.
+
 ## OIDC sign-in problems
 
 - **`redirect_uri` mismatch at the IdP** — register exactly

--- a/lib/auth/app-url-check.test.ts
+++ b/lib/auth/app-url-check.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { detectAppUrlMismatch } from "./app-url-check";
+
+function h(init: Record<string, string>): Headers {
+  return new Headers(init);
+}
+
+describe("detectAppUrlMismatch", () => {
+  it("matches when host + scheme line up exactly", () => {
+    expect(
+      detectAppUrlMismatch(h({ host: "dns.example.com" }), "https://dns.example.com", "https"),
+    ).toEqual({
+      mismatch: false,
+      actualOrigin: "https://dns.example.com",
+      expectedOrigin: "https://dns.example.com",
+    });
+  });
+
+  it("detects the classic 'copied localhost from .env.example' case", () => {
+    // Operator accessed http://192.168.1.10:3000 but APP_URL is localhost:3000.
+    const result = detectAppUrlMismatch(
+      h({ host: "192.168.1.10:3000" }),
+      "http://localhost:3000",
+      "http",
+    );
+    expect(result).toEqual({
+      mismatch: true,
+      actualOrigin: "http://192.168.1.10:3000",
+      expectedOrigin: "http://localhost:3000",
+    });
+  });
+
+  it("uses X-Forwarded-Host + X-Forwarded-Proto when present (behind a proxy)", () => {
+    expect(
+      detectAppUrlMismatch(
+        h({
+          host: "app:3000",
+          "x-forwarded-host": "dns.example.com",
+          "x-forwarded-proto": "https",
+        }),
+        "https://dns.example.com",
+        "http",
+      ),
+    ).toEqual({
+      mismatch: false,
+      actualOrigin: "https://dns.example.com",
+      expectedOrigin: "https://dns.example.com",
+    });
+  });
+
+  it("takes only the first value from chained X-Forwarded headers", () => {
+    expect(
+      detectAppUrlMismatch(
+        h({
+          host: "app:3000",
+          "x-forwarded-host": "dns.example.com, internal-lb",
+          "x-forwarded-proto": "https, http",
+        }),
+        "https://dns.example.com",
+        "http",
+      )?.mismatch,
+    ).toBe(false);
+  });
+
+  it("flags scheme-only mismatches (http vs https)", () => {
+    expect(
+      detectAppUrlMismatch(h({ host: "dns.example.com" }), "https://dns.example.com", "http")
+        ?.mismatch,
+    ).toBe(true);
+  });
+
+  it("flags port-only mismatches", () => {
+    expect(
+      detectAppUrlMismatch(h({ host: "localhost" }), "http://localhost:3000", "http")?.mismatch,
+    ).toBe(true);
+  });
+
+  it("returns null when the Host header is missing (no signal, not a mismatch)", () => {
+    expect(detectAppUrlMismatch(h({}), "http://localhost:3000", "http")).toBeNull();
+  });
+
+  it("returns null when APP_URL is malformed (env.ts should have already failed boot)", () => {
+    expect(detectAppUrlMismatch(h({ host: "anything" }), "::not a url::", "http")).toBeNull();
+  });
+});

--- a/lib/auth/app-url-check.ts
+++ b/lib/auth/app-url-check.ts
@@ -1,0 +1,67 @@
+/**
+ * lib/auth/app-url-check.ts
+ *
+ * Compare the configured `APP_URL` against the request's actual host/scheme.
+ * A mismatch means the browser-set Session + CSRF cookies (scoped to the
+ * `APP_URL` host) get silently rejected by every browser — sign-in just looks
+ * "broken" with no useful console message unless DevTools is open. The login
+ * page surfaces a banner when this returns `mismatch=true` so operators don't
+ * have to dig.
+ *
+ * Not a security control — the cookies stay correctly scoped to the configured
+ * host either way. This is a usability + diagnostic check.
+ *
+ * Pure helper (no DB, no env import) so it's unit-testable. The login page is
+ * the only caller; it passes `env.APP_URL` and the request headers in.
+ */
+
+export interface AppUrlMismatch {
+  mismatch: boolean;
+  /** Origin (scheme://host[:port]) the browser used to reach us. */
+  actualOrigin: string;
+  /** Origin parsed from `env.APP_URL`. */
+  expectedOrigin: string;
+}
+
+/**
+ * Reconstruct the browser-visible origin from request headers, honouring the
+ * common reverse-proxy headers (`X-Forwarded-Host`, `X-Forwarded-Proto`).
+ * Returns `null` when we can't determine a host header — that's not a
+ * mismatch, it's "no signal" (avoid false-positive banners).
+ *
+ * @param requestHeaders the incoming request's `Headers` (Next.js `headers()`)
+ * @param appUrl         the configured `env.APP_URL`
+ * @param defaultProto   scheme to assume when X-Forwarded-Proto is absent.
+ *                       Production callers should pass "https"; dev passes "http".
+ */
+export function detectAppUrlMismatch(
+  requestHeaders: Headers,
+  appUrl: string,
+  defaultProto: "http" | "https",
+): AppUrlMismatch | null {
+  const forwardedHost = requestHeaders.get("x-forwarded-host");
+  const host = forwardedHost ?? requestHeaders.get("host");
+  if (!host) return null;
+
+  const forwardedProto = requestHeaders.get("x-forwarded-proto");
+  const proto = (forwardedProto?.split(",")[0]?.trim() ?? defaultProto).toLowerCase();
+
+  // Take only the first value from XFF lists (proxies sometimes chain).
+  const firstHost = host.split(",")[0]?.trim() ?? host;
+  const actualOrigin = `${proto}://${firstHost}`;
+
+  let expectedOrigin: string;
+  try {
+    expectedOrigin = new URL(appUrl).origin;
+  } catch {
+    // env.ts already rejects a malformed APP_URL at boot, so we shouldn't get
+    // here — but if we do, no banner beats a crash.
+    return null;
+  }
+
+  return {
+    mismatch: actualOrigin !== expectedOrigin,
+    actualOrigin,
+    expectedOrigin,
+  };
+}

--- a/lib/auth/mfa-compliance.test.ts
+++ b/lib/auth/mfa-compliance.test.ts
@@ -77,14 +77,21 @@ describe("checkMfaCompliance — SSO exemption + per-user override", () => {
     ).toEqual({ compliant: true });
   });
 
-  it("override=true requires MFA even with no role requiring it (and even for SSO)", () => {
-    expect(
-      checkMfaCompliance({ totpEnrolled: false, mfaOverride: true, ssoOnly: true }, []),
-    ).toEqual({
+  it("override=true requires MFA for local accounts with no role requiring it", () => {
+    expect(checkMfaCompliance({ totpEnrolled: false, mfaOverride: true }, [])).toEqual({
       compliant: false,
       reason: "no-mfa-enrolled",
       requiringRoleSlugs: ["(per-user override)"],
     });
+  });
+
+  it("SSO-only accounts stay exempt even with a stale override=true (legacy rows aren't lockouts)", () => {
+    // The admin UI hides the override for SSO users and the PATCH endpoint
+    // rejects setting it to true; this guards against legacy DB rows that
+    // were written before that policy landed.
+    expect(
+      checkMfaCompliance({ totpEnrolled: false, mfaOverride: true, ssoOnly: true }, []),
+    ).toEqual({ compliant: true });
   });
 
   it("override=true is satisfied once TOTP is enrolled", () => {

--- a/lib/auth/mfa-compliance.ts
+++ b/lib/auth/mfa-compliance.ts
@@ -27,14 +27,18 @@ export interface UserMfaState {
   /** Has at least one TOTP enrollment. */
   totpEnrolled: boolean;
   /**
-   * SSO-only account (no local password). Under "inherit" these are exempt —
-   * the IdP is the second-factor authority. Default false.
+   * SSO-only account (no local password). The IdP is the second-factor
+   * authority — the in-app TOTP flow renders read-only for SSO and the
+   * admin UI hides the per-user MFA override for them, so SSO accounts
+   * are ALWAYS exempt from this gate (only `mfaOverride === false`
+   * short-circuits earlier — same outcome). Default false.
    */
   ssoOnly?: boolean;
   /**
-   * Per-user MFA override that SUPERSEDES roles (and, when set, the SSO
-   * exemption): `true` = always require TOTP, `false` = never require,
-   * `null`/`undefined` = inherit (SSO-exempt, else role-based).
+   * Per-user MFA override: `true` = always require TOTP, `false` = never
+   * require, `null`/`undefined` = inherit (role-based). The `true` value is
+   * inert for SSO-only users (see `ssoOnly`); the admin UI prevents writing
+   * it and `checkMfaCompliance` ignores legacy rows that carry it.
    */
   mfaOverride?: boolean | null;
 }
@@ -67,12 +71,20 @@ export function checkMfaCompliance(
   // The per-user override wins over everything — roles AND the SSO exemption.
   if (user.mfaOverride === false) return { compliant: true };
 
+  // SSO-only users can't enroll TOTP in this app: the IdP is the second-factor
+  // authority. Forcing MFA on an SSO account would just deadlock it (the
+  // /profile TOTP section renders read-only for SSO). The admin UI hides the
+  // per-user override for SSO users and the PATCH endpoint refuses to set it
+  // to `true`, but we still defend against legacy rows that carried that
+  // setting before the policy landed — treat them as compliant rather than
+  // lock the operator out.
+  if (user.ssoOnly) return { compliant: true };
+
   let requiringRoleSlugs: string[];
   if (user.mfaOverride === true) {
     requiringRoleSlugs = ["(per-user override)"];
   } else {
-    // Inherit: SSO accounts are exempt; otherwise any role marked requiresMfa.
-    if (user.ssoOnly) return { compliant: true };
+    // Inherit: any role marked requiresMfa.
     const requiringRoles = roles.filter((r) => r.requiresMfa);
     if (requiringRoles.length === 0) return { compliant: true };
     requiringRoleSlugs = requiringRoles.map((r) => r.slug ?? "(unnamed role)").sort();

--- a/lib/auth/require-user.ts
+++ b/lib/auth/require-user.ts
@@ -24,6 +24,7 @@ import { env } from "@/lib/env";
 import { UnauthorizedError, ForbiddenError } from "@/lib/errors";
 import type { Subject } from "@/lib/rbac/ability";
 import { listRoleMfaStatesForUser } from "@/lib/db/repositories/roles";
+import { checkMfaCompliance } from "./mfa-compliance";
 import { getCurrentUser, type AuthenticatedRequest } from "./get-current-user";
 
 /** Routes a non-compliant user (forced-MFA-not-enrolled, mustChangePassword) is
@@ -149,11 +150,31 @@ export async function requireUserForPage(
     // could click around freely until the next full reload. We rerun the same
     // gate at the page level (cheap; `requireUser` already loaded the user).
     const result = await requireUser({ ...opts, skipComplianceGate: true });
-    const hdrs = await headers();
-    const pathname = hdrs.get("x-pathname") ?? "/";
-    const allowed = COMPLIANCE_ALLOWLIST.some((p) => pathname.startsWith(p));
-    if (!allowed && result.user.mustChangePassword) {
-      redirect("/profile?must-change-password=1");
+    if (result.source === "session") {
+      const hdrs = await headers();
+      const pathname = hdrs.get("x-pathname") ?? "/";
+      const allowed = COMPLIANCE_ALLOWLIST.some((p) => pathname.startsWith(p));
+      if (!allowed) {
+        // MFA gate is checked first to match `evaluateSessionCompliance` —
+        // an operator who is both non-enrolled AND flagged for a password
+        // change is sent to the more security-critical remediation first.
+        const roleMfaStates = await listRoleMfaStatesForUser(result.user.id);
+        const mfa = checkMfaCompliance(
+          {
+            totpEnrolled: result.user.totpSecretEncrypted !== null,
+            ssoOnly: result.user.passwordHash === null,
+            mfaOverride: result.user.mfaRequired,
+          },
+          roleMfaStates,
+        );
+        if (!mfa.compliant) {
+          const because = encodeURIComponent(mfa.requiringRoleSlugs.join(","));
+          redirect(`/profile?mfa-required=1&because=${because}`);
+        }
+        if (result.user.mustChangePassword) {
+          redirect("/profile?must-change-password=1");
+        }
+      }
     }
     return result;
   } catch (err) {

--- a/lib/auth/session-compliance.test.ts
+++ b/lib/auth/session-compliance.test.ts
@@ -67,13 +67,15 @@ describe("evaluateSessionCompliance", () => {
       ).toEqual({ ok: true });
     });
 
-    it("override=true overrides the SSO exemption (blocks SSO user with no TOTP)", () => {
+    it("SSO-only accounts stay exempt even with a stale override=true (legacy rows aren't lockouts)", () => {
+      // Per lib/auth/mfa-compliance.ts: the admin UI hides + the API rejects
+      // setting mfaOverride=true for SSO users; this guards legacy rows.
       expect(
         evaluateSessionCompliance(
           base({ totpEnrolled: false, ssoOnly: true, mfaOverride: true }),
           NO_ROLES,
         ),
-      ).toEqual({ ok: false, reason: "mfa" });
+      ).toEqual({ ok: true });
     });
 
     it("treats mfaOverride === undefined the same as null (inherit)", () => {

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -19,6 +19,7 @@
  */
 
 import "server-only";
+import { randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { z } from "zod";
 
@@ -349,11 +350,11 @@ const envSchema = z.object({
     .pipe(z.boolean())
     .default(true),
   /**
-   * Optional bearer token required to scrape `/metrics`. When unset,
-   * the endpoint is open (network-level access control is the
-   * operator's responsibility — typical Prometheus deployments scrape
-   * over a private network). When set, requests must include
-   * `Authorization: Bearer <token>` matching this value.
+   * Bearer token required to scrape `/metrics`. Pin one in env for stable
+   * scrape configs; if unset (and METRICS_ENABLED is true), the app
+   * generates a random 32-char token on every boot and logs it once so the
+   * endpoint is never accidentally open on a shared LAN. To opt out of
+   * /metrics entirely, set METRICS_ENABLED=false.
    */
   METRICS_TOKEN: z.string().min(16).optional(),
 
@@ -588,6 +589,27 @@ function parseEnv(): Env {
   // design (they're long enough and don't match the obvious-junk regex),
   // so this check is the only thing standing between the deploy and a
   // fixed shared secret in production.
+  // Auto-generate METRICS_TOKEN when the operator didn't pin one. /metrics is
+  // a typical scrape target on a private network, but leaving it open in a
+  // shared LAN is the kind of accidental exposure that's easy to never notice.
+  // We default to "always require bearer auth"; if you actively want the
+  // endpoint open, set METRICS_ENABLED=false or pick your own static token.
+  // Skipped during build (placeholders only) and tests (deterministic vars).
+  if (
+    !isBuildPhase &&
+    parsed.METRICS_ENABLED &&
+    !parsed.METRICS_TOKEN &&
+    parsed.NODE_ENV !== "test"
+  ) {
+    const generated = randomBytes(24).toString("base64url"); // 32 url-safe chars
+    parsed.METRICS_TOKEN = generated;
+    console.log(
+      `[env] METRICS_TOKEN not provided, randomly generated instead: ${generated}\n` +
+        "       Scrape with: Authorization: Bearer <token>. Pin it via .env (or set\n" +
+        "       METRICS_ENABLED=false to opt out of the /metrics endpoint).",
+    );
+  }
+
   const placeholderViolations = detectBuildTimePlaceholders({
     APP_SECRET_KEY: parsed.APP_SECRET_KEY,
     APP_ENCRYPTION_KEY: parsed.APP_ENCRYPTION_KEY,


### PR DESCRIPTION
## Summary

Bundles several operator-facing fixes that came out of the same shake-down
session — all touching auth UX, the install path, and the admin Roles surface.
Single PR per the bundle-it ask; full breakdown below.

### 1. APP_URL mismatch — surfaced on the login page

When `env.APP_URL` doesn't match the URL the browser is actually using (the
classic "copied `http://localhost:3000` from `.env.example` but I'm browsing the
LAN host"), Chromium/Firefox **silently reject** the session + CSRF cookies for
an invalid domain. Sign-in just looks "stuck" with no usable error unless
DevTools is open.

- New pure helper `lib/auth/app-url-check.ts` reconstructs the request origin
  (honouring `X-Forwarded-Host` / `X-Forwarded-Proto`) and compares it to
  `env.APP_URL`. Unit-tested.
- `/login` renders an inline error banner with both origins + a link to
  the install doc when they don't match.
- Cookie reasoning + the "rejected for invalid domain" warning are now
  documented in `docs/02-INSTALLATION.md` (its own step) and
  `docs/10-TROUBLESHOOTING.md`.

### 2. Force MFA now mirrors must-change-password (and works)

Password-change enforcement intercepted client-side nav and shook a banner;
forced MFA enrolment did neither — operators could click around freely until
the next full reload. Generalised the single guard:

- Renamed `MustChangePasswordProvider` → `ComplianceGuardProvider` with
  `mfaRequired` + `passwordChangeRequired` flags. Same shake animation, same
  click interception, banner copy adapts.
- `requireUserForPage` now re-checks MFA on every page (mirrors the existing
  password re-check) so soft navs stay gated.

### 3. OIDC users excluded from Force MFA

SSO-only accounts (no local password) have no way to enroll TOTP — the IdP is
the second-factor authority. Forcing MFA on them just deadlocked the account.

- Admin user-detail page hides `<MfaRequiredOverride>` when `passwordHash IS NULL`.
- `PATCH /api/admin/users/:id` rejects setting `mfaRequired=true` for SSO users.
- `checkMfaCompliance` treats SSO + `mfaOverride=true` as compliant (defends
  legacy rows that pre-date this policy). Tests updated.

### 4. Roles — description column

Schema, repo, edit form and seed already carried `description`. Now also:

- Roles list table has a "Description" column (wraps, never truncates,
  per the ask).
- Custom-role detail page renders the description too (was system-only).
- `docs/07-RBAC.md` shows the seeded descriptions inline.

### 5. METRICS_TOKEN auto-generated when not set

`/metrics` was open by default unless an operator pinned a bearer — easy to
miss on a shared LAN. If `METRICS_ENABLED=true` and `METRICS_TOKEN` is unset,
the app now generates a 32-char random token at boot and logs it once:

```
[env] METRICS_TOKEN not provided, randomly generated instead: <token>
```

Pin a stable value in `.env` for scrape configs, or set
`METRICS_ENABLED=false` to disable the endpoint entirely.

### 6. Installation docs split: Docker vs from-source + reverse-proxy examples

`docs/02-INSTALLATION.md` now has two clearly-labelled install paths:
**A — Docker** (the existing flow, unchanged steps) and **B — From source**
(node 24 + `npm ci` + build + migrate/seed/start, plus a systemd unit). The
reverse-proxy section now has working nginx and HAProxy examples that get the
`X-Forwarded-*` headers right (so the APP_URL mismatch detector doesn't
false-positive behind a proxy), alongside the existing Caddy snippet.

### 7. Login page — preload warnings gone

`<Wordmark>` rendered both light + dark PNGs with Next.js `priority`,
emitting two `<link rel="preload">` tags while CSS hid one — browsers warned
on every page render. Dropped `priority`; the visible asset still loads
eagerly above the fold.

## Test plan

Local validation gate (all green):

- [x] `act -j static-checks` — ESLint, prettier, tsc
- [x] `act -j test` — unit suite, 893 passes (+ 9 skipped)
- [x] `npm run build` — production build clean
- [x] `npm run test:integration` — 203 passes (+ 6 skipped)

Manual verification recommended on the PR reviewer's side:

- [ ] Boot a fresh stack with `APP_URL=http://localhost:3000` and access via
      `127.0.0.1:3000` → login page shows the mismatch banner.
- [ ] On a non-OIDC user with `requiresMfa=true` role, click any nav link →
      banner shakes, no navigation.
- [ ] On an OIDC user, /admin/users/:id no longer shows the per-user MFA override.
- [ ] Roles list shows the seeded descriptions in the new column.
- [ ] App boots without `METRICS_TOKEN` set → log line announces the generated
      token; `curl -H "Authorization: Bearer <that>" /metrics` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)