### PR TITLE
fix(settings): register SETTINGS_RO in ENV_KEYS so the flag actually works

### DIFF
--- a/lib/env.test.ts
+++ b/lib/env.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from "vitest";
-import { BUILD_TIME_PLACEHOLDER_MARK, detectBuildTimePlaceholders } from "./env";
+import {
+  BUILD_TIME_PLACEHOLDER_MARK,
+  detectBuildTimePlaceholders,
+  ENV_KEYS,
+  envSchema,
+} from "./env";
+
+describe("ENV_KEYS coverage", () => {
+  // A schema key absent from ENV_KEYS is never read from process.env, so the
+  // schema silently applies its default and the variable does nothing at
+  // runtime (this regressed SETTINGS_RO once). Keep the two in lockstep.
+  it("collects every variable declared in envSchema", () => {
+    const schemaKeys = Object.keys(envSchema.shape);
+    const collected = new Set<string>(ENV_KEYS);
+    const missing = schemaKeys.filter((k) => !collected.has(k));
+    expect(missing).toEqual([]);
+  });
+
+  it("has no ENV_KEYS entry without a matching schema field", () => {
+    const schemaKeys = new Set(Object.keys(envSchema.shape));
+    const orphaned = ENV_KEYS.filter((k) => !schemaKeys.has(k));
+    expect(orphaned).toEqual([]);
+  });
+});
 
 const realLooking = {
   APP_SECRET_KEY: "Z".repeat(48),

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -83,7 +83,7 @@ const secretKey = z
     message: "looks like a placeholder. Generate a real secret with: openssl rand -base64 32",
   });
 
-const envSchema = z.object({
+export const envSchema = z.object({
   // --- Runtime ---
   NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
   PORT: z.coerce.number().int().positive().default(3000),
@@ -519,7 +519,11 @@ export type Env = z.infer<typeof envSchema>;
 // Boot-time validation
 // =============================================================================
 
-const ENV_KEYS = [
+// The allow-list of variables read from the environment (each also accepts a
+// `_FILE` suffix - see readEnvWithFileSuffix). Every key in `envSchema` MUST
+// appear here, or its value is never collected and the schema silently falls
+// back to its default. The env.test.ts coverage check enforces that invariant.
+export const ENV_KEYS = [
   "NODE_ENV",
   "PORT",
   "APP_URL",
@@ -540,6 +544,7 @@ const ENV_KEYS = [
   "BOOTSTRAP_ADMIN_EMAIL",
   "BOOTSTRAP_ADMIN_PASSWORD",
   "BOOTSTRAP_ADMIN_RO",
+  "SETTINGS_RO",
   "OIDC_ENABLED",
   "OIDC_PROVIDER_ID",
   "OIDC_PROVIDER_NAME",


### PR DESCRIPTION
## Problem

`SETTINGS_RO=true` did nothing — the admin Settings page stayed fully editable. `SETTINGS_RO` was added to the env **schema** (`envSchema`) in 1.4.1 but never to **`ENV_KEYS`**, the allow-list `collectEnv()` reads from `process.env`. So the value was never collected, the schema applied its `false` default, and the lock never engaged.

## Fix

- Add `"SETTINGS_RO"` to `ENV_KEYS`.
- Add an `env.test.ts` coverage check asserting every `envSchema` key is present in `ENV_KEYS` (and no orphan `ENV_KEYS` entry exists), so a schema flag can never again be silently dropped — this is the test that was missing. Exports `ENV_KEYS` + `envSchema` for it.

## Validation (local)

- `npm run validate` (lint + typecheck + format:check + test): **962 passed**, 15 skipped — including the 2 new coverage tests.
- The new coverage test fails against the pre-fix code (`missing: ["SETTINGS_RO"]`), confirming it catches the regression.

## Release

Per maintainer decision, after merge the `v1.4.1` tag is moved onto this commit so the released `:1.4.1` image includes the fix (no history rewrite).
