### PR TITLE
feat(settings): SETTINGS_RO flag to make the Settings page read-only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,13 @@ BOOTSTRAP_ADMIN_PASSWORD=change-me-now
 # account can no longer change it.
 BOOTSTRAP_ADMIN_RO=false
 
+# Lock the entire admin Settings page (site name, branding, login intro, lockout
+# policy, password-reset toggle) against edits. Intended for a PUBLIC DEMO where
+# visitors may hold a settings-capable role but must not reconfigure the install:
+# with this on, PATCH /api/admin/settings returns 403 for everyone and the form
+# renders read-only. Default false - leave it off for real installs.
+SETTINGS_RO=false
+
 
 # -----------------------------------------------------------------------------
 # First-boot provisioning (ADR-0012)

--- a/app/(app)/admin/settings/_components/settings-form.tsx
+++ b/app/(app)/admin/settings/_components/settings-form.tsx
@@ -22,6 +22,12 @@ interface SettingsFormProps {
     allow_password_reset: boolean;
   };
   canWrite: boolean;
+  /**
+   * True when edits are disabled by the global `SETTINGS_RO` deployment lock
+   * rather than by a missing `settings.write` permission. Only changes which
+   * read-only notice is shown; `canWrite` already reflects the lock.
+   */
+  lockedByPolicy: boolean;
 }
 
 interface ErrorBody {
@@ -41,7 +47,7 @@ const ALLOWED_MIME = new Set([
   "image/webp",
 ]);
 
-export function SettingsForm({ initial, canWrite }: SettingsFormProps) {
+export function SettingsForm({ initial, canWrite, lockedByPolicy }: SettingsFormProps) {
   const router = useRouter();
   const [siteName, setSiteName] = useState(initial.site_name);
   const [brandLogoUrl, setBrandLogoUrl] = useState(initial.brand_logo_url);
@@ -397,6 +403,10 @@ export function SettingsForm({ initial, canWrite }: SettingsFormProps) {
         >
           {saving ? "Saving…" : "Save changes"}
         </button>
+      ) : lockedByPolicy ? (
+        <p className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] px-3 py-2.5 text-xs text-[color:var(--color-fg-muted)]">
+          Settings are read-only on this deployment (SETTINGS_RO) and can&apos;t be changed.
+        </p>
       ) : (
         <p className="text-xs text-[color:var(--color-fg-muted)]">
           You have read-only access. The settings.write permission is required to edit.

--- a/app/(app)/admin/settings/page.tsx
+++ b/app/(app)/admin/settings/page.tsx
@@ -13,13 +13,17 @@
 import Link from "next/link";
 import { Database } from "lucide-react";
 import { requireUserForPage } from "@/lib/auth/require-user";
+import { isSettingsReadOnly } from "@/lib/auth/settings-lock";
 import { listAllSettings } from "@/lib/db/repositories/settings";
 import { SETTING_DEFAULTS, type KnownSettingKey } from "@/lib/validators/settings";
 import { SettingsForm } from "./_components/settings-form";
 
 export default async function SettingsPage() {
   const { ability, globalPermissions } = await requireUserForPage({ can: "settings.read" });
-  const canWrite = ability.can("write", "Settings");
+  // SETTINGS_RO locks edits for everyone (demo hardening), even settings.write
+  // holders - so it overrides the RBAC capability when computing edit access.
+  const lockedByPolicy = isSettingsReadOnly();
+  const canWrite = ability.can("write", "Settings") && !lockedByPolicy;
   const canReadAuth = ability.can("read", "Auth");
   const canBackup = globalPermissions.has("system.backup");
 
@@ -76,7 +80,7 @@ export default async function SettingsPage() {
         </p>
       </header>
 
-      <SettingsForm initial={initial} canWrite={canWrite} />
+      <SettingsForm initial={initial} canWrite={canWrite} lockedByPolicy={lockedByPolicy} />
 
       {canBackup ? (
         <section className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] p-5">

--- a/app/api/admin/settings/route.ts
+++ b/app/api/admin/settings/route.ts
@@ -15,6 +15,7 @@ import { appendAudit } from "@/lib/audit/log";
 import { getRequestContext } from "@/lib/client-ip";
 import { requireUser } from "@/lib/auth/require-user";
 import { requireCsrf } from "@/lib/auth/csrf";
+import { assertSettingsMutable } from "@/lib/auth/settings-lock";
 import { sanitizeBrandLogoValue } from "@/lib/security/svg";
 import { db } from "@/lib/db";
 import { deleteSetting, listAllSettings, upsertSetting } from "@/lib/db/repositories/settings";
@@ -49,6 +50,8 @@ export async function PATCH(request: Request): Promise<Response> {
   try {
     const { user } = await requireUser({ can: "settings.write" });
     await requireCsrf(request);
+    // Global demo lock - rejects even settings.write holders (SETTINGS_RO).
+    assertSettingsMutable();
 
     let input;
     try {

--- a/lib/auth/settings-lock.test.ts
+++ b/lib/auth/settings-lock.test.ts
@@ -1,0 +1,46 @@
+/**
+ * lib/auth/settings-lock.test.ts
+ *
+ * The Settings RO lock is a pure decision (env flag → allow/deny), so it's
+ * unit-tested in isolation. The route handler that calls it maps the thrown
+ * ForbiddenError to a 403 via the shared error-response layer — that mapping is
+ * covered once in lib/errors; here we only assert the decision itself.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ForbiddenError } from "@/lib/errors";
+
+// Mutable mock env — `mock`-prefixed so vitest's hoisting allows the factory to
+// close over it. Each test sets the one field it cares about in beforeEach.
+const mockEnv: { SETTINGS_RO: boolean } = { SETTINGS_RO: false };
+
+vi.mock("@/lib/env", () => ({ env: mockEnv }));
+
+const { isSettingsReadOnly, assertSettingsMutable } = await import("./settings-lock");
+
+beforeEach(() => {
+  mockEnv.SETTINGS_RO = false;
+});
+
+describe("isSettingsReadOnly", () => {
+  it("is false by default (lock off)", () => {
+    expect(isSettingsReadOnly()).toBe(false);
+  });
+
+  it("is true when the lock is on", () => {
+    mockEnv.SETTINGS_RO = true;
+    expect(isSettingsReadOnly()).toBe(true);
+  });
+});
+
+describe("assertSettingsMutable", () => {
+  it("does not throw when the lock is off", () => {
+    mockEnv.SETTINGS_RO = false;
+    expect(() => assertSettingsMutable()).not.toThrow();
+  });
+
+  it("throws ForbiddenError when the lock is on", () => {
+    mockEnv.SETTINGS_RO = true;
+    expect(() => assertSettingsMutable()).toThrow(ForbiddenError);
+  });
+});

--- a/lib/auth/settings-lock.ts
+++ b/lib/auth/settings-lock.ts
@@ -1,0 +1,35 @@
+/**
+ * lib/auth/settings-lock.ts
+ *
+ * The `SETTINGS_RO` global lock for the admin Settings page. When enabled
+ * (intended for a public demo where visitors may hold a settings-capable role),
+ * every runtime-mutable app setting is frozen: site name, branding, login intro,
+ * support contact, lockout policy, and the password-reset toggle. This stops a
+ * visitor from reconfiguring a shared install without having to strip the
+ * `settings.write` permission from the demo role.
+ *
+ * The lock is a pure env switch - no schema column, no migration - so it is a
+ * no-op unless `SETTINGS_RO=true` and real deployments are entirely unaffected.
+ *
+ * Enforcement lives at the API route handler (the security boundary); the
+ * matching UI affordance (disabled form + notice) is a convenience layer that
+ * calls `isSettingsReadOnly` to avoid dead-end clicks.
+ */
+
+import { env } from "@/lib/env";
+import { ForbiddenError } from "@/lib/errors";
+
+/** Whether the Settings page is globally locked against edits. */
+export function isSettingsReadOnly(): boolean {
+  return env.SETTINGS_RO;
+}
+
+/**
+ * Throw `ForbiddenError` when the Settings page is globally locked. Call this at
+ * every route that mutates app settings, after the permission + CSRF checks.
+ */
+export function assertSettingsMutable(): void {
+  if (isSettingsReadOnly()) {
+    throw new ForbiddenError("Settings are read-only on this deployment and cannot be modified.");
+  }
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -208,6 +208,24 @@ const envSchema = z.object({
     .pipe(z.boolean())
     .default(false),
 
+  /**
+   * Lock the whole admin Settings page against edits. When true, the
+   * runtime-mutable settings (site name, branding, login intro, lockout
+   * policy, password-reset toggle) become read-only for everyone - the
+   * `PATCH /api/admin/settings` route rejects with 403 regardless of
+   * `settings.write`, and the form renders disabled with a notice.
+   *
+   * Intended for a publicly-hosted demo where visitors may hold a
+   * settings-capable role but must not be able to reconfigure the install.
+   * Default false, so real deployments are unaffected. Unlike
+   * BOOTSTRAP_ADMIN_RO this needs no companion variable.
+   */
+  SETTINGS_RO: z
+    .string()
+    .transform((s) => s.toLowerCase() === "true")
+    .pipe(z.boolean())
+    .default(false),
+
   // --- OIDC (one provider later; multi-provider later) ---
   OIDC_ENABLED: z
     .string()


### PR DESCRIPTION
## Summary

Adds a deployment switch, **`SETTINGS_RO`**, that makes the entire admin **Settings** page read-only. It mirrors the existing `BOOTSTRAP_ADMIN_RO` demo-hardening pattern.

When `SETTINGS_RO=true`, the runtime-mutable settings (site name, branding, login intro, support contact, lockout policy, password-reset toggle) are frozen for **everyone** — even users who hold `settings.write`. Intended for a public demo where visitors may hold a settings-capable role but must not be able to reconfigure the install, without having to strip the permission from the demo role.

## Changes

- **`lib/env.ts`** — `SETTINGS_RO` boolean, default `false` (no companion variable required, unlike `BOOTSTRAP_ADMIN_RO`).
- **`lib/auth/settings-lock.ts`** (new) — `isSettingsReadOnly()` and `assertSettingsMutable()` (throws `ForbiddenError` → 403 via the shared error-response layer).
- **`PATCH /api/admin/settings`** — calls `assertSettingsMutable()` after the `settings.write` + CSRF checks, so the lock is enforced at the security boundary.
- **Settings page** — folds the lock into `canWrite` and passes `lockedByPolicy` so the form renders disabled with a distinct "read-only on this deployment" notice instead of the missing-permission one.
- **`.env.example`** — documents the flag.
- **Unit tests** — cover the lock decision (`lib/auth/settings-lock.test.ts`).

## Behavior / scope

No-op unless `SETTINGS_RO=true`, so real deployments are unaffected. The flag is purely additive — RBAC `settings.write` still governs edit access when the flag is off; the flag only adds a global override on top.

## Verification

- `tsc --noEmit` clean
- ESLint clean
- Prettier clean (code files)
- Full unit suite: **960 passed**, 15 skipped (4 new)

## Alternative considered

RBAC already supports per-role read-only (omit `settings.write`). This flag is for the case where you want a global lock independent of roles — e.g. a shared demo admin that still needs `settings.write` semantics elsewhere — matching how `BOOTSTRAP_ADMIN_RO` works.
