### PR TITLE
release: 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2026-06-02
+
+A cosmetic patch release. No migration, no breaking changes, no config or
+permission changes. See
+[Upgrading -> 1.4.2](./docs/09-UPGRADING.md#upgrading-to-142-from-141).
+
+### Fixed - favicon now matches the marketing site exactly
+
+The in-app browser-tab icon is now the same `{}` brace mark the marketing site
+([powerdns-authadmin.org](https://powerdns-authadmin.org)) serves. It was being
+generated as a PNG via `next/og`, which re-drew the glyph with a bundled font and
+its own sizing, so it never matched the site's SVG favicon pixel-for-pixel. The
+PNG generator (`app/icon.tsx`) is replaced with a static `app/icon.svg` holding
+the identical markup the site embeds as its data-URI favicon; Next.js auto-injects
+`<link rel="icon" type="image/svg+xml" sizes="any">` and serves the file verbatim,
+so the icon renders identically across platforms.
+
 ## [1.4.1] - 2026-06-02
 
 A small fix-and-polish release. No migration; no breaking changes. Adds an opt-in
@@ -1137,7 +1154,8 @@ First production release.
 - **Distribution** - multi-arch (`linux/amd64` + `linux/arm64`) image published to Docker Hub as
   `jseifeddine/powerdns-authadmin`, plus a one-command minimal-demo stack.
 
-[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.4.1...HEAD
+[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.4.2...HEAD
+[1.4.2]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.4.0...v1.4.1
 [1.1.5]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.3...v1.1.4

--- a/docs/09-UPGRADING.md
+++ b/docs/09-UPGRADING.md
@@ -37,6 +37,13 @@ half-migrated schema; fix the cause and restart.
 
 ## Version-specific notes
 
+### Upgrading to 1.4.2 (from 1.4.1)
+
+No migration, no breaking changes, and no config or permission changes - pull the
+new tag and recreate the container as above. The release only swaps the in-app
+favicon to the static `{}` SVG the marketing site uses so the browser-tab icon
+matches; nothing operational changes.
+
 ### Upgrading to 1.4.1 (from 1.4.0)
 
 No migration and no breaking changes - pull the new tag and recreate the container

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerdns-authadmin",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@casl/ability": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "description": "Modern, self-hosted DNS administration UI for PowerDNS - multi-team RBAC, real audit, real SSO. From-scratch rebuild of PowerDNS-Admin in Node.js + TypeScript.",
   "license": "MIT",


### PR DESCRIPTION
Cosmetic patch release. **No migration, no breaking changes, no config or permission changes.**

## Contents

- **Fixed** — the in-app browser-tab favicon now matches the marketing site ([powerdns-authadmin.org](https://powerdns-authadmin.org)) pixel-for-pixel. The previous `next/og` PNG re-drew the `{}` mark with a bundled font; it's replaced by a static `app/icon.svg` holding the identical markup the site embeds as its data-URI favicon (merged in #94).

## Release bookkeeping

- `package.json` + `package-lock.json` → `1.4.2`
- `CHANGELOG.md` → new `[1.4.2]` section + compare link
- `docs/09-UPGRADING.md` → "Upgrading to 1.4.2 (from 1.4.1)" note

## Verification

- `npm run validate` green (lint + typecheck + format + 962 tests).
- No remaining stray version references (grep clean; version is centralized in package files + changelog/upgrading).

After merge: tag `v1.4.2` + `gh release create`; the `release-sign.yml` workflow then attaches SBOM, checksums, signature bundle, and SLSA provenance assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)