### PR TITLE
fix(ui): contain sr-only spans so large lists don't overflow the document

### DIFF
--- a/components/ui/app-shell.tsx
+++ b/components/ui/app-shell.tsx
@@ -83,10 +83,21 @@ export function AppShell({
         {/* `min-h-0` is the canonical flexbox-clipping fix: a `flex-1` child
             without it can grow beyond its parent's height when its content
             is taller, defeating `overflow-y-auto` and leaking a second
-            outer scroll region. Previously this surfaced on the zones list
-            at high page sizes (100+) as the "scroll-in-scroll, half the
-            page goes black at the bottom" bug. */}
-        <main className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6 lg:p-8">{children}</main>
+            outer scroll region.
+
+            `relative` makes this the containing block for absolutely-positioned
+            descendants - notably Tailwind `sr-only` spans, which are
+            `position: absolute`. `overflow-y-auto` alone does NOT establish a
+            containing block, so without `relative` those spans escape the scroll
+            region and anchor to the document at their full-content-height static
+            position, stretching <html> past the viewport. That re-introduced the
+            exact "scroll-in-scroll, black at the bottom" bug on the zones list at
+            high row counts even with `min-h-0` already in place (each row's
+            screen-reader label is one such span; 50 of them push the document to
+            ~2000px tall behind a correctly-sized 100dvh shell). */}
+        <main className="relative min-h-0 flex-1 overflow-y-auto p-4 sm:p-6 lg:p-8">
+          {children}
+        </main>
       </div>
     </div>
   );


### PR DESCRIPTION
## The bug

On the zones list (any long table) at high row counts, the page got a document-level scrollbar with a large black gap below the content — the "scroll-in-scroll, black at the bottom" symptom — **even though** the shell is a correctly-sized `100dvh` container and `<main>` already had the `min-h-0` fix.

## Diagnosis (from live DevTools + headless repro)

Live measurements showed the shell was fine — `shellH 809`, `asideH 809`, `mainH 753`, `main` `min-height: 0px`, `overflow-y: auto` — yet `document.scrollHeight = 1979`. The overflowing elements were a stack of `span.sr-only` (one per row, the screen-reader status label), each `position: absolute`, anchored down the document.

**Root cause:** `sr-only` is `position: absolute`. `<main>` was `overflow-y-auto` but **not** `position: relative`, and `overflow` alone does **not** establish a containing block for absolutely-positioned descendants. So the spans escaped `<main>`, anchored to the document at their full-table-height static position, and stretched `<html>` to ~2000px behind the 809px shell.

## Fix

Add `relative` to `<main>` so it's the containing block; the `sr-only` spans then scroll within it and the document stays at viewport height. One word, app-wide, and it complements the existing `min-h-0`.

## Verification

Headless Playwright repro with 50 rows, real shell markup + compiled Tailwind CSS:

| `<main>` | `document.scrollHeight` |
|---|---|
| static (before) | **2306** (overflow) |
| `relative` (after) | **809** (contained) |

Confirmed the shell layout itself was already correct in both Chromium and Firefox. Dropdowns are unaffected — the `SelectMenu` listbox is portaled to `<body>` with `position: fixed`.

`tsc` / ESLint / Prettier clean.
