### PR TITLE
fix(zones): auto-select default template for clustered/grouped primaries

### DIFF
--- a/app/(app)/zones/_components/create-zone-form.tsx
+++ b/app/(app)/zones/_components/create-zone-form.tsx
@@ -40,12 +40,14 @@ export interface BackendOption {
   /** server slug OR cluster slug, qualified by `kind`. */
   slug: string;
   /**
-   * For kind=server, the underlying `pdns_servers.id` - used to match a
-   * template's `defaultForPrimaryIds` so we can preselect a default
-   * template the moment the operator picks one of its primaries.
-   * Clusters don't carry a primary id; the field stays undefined.
+   * Writable primary ids (`pdns_servers.id`) this backend creates zones
+   * through: a single id for a standalone primary, one per peer for a
+   * cluster. The form matches these against a template's
+   * `defaultForPrimaryIds` to preselect a default template - so a cluster
+   * auto-selects a template registered as the default for any of its
+   * member primaries, not just a standalone server.
    */
-  id?: string;
+  primaryIds: string[];
   name: string;
   /** Only meaningful for kind=server. Clusters never carry isDefault. */
   isDefault: boolean;
@@ -151,21 +153,30 @@ export function CreateZoneForm(props: Props) {
   const [kind, setKind] = useState<(typeof KINDS)[number]["value"]>("Native");
 
   // Compute the template the form should pre-apply for a given backend
-  // selection - first template whose `defaultForPrimaryIds` lists the
-  // selected primary's id wins. Clusters have no primary id, so no
-  // default ever auto-selects for cluster backends.
+  // selection - the first template registered as the default for any
+  // primary the backend writes through wins (a standalone primary exposes
+  // one such id; a cluster exposes one per peer). First match wins across
+  // templates, in their name sort order.
   function defaultTemplateIdFor(selection: { kind: "server" | "cluster"; slug: string } | null) {
-    if (selection?.kind !== "server") return "";
-    const opt = props.backends.find((b) => b.kind === "server" && b.slug === selection.slug);
-    const primaryId = opt?.id;
-    if (!primaryId) return "";
-    const match = props.templates.find((t) => t.defaultForPrimaryIds.includes(primaryId));
+    if (!selection) return "";
+    const backend = props.backends.find(
+      (b) => b.kind === selection.kind && b.slug === selection.slug,
+    );
+    const backendPrimaryIds = backend?.primaryIds ?? [];
+    if (backendPrimaryIds.length === 0) return "";
+    const match = props.templates.find((template) =>
+      template.defaultForPrimaryIds.some((primaryId) => backendPrimaryIds.includes(primaryId)),
+    );
     return match?.id ?? "";
   }
 
-  const initialBackendSelection = defaultBackendKey ? parseKey(defaultBackendKey) : null;
+  // Resolve the initial template once (lazy initializer - off the hot render
+  // path): an explicit `?template=` deep-link wins; otherwise fall back to the
+  // default template registered for the initially-selected backend.
   const [templateId, setTemplateId] = useState<string>(
-    props.initialTemplateId ?? defaultTemplateIdFor(initialBackendSelection),
+    () =>
+      props.initialTemplateId ??
+      (defaultBackendKey ? defaultTemplateIdFor(parseKey(defaultBackendKey)) : ""),
   );
 
   // Track whether the operator has manually touched the template picker

--- a/app/(app)/zones/new/page.tsx
+++ b/app/(app)/zones/new/page.tsx
@@ -43,7 +43,7 @@ export default async function NewZonePage({
       ? {
           kind: "cluster",
           slug: b.cluster.slug,
-          name: `${b.cluster.name} · ${b.peers.length}-peer cluster`,
+          name: `${b.cluster.name} · ${describeGroupTopology(b.peers.length, b.secondaries.length)}`,
           isDefault: false,
           primaryIds: b.peers.map((peer) => peer.id),
           secondaries: [],
@@ -101,4 +101,23 @@ export default async function NewZonePage({
       />
     </div>
   );
+}
+
+/**
+ * Human label for a group backend (a `pdns_clusters` row), shown in the
+ * backend picker. Both topologies are stored as a cluster, but they read very
+ * differently to an operator:
+ *
+ *   - 2+ writable peers        → a true multi-primary cluster ("3-peer cluster")
+ *   - 1 primary + secondaries  → a primary + secondaries group
+ *                                ("primary + 2 secondaries")
+ *   - 1 primary, no secondaries → just a primary that happens to sit in a group
+ *
+ * Calling a single primary + secondary pair a "1-peer cluster" (the old label)
+ * was misleading - the operator sees the count of write targets, not mirrors.
+ */
+function describeGroupTopology(peerCount: number, secondaryCount: number): string {
+  if (peerCount >= 2) return `${peerCount}-peer cluster`;
+  if (secondaryCount === 0) return "primary";
+  return `primary + ${secondaryCount} ${secondaryCount === 1 ? "secondary" : "secondaries"}`;
 }

--- a/app/(app)/zones/new/page.tsx
+++ b/app/(app)/zones/new/page.tsx
@@ -33,10 +33,11 @@ export default async function NewZonePage({
 
   // Collapse SelectableBackend[] into the form's option shape. A cluster
   // is ONE option (not its peers) - the write_strategy picks the peer at
-  // submit time on the server. Standalone-primary entries also carry the
-  // primary's id (so the form can match against template
-  // `defaultForPrimaryIds`) and its active secondaries (so the BACKEND
-  // section can render them as children).
+  // submit time on the server. Every entry carries the writable primary
+  // ids it creates zones through (the standalone primary's own id, or each
+  // cluster peer's id) so the form can match against template
+  // `defaultForPrimaryIds`; standalone entries also carry their active
+  // secondaries so the BACKEND section can render them as children.
   const backendOptions: BackendOption[] = backends.map((b) =>
     b.kind === "cluster"
       ? {
@@ -44,14 +45,15 @@ export default async function NewZonePage({
           slug: b.cluster.slug,
           name: `${b.cluster.name} · ${b.peers.length}-peer cluster`,
           isDefault: false,
+          primaryIds: b.peers.map((peer) => peer.id),
           secondaries: [],
         }
       : {
           kind: "server",
-          id: b.server.id,
           slug: b.server.slug,
           name: b.server.name,
           isDefault: b.server.isDefault,
+          primaryIds: [b.server.id],
           secondaries: b.secondaries.map((s) => ({ slug: s.slug, name: s.name })),
         },
   );

--- a/lib/provisioning/apply.ts
+++ b/lib/provisioning/apply.ts
@@ -317,36 +317,45 @@ export async function applyProvisioning(config: ProvisioningConfig): Promise<Pro
       if (row) serverIdsBySlug.set(row.slug, row.id);
       result.pdnsServersUpserted += 1;
     }
+  }
 
-    // Resolve zone-template `default_for_primary_slugs` (server slugs) into
-    // ids. Pull in any referenced server already in the DB but absent from
-    // this file.
-    if (config.zone_templates) {
-      const hasUnknown = config.zone_templates
-        .flatMap((z) => z.default_for_primary_slugs)
-        .some((slug) => !serverIdsBySlug.has(slug));
-      if (hasUnknown) {
-        const existing = await db
-          .select({ id: pdnsServers.id, slug: pdnsServers.slug })
-          .from(pdnsServers);
-        for (const p of existing) {
-          if (!serverIdsBySlug.has(p.slug)) serverIdsBySlug.set(p.slug, p.id);
-        }
+  // Resolve each zone template's `default_for_primary_slugs` (server slugs) into
+  // the `pdns_servers.id`s the create-zone form matches against to auto-select a
+  // default template. This MUST run whenever the file declares zone templates -
+  // even if it omits the `pdns_servers` section (servers added through the UI or
+  // a prior run) - otherwise a templates-only re-provision would leave the column
+  // holding raw slugs that never match a backend id, silently disabling
+  // auto-selection. Primaries referenced by slug but absent from this file are
+  // back-filled from the database.
+  if (config.zone_templates) {
+    const referencedPrimarySlugs = config.zone_templates.flatMap(
+      (template) => template.default_for_primary_slugs,
+    );
+    const hasUnresolvedSlug = referencedPrimarySlugs.some((slug) => !serverIdsBySlug.has(slug));
+    if (hasUnresolvedSlug) {
+      const existingServers = await db
+        .select({ id: pdnsServers.id, slug: pdnsServers.slug })
+        .from(pdnsServers);
+      for (const server of existingServers) {
+        if (!serverIdsBySlug.has(server.slug)) serverIdsBySlug.set(server.slug, server.id);
       }
-      for (const z of config.zone_templates) {
-        if (z.default_for_primary_slugs.length === 0) continue;
-        const ids: string[] = [];
-        for (const slug of z.default_for_primary_slugs) {
-          const id = serverIdsBySlug.get(slug);
-          if (id) ids.push(id);
-          else
-            logger.warn({ template: z.slug, slug }, "provisioning.zone-template.unknown-primary");
-        }
-        await db
-          .update(zoneTemplates)
-          .set({ defaultForPrimaryIds: ids, updatedAt: new Date() })
-          .where(eq(zoneTemplates.slug, z.slug));
+    }
+    for (const template of config.zone_templates) {
+      if (template.default_for_primary_slugs.length === 0) continue;
+      const resolvedPrimaryIds: string[] = [];
+      for (const slug of template.default_for_primary_slugs) {
+        const primaryId = serverIdsBySlug.get(slug);
+        if (primaryId) resolvedPrimaryIds.push(primaryId);
+        else
+          logger.warn(
+            { template: template.slug, slug },
+            "provisioning.zone-template.unknown-primary",
+          );
       }
+      await db
+        .update(zoneTemplates)
+        .set({ defaultForPrimaryIds: resolvedPrimaryIds, updatedAt: new Date() })
+        .where(eq(zoneTemplates.slug, template.slug));
     }
   }
 


### PR DESCRIPTION


---

### Follow-up in this PR: clearer backend-picker label

A `pdns_clusters` row backs both a true multi-primary cluster and a primary+secondary group. The picker previously labelled every group `<name> · N-peer cluster` using the writable-peer count, so a primary+secondary pair read as a misleading "1-peer cluster". Now labelled by topology: `3-peer cluster` (2+ peers), `primary + N secondaries` (single primary with mirrors), or `primary` (lone primary in a group).
