### PR TITLE
chore: tighten repo standards compliance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,12 @@ APP_URL=http://localhost:3000
 # Log level: trace | debug | info | warn | error | fatal. Default: info.
 LOG_LEVEL=info
 
+# Build provenance for packaged images. Docker/CI inject these; leave unset in
+# normal local `.env` files. APP_RELEASE=true means APP_GIT_SHA came from a
+# vX.Y.Z tag build.
+# APP_GIT_SHA=
+# APP_RELEASE=false
+
 
 # -----------------------------------------------------------------------------
 # Secrets - REQUIRED. APP_SECRET_KEY ≥32 chars; APP_ENCRYPTION_KEY must be

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --include=dev
 
       - name: Lint
         run: npm run lint
@@ -82,7 +82,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --include=dev
 
       - name: Run unit tests
         run: npm run test
@@ -115,7 +115,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --include=dev
 
       - name: Integration suite (full stack via docker compose, PDNS 4.9)
         # docker-compose-combined.yml requires the two secrets via ${VAR:?} at
@@ -145,7 +145,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --include=dev
 
       - name: Audit (production deps only)
         run: npm audit --audit-level=high --omit=dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,8 +118,8 @@ ENV PATH=/nodejs/bin:$PATH
 # Build provenance surfaced in the UI (sidebar version chip + GitHub/Docs
 # links, see lib/app-meta.ts). The CI docker job sets GIT_SHA to the
 # commit and APP_RELEASE=true only for vX.Y.Z tag builds. Both default
-# empty for a plain `docker build`, which makes the app fall back to
-# release/tag links.
+# empty/false for a plain `docker build`, which makes the app fall back
+# to local-dev labels and main-branch links.
 ARG GIT_SHA=""
 ARG APP_RELEASE="false"
 ENV APP_GIT_SHA=$GIT_SHA

--- a/app/(auth)/login/ldap-login-form.tsx
+++ b/app/(auth)/login/ldap-login-form.tsx
@@ -12,6 +12,7 @@
 
 import { useState, type FormEvent } from "react";
 import { TurnstileWidget } from "@/components/ui/turnstile-widget";
+import { apiFetch } from "@/lib/client/api-fetch";
 
 interface Props {
   slug: string;
@@ -40,7 +41,7 @@ export function LdapLoginForm({
     setError(null);
 
     try {
-      const res = await fetch(`/api/auth/ldap/${encodeURIComponent(slug)}/login`, {
+      const res = await apiFetch(`/api/auth/ldap/${encodeURIComponent(slug)}/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -24,6 +24,7 @@
 import { useState, type FormEvent } from "react";
 import { startAuthentication } from "@simplewebauthn/browser";
 import { TurnstileWidget } from "@/components/ui/turnstile-widget";
+import { apiFetch } from "@/lib/client/api-fetch";
 
 type MfaMethod = "totp" | "webauthn";
 
@@ -57,7 +58,7 @@ export function LoginForm({
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch("/api/auth/mfa/totp", {
+      const res = await apiFetch("/api/auth/mfa/totp", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ challengeToken: mfa.mfaToken, code }),
@@ -86,7 +87,7 @@ export function LoginForm({
       // First call: mint an assertion challenge. Pass the email so
       // `allowCredentials` is scoped to this user (the email was
       // already authenticated by the prior password POST).
-      const optsRes = await fetch("/api/auth/webauthn/assertion-options", {
+      const optsRes = await apiFetch("/api/auth/webauthn/assertion-options", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email }),
@@ -102,7 +103,7 @@ export function LoginForm({
 
       const assertion = await startAuthentication({ optionsJSON: options });
 
-      const verifyRes = await fetch("/api/auth/webauthn/assertion-verify", {
+      const verifyRes = await apiFetch("/api/auth/webauthn/assertion-verify", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -137,7 +138,7 @@ export function LoginForm({
     setError(null);
 
     try {
-      const res = await fetch("/api/auth/login", {
+      const res = await apiFetch("/api/auth/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/app/(auth)/login/passkey-button.tsx
+++ b/app/(auth)/login/passkey-button.tsx
@@ -18,6 +18,7 @@
 import { useState } from "react";
 import { Fingerprint } from "lucide-react";
 import { startAuthentication } from "@simplewebauthn/browser";
+import { apiFetch } from "@/lib/client/api-fetch";
 
 export function PasskeyButton({ next = "/dashboard" }: { next?: string }) {
   const [busy, setBusy] = useState(false);
@@ -27,7 +28,7 @@ export function PasskeyButton({ next = "/dashboard" }: { next?: string }) {
     setBusy(true);
     setError(null);
     try {
-      const optsRes = await fetch("/api/auth/webauthn/assertion-options", {
+      const optsRes = await apiFetch("/api/auth/webauthn/assertion-options", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
@@ -41,7 +42,7 @@ export function PasskeyButton({ next = "/dashboard" }: { next?: string }) {
         challengeToken: string;
       };
       const assertion = await startAuthentication({ optionsJSON: options });
-      const verifyRes = await fetch("/api/auth/webauthn/assertion-verify", {
+      const verifyRes = await apiFetch("/api/auth/webauthn/assertion-verify", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/app/(auth)/reset-password/forgot-form.tsx
+++ b/app/(auth)/reset-password/forgot-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type FormEvent } from "react";
 import { TurnstileWidget } from "@/components/ui/turnstile-widget";
+import { apiFetch } from "@/lib/client/api-fetch";
 
 export function ForgotPasswordForm({ turnstileSiteKey }: { turnstileSiteKey?: string }) {
   const [email, setEmail] = useState("");
@@ -17,7 +18,7 @@ export function ForgotPasswordForm({ turnstileSiteKey }: { turnstileSiteKey?: st
     setMessage(null);
     setError(null);
     try {
-      const res = await fetch("/api/auth/forgot-password", {
+      const res = await apiFetch("/api/auth/forgot-password", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/app/(auth)/signup/signup-form.tsx
+++ b/app/(auth)/signup/signup-form.tsx
@@ -15,6 +15,7 @@
 import { useState, type FormEvent } from "react";
 import { MIN_PASSWORD_LENGTH } from "@/lib/validators/password-policy";
 import { TurnstileWidget } from "@/components/ui/turnstile-widget";
+import { apiFetch } from "@/lib/client/api-fetch";
 
 export function SignupForm({ turnstileSiteKey }: { turnstileSiteKey?: string }) {
   const [email, setEmail] = useState("");
@@ -44,7 +45,7 @@ export function SignupForm({ turnstileSiteKey }: { turnstileSiteKey?: string }) 
 
     setLoading(true);
     try {
-      const res = await fetch("/api/auth/signup", {
+      const res = await apiFetch("/api/auth/signup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/app/api/admin/backend-advisories/[id]/ack/route.ts
+++ b/app/api/admin/backend-advisories/[id]/ack/route.ts
@@ -9,10 +9,13 @@
 
 import { requireUser } from "@/lib/auth/require-user";
 import { requireCsrf } from "@/lib/auth/csrf";
+import { appendAudit } from "@/lib/audit/log";
 import { errorResponse } from "@/lib/http/error-response";
 import { NotFoundError } from "@/lib/errors";
 import { acknowledgeAdvisory } from "@/lib/db/repositories/backend-advisories";
 import { publishHealthEvent } from "@/lib/realtime/event-bus";
+import { headers } from "next/headers";
+import { getRequestContext } from "@/lib/client-ip";
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -20,11 +23,21 @@ interface RouteContext {
 
 export async function POST(request: Request, context: RouteContext): Promise<Response> {
   try {
-    await requireUser({ can: "server.read" });
+    const { user } = await requireUser({ can: "server.read" });
     await requireCsrf(request);
     const { id } = await context.params;
-    const ok = await acknowledgeAdvisory(id);
-    if (!ok) throw new NotFoundError("Advisory not found or already acknowledged.");
+    const advisory = await acknowledgeAdvisory(id);
+    if (!advisory) throw new NotFoundError("Advisory not found or already acknowledged.");
+
+    await appendAudit({
+      actor: { type: "user", id: user.id },
+      action: "backend_advisory.acknowledge",
+      resource: { type: "backend_advisory", id: advisory.id },
+      before: { ...advisory, acknowledgedAt: null },
+      after: advisory,
+      request: getRequestContext(await headers()),
+    });
+
     // Acking drops it from the unacked count for everyone - nudge other bells.
     publishHealthEvent();
     return Response.json({ ok: true });

--- a/components/auth/README.md
+++ b/components/auth/README.md
@@ -1,0 +1,6 @@
+## components/auth
+
+Reusable authentication-adjacent UI components, such as compliance gates.
+
+Components here render state passed to them. They should not read secrets,
+query the database, or import server-only auth internals.

--- a/components/domain/README.md
+++ b/components/domain/README.md
@@ -1,0 +1,8 @@
+## components/domain
+
+Feature-specific UI components for DNS, audit, backend status, and admin
+workflows.
+
+Use shared primitives from `components/ui` for tables, dialogs, switches, and
+other common controls. Components here should not reach into `lib/db`,
+`lib/pdns`, or `lib/auth`; server components or route handlers pass data in.

--- a/components/realtime/README.md
+++ b/components/realtime/README.md
@@ -1,0 +1,7 @@
+## components/realtime
+
+Client components that subscribe to realtime events and render live status in
+the app chrome.
+
+Keep browser subscription and display logic here. Event production and polling
+coordination belong under `lib/realtime`.

--- a/components/ui/README.md
+++ b/components/ui/README.md
@@ -1,0 +1,7 @@
+## components/ui
+
+Generic reusable UI primitives: tables, dialogs, switches, selectors, shell
+chrome, theme controls, toasts, skeletons, and small interaction helpers.
+
+These components are domain-neutral. Feature-specific DNS/admin behavior belongs
+under `components/domain` or the relevant `app/` route segment.

--- a/lib/app-meta.ts
+++ b/lib/app-meta.ts
@@ -25,14 +25,14 @@
 
 import "server-only";
 import pkg from "@/package.json";
+import { env } from "@/lib/env";
 
 /** Short commit SHA baked into the image at build time, or null in local dev. */
-const rawSha = process.env["APP_GIT_SHA"]?.trim();
+const rawSha = env.APP_GIT_SHA?.trim();
 const shortSha = rawSha ? rawSha.slice(0, 7) : null;
 
 type BuildKind = "release" | "commit" | "dev";
-const buildKind: BuildKind =
-  process.env["APP_RELEASE"] === "true" ? "release" : shortSha !== null ? "commit" : "dev";
+const buildKind: BuildKind = env.APP_RELEASE ? "release" : shortSha !== null ? "commit" : "dev";
 
 /** True only for an image built from a `vX.Y.Z` release tag. */
 export const IS_RELEASE_BUILD: boolean = buildKind === "release";

--- a/lib/audit/README.md
+++ b/lib/audit/README.md
@@ -1,0 +1,8 @@
+## lib/audit
+
+Append-only audit-log support: the typed action vocabulary, audit writer,
+secret redaction, CSV export, and display helpers.
+
+This directory records what already happened. It does not decide whether a
+caller is allowed to perform an operation, and resource mutations should still
+live in route handlers or domain modules that call `appendAudit`.

--- a/lib/audit/actions.ts
+++ b/lib/audit/actions.ts
@@ -101,6 +101,9 @@ export const AUDIT_ACTIONS = [
   // Fleet-level refresh of every active PDNS backend's
   // version_cache (T-110). Sister action to oidc.provider.refresh-all.
   "pdns_server.refresh-all",
+  // Operator dismissed an active health-bell advisory. The underlying backend
+  // condition remains monitored and will re-alert if the advisory changes.
+  "backend_advisory.acknowledge",
 
   // Zones / records
   "zone.create",

--- a/lib/auth/README.md
+++ b/lib/auth/README.md
@@ -1,0 +1,8 @@
+## lib/auth
+
+Authentication and account-security domain code: sessions, password handling,
+CSRF, MFA, WebAuthn, password reset, signup policy, rate limiting, and external
+identity providers.
+
+Modules here are server-only. UI belongs under `app/` or `components/`, and
+authorization policy belongs under `lib/rbac`.

--- a/lib/client/README.md
+++ b/lib/client/README.md
@@ -1,0 +1,7 @@
+## lib/client
+
+Browser-only helpers shared by client components, currently the CSRF-aware
+`apiFetch` mutation wrapper.
+
+Do not put server-only code, secrets, database access, or PowerDNS calls here.
+Anything in this directory must be safe for the browser bundle.

--- a/lib/crypto/README.md
+++ b/lib/crypto/README.md
@@ -1,0 +1,7 @@
+## lib/crypto
+
+Cryptographic primitives owned by the app, including envelope encryption and
+key derivation for persisted secrets.
+
+Callers should pass already-validated configuration from `lib/env`; this
+directory should not grow ad hoc secret parsing or persistence logic.

--- a/lib/db/README.md
+++ b/lib/db/README.md
@@ -1,0 +1,8 @@
+## lib/db
+
+Database schema selection, Drizzle setup, migrations support, and repository
+functions for Postgres and SQLite.
+
+This layer persists and retrieves data. It must not import RBAC or UI code;
+authorization happens above repositories, and React components receive data
+through pages, route handlers, or domain orchestration.

--- a/lib/db/repositories/backend-advisories.ts
+++ b/lib/db/repositories/backend-advisories.ts
@@ -154,6 +154,18 @@ export interface ActiveAdvisory {
   acknowledgedAt: Date | null;
 }
 
+export interface AcknowledgedAdvisory {
+  id: string;
+  backendId: string;
+  code: string;
+  severity: string;
+  title: string;
+  detail: string;
+  firstSeenAt: Date;
+  lastSeenAt: Date;
+  acknowledgedAt: Date;
+}
+
 /**
  * Confirmed advisories (seen on ≥2 cycles) joined with backend identity.
  * Ordered errors-first, then by backend name. Includes acknowledged ones so the
@@ -185,12 +197,28 @@ export async function listActiveAdvisories(): Promise<ActiveAdvisory[]> {
   return rows.map((r) => ({ ...r, acknowledgedAt: r.acknowledgedAt ?? null }));
 }
 
-/** Acknowledge a single advisory by id. Returns true if a row was updated. */
-export async function acknowledgeAdvisory(id: string): Promise<boolean> {
+/**
+ * Acknowledge a single advisory by id.
+ *
+ * @returns The acknowledged row, or null when the advisory is missing/already acked.
+ */
+export async function acknowledgeAdvisory(id: string): Promise<AcknowledgedAdvisory | null> {
   const updated = await db
     .update(backendAdvisories)
     .set({ acknowledgedAt: new Date() })
     .where(and(eq(backendAdvisories.id, id), isNull(backendAdvisories.acknowledgedAt)))
-    .returning({ id: backendAdvisories.id });
-  return updated.length > 0;
+    .returning({
+      id: backendAdvisories.id,
+      backendId: backendAdvisories.backendId,
+      code: backendAdvisories.code,
+      severity: backendAdvisories.severity,
+      title: backendAdvisories.title,
+      detail: backendAdvisories.detail,
+      firstSeenAt: backendAdvisories.firstSeenAt,
+      lastSeenAt: backendAdvisories.lastSeenAt,
+      acknowledgedAt: backendAdvisories.acknowledgedAt,
+    });
+  const row = updated[0];
+  if (!row?.acknowledgedAt) return null;
+  return { ...row, acknowledgedAt: row.acknowledgedAt };
 }

--- a/lib/diff/README.md
+++ b/lib/diff/README.md
@@ -1,0 +1,7 @@
+## lib/diff
+
+Pure diffing helpers used to present before/after state, especially JSON-line
+changes in audit and zone-change surfaces.
+
+Keep this directory side-effect free. It should not know about the database,
+authorization, or network clients.

--- a/lib/dns/README.md
+++ b/lib/dns/README.md
@@ -1,0 +1,7 @@
+## lib/dns
+
+DNS text-format and zone-file helpers: name normalization, SOA serials, TXT
+escaping, BIND formatting, and zone-file parsing.
+
+Keep protocol parsing and formatting here. PowerDNS HTTP behavior belongs under
+`lib/pdns`, and request validation belongs under `lib/validators`.

--- a/lib/dyndns/README.md
+++ b/lib/dyndns/README.md
@@ -1,0 +1,7 @@
+## lib/dyndns
+
+Dynamic DNS request parsing and normalization for the `/nic/update` surface.
+
+This directory should stay focused on the DynDNS protocol contract. Auth,
+authorization, audit logging, and PowerDNS writes are handled by the route and
+the PDNS domain modules.

--- a/lib/email/README.md
+++ b/lib/email/README.md
@@ -1,0 +1,7 @@
+## lib/email
+
+SMTP transport creation, message templates, and the send API used by password
+reset, email verification, and account-change flows.
+
+Configuration comes from `lib/env`. This directory should not make account or
+authorization decisions; callers decide whether an email should be sent.

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -92,6 +92,14 @@ export const envSchema = z.object({
     .url("APP_URL must be a fully-qualified URL with no trailing slash")
     .refine((u) => !u.endsWith("/"), "APP_URL must not end with a trailing slash"),
   LOG_LEVEL: z.enum(["trace", "debug", "info", "warn", "error", "fatal"]).default("info"),
+  // Build provenance injected by Docker/CI. Optional for local dev, but still
+  // centralized here so runtime modules do not read `process.env` directly.
+  APP_GIT_SHA: z.string().optional(),
+  APP_RELEASE: z
+    .string()
+    .transform((s) => s.toLowerCase() === "true")
+    .pipe(z.boolean())
+    .default(false),
 
   // --- Secrets ---
   APP_SECRET_KEY: secretKey,
@@ -528,6 +536,8 @@ export const ENV_KEYS = [
   "PORT",
   "APP_URL",
   "LOG_LEVEL",
+  "APP_GIT_SHA",
+  "APP_RELEASE",
   "APP_SECRET_KEY",
   "APP_ENCRYPTION_KEY",
   "DATABASE_URL",

--- a/lib/errors/README.md
+++ b/lib/errors/README.md
@@ -1,0 +1,7 @@
+## lib/errors
+
+Error-adjacent helpers that do not belong in the root `lib/errors.ts` typed
+error hierarchy, currently secret redaction tests and utilities.
+
+Use `lib/errors.ts` for application error classes. Use this directory for
+supporting utilities that keep errors safe to log or return.

--- a/lib/health/README.md
+++ b/lib/health/README.md
@@ -1,0 +1,7 @@
+## lib/health
+
+Pure backend-health evaluation logic used to turn observed PowerDNS state into
+operator-facing advisories.
+
+This directory computes verdicts. Polling, persistence, and SSE fan-out are
+handled by `lib/realtime` and database repositories.

--- a/lib/http/README.md
+++ b/lib/http/README.md
@@ -1,0 +1,7 @@
+## lib/http
+
+Shared HTTP response helpers for route handlers, including typed-error to
+status-code mapping.
+
+Routes still own authentication, authorization, CSRF checks, validation, and
+audit logging before they call these helpers.

--- a/lib/metrics/README.md
+++ b/lib/metrics/README.md
@@ -1,0 +1,7 @@
+## lib/metrics
+
+Metrics collection helpers: Prometheus exposition, dashboard time windows,
+retention, and PowerDNS statistics sampling.
+
+Keep metric shaping here. Background scheduling belongs under `lib/realtime`,
+and UI rendering belongs under `app/` or `components/`.

--- a/lib/net/README.md
+++ b/lib/net/README.md
@@ -1,0 +1,8 @@
+## lib/net
+
+Network safety helpers for server-side outbound requests: host classification,
+URL guardrails, and pinned fetch behavior that mitigates DNS rebinding.
+
+Protocol-specific clients should call these helpers rather than duplicating
+SSRF checks. This directory should not contain PowerDNS, OIDC, LDAP, or SAML
+business logic.

--- a/lib/net/url-safety.ts
+++ b/lib/net/url-safety.ts
@@ -224,13 +224,6 @@ export async function checkOutboundUrlSafe(
   if (url.protocol !== "http:" && url.protocol !== "https:") {
     return { safe: false, reason: `${policy.label} must use http:// or https://.` };
   }
-  if (isProduction && url.protocol !== "https:" && !policy.allowInsecureHttp) {
-    return {
-      safe: false,
-      reason: `${policy.label} must use https:// in production. ${policy.insecureHttpHint}`,
-    };
-  }
-
   const host = url.hostname;
   if (!host) return { safe: false, reason: `${policy.label} has no host.` };
 
@@ -272,6 +265,13 @@ export async function checkOutboundUrlSafe(
         reason: `Host '${host}' resolves to ${addr}, which is a private address. ${policy.privateNetworkHint}`,
       };
     }
+  }
+
+  if (isProduction && url.protocol !== "https:" && !policy.allowInsecureHttp) {
+    return {
+      safe: false,
+      reason: `${policy.label} must use https:// in production. ${policy.insecureHttpHint}`,
+    };
   }
 
   return { safe: true, addresses };

--- a/lib/pdns/README.md
+++ b/lib/pdns/README.md
@@ -1,0 +1,9 @@
+## lib/pdns
+
+Typed PowerDNS Authoritative API integration: HTTP client, topology handling,
+zone and RRset operations, TSIG/DNSSEC support, capability detection, and
+cluster helpers.
+
+This is the protocol/domain adapter. RBAC and audit happen above it. The few
+sanctioned database bridge modules are documented in ADR-0013 and carry explicit
+lint exceptions.

--- a/lib/provisioning/README.md
+++ b/lib/provisioning/README.md
@@ -1,0 +1,7 @@
+## lib/provisioning
+
+First-boot YAML provisioning: schema validation, application logic, and demo
+zone generation.
+
+Provisioning is an install-time source of desired state. Runtime UI actions and
+API routes should not depend on this directory for normal CRUD behavior.

--- a/lib/rbac/README.md
+++ b/lib/rbac/README.md
@@ -1,0 +1,7 @@
+## lib/rbac
+
+Authorization policy: permission vocabulary, CASL ability building, target
+ceilings, default roles, and zone-grant permission helpers.
+
+RBAC decides what an already-authenticated actor can do. It should not query the
+database directly from repositories, render UI, or talk to PowerDNS.

--- a/lib/realtime/README.md
+++ b/lib/realtime/README.md
@@ -1,0 +1,8 @@
+## lib/realtime
+
+Realtime and background coordination: SSE event bus, backend health refreshes,
+zone-state polling, replication drift tracking, Redis fan-out, and startup-mode
+logging.
+
+This directory coordinates ongoing work. It should call domain/repository
+helpers rather than embedding route-specific authorization or UI behavior.

--- a/lib/security/README.md
+++ b/lib/security/README.md
@@ -1,0 +1,7 @@
+## lib/security
+
+Security helpers used across the app, currently CSP construction and SVG
+sanitization.
+
+Keep reusable security policy here. Request-level header application lives in
+`proxy.ts`, and validation of user input belongs under `lib/validators`.

--- a/lib/settings/README.md
+++ b/lib/settings/README.md
@@ -1,0 +1,6 @@
+## lib/settings
+
+Runtime application settings helpers layered on top of the settings repository.
+
+This directory should expose typed settings behavior. Database schema and raw
+CRUD live under `lib/db`, and settings UI belongs under `app/`.

--- a/lib/validators/README.md
+++ b/lib/validators/README.md
@@ -1,0 +1,7 @@
+## lib/validators
+
+Zod schemas for request bodies, query strings, configuration payloads, and DNS
+record-type data at application boundaries.
+
+Past this directory, code should work with narrowed typed values. Do not put
+database writes, PowerDNS calls, or UI rendering in validators.

--- a/tests/integration/admin/audit.test.ts
+++ b/tests/integration/admin/audit.test.ts
@@ -8,6 +8,7 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { createUser, loginAs, loginAsBootstrap, SYSTEM_ROLES, uniqueEmail } from "../helpers/auth";
+import { dbQuery } from "../helpers/db";
 import { resetState } from "../helpers/reset";
 
 describe("/api/admin/audit/export", () => {
@@ -52,6 +53,40 @@ describe("/api/admin/audit/export", () => {
     const admin = await loginAsBootstrap();
     const res = await admin.call("/api/admin/audit/export?from=not-a-date");
     expect(res.status).toBe(400);
+  });
+
+  it("records backend advisory acknowledgements", async () => {
+    const admin = await loginAsBootstrap();
+    const [server] = await dbQuery<{ id: string }>("SELECT id FROM pdns_servers LIMIT 1");
+    expect(server).toBeDefined();
+
+    const code = `test.audit-ack.${Date.now()}`;
+    const [advisory] = await dbQuery<{ id: string }>(
+      `INSERT INTO backend_advisories
+         (backend_id, code, severity, title, detail, first_seen_at, last_seen_at)
+       VALUES
+         ($1, $2, 'warn', 'Integration test advisory', 'Seeded by audit test', now() - interval '2 minutes', now())
+       RETURNING id`,
+      [server!.id, code],
+    );
+    expect(advisory).toBeDefined();
+
+    await admin.sendJson("POST", `/api/admin/backend-advisories/${advisory!.id}/ack`);
+
+    const rows = await dbQuery<{ action: string; resource_type: string; resource_id: string }>(
+      `SELECT action, resource_type, resource_id
+       FROM audit_log
+       WHERE action = 'backend_advisory.acknowledge'
+         AND resource_id = $1`,
+      [advisory!.id],
+    );
+    expect(rows).toEqual([
+      {
+        action: "backend_advisory.acknowledge",
+        resource_type: "backend_advisory",
+        resource_id: advisory!.id,
+      },
+    ]);
   });
 
   it("non-admin (operator) cannot export - 403", async () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,10 +2,10 @@
  * tests/setup.ts
  *
  * Vitest setupFiles hook. Runs before every test file and primes the
- * environment variables that `lib/env.ts` validates at module load. Without
- * this, any test whose transitive imports reach `lib/env` (logger, audit,
- * pdns client, anything db-shaped) blows up at import time before a single
- * test runs.
+ * environment variables that `lib/env.ts` validates at module load. We assign
+ * these unconditionally because developer shells may auto-load `.env` /
+ * `.env.example` (for example via a dotenv shell plugin); unit tests must not
+ * inherit production/demo settings like `DATABASE_URL=file:/data/...`.
  *
  * The values are placeholders sized to pass schema validation - never real
  * secrets. Tests that exercise encryption or the database should still spin
@@ -16,10 +16,10 @@
 // the 32 bytes that `APP_ENCRYPTION_KEY` requires for AES-256-GCM.
 const TEST_BASE64_32 = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="; // "0123456789abcdef0123456789abcdef"
 
-process.env["APP_URL"] ??= "http://localhost:3000";
-process.env["APP_SECRET_KEY"] ??= "test-secret-key-padded-to-meet-min-32-chars-please";
-process.env["APP_ENCRYPTION_KEY"] ??= TEST_BASE64_32;
-process.env["DATABASE_URL"] ??= "postgres://test:test@localhost:5432/test";
-process.env["LOG_LEVEL"] ??= "fatal";
+process.env["APP_URL"] = "http://localhost:3000";
+process.env["APP_SECRET_KEY"] = "test-secret-key-padded-to-meet-min-32-chars-please";
+process.env["APP_ENCRYPTION_KEY"] = TEST_BASE64_32;
+process.env["DATABASE_URL"] = "postgres://test:test@localhost:5432/test";
+process.env["LOG_LEVEL"] = "fatal";
 // NODE_ENV is typed `readonly` in @types/node; the cast is intentional.
-(process.env as Record<string, string>)["NODE_ENV"] ??= "test";
+(process.env as Record<string, string>)["NODE_ENV"] = "test";


### PR DESCRIPTION
Closes #96

## Summary

This PR tightens repository standards compliance after a full pass against `CONTRIBUTING.md`, the architecture ADRs, and the existing local verification gates.

## Changes

- Adds audit logging for backend health advisory acknowledgements, including before and after snapshots plus request context.
- Adds an integration regression test that seeds an advisory, acknowledges it through the API, and asserts the audit row.
- Routes auth client POST flows through the shared CSRF-aware `apiFetch` wrapper instead of raw browser `fetch`.
- Moves build provenance variables (`APP_GIT_SHA`, `APP_RELEASE`) into the central validated env surface and documents them in `.env.example`.
- Fixes outbound URL safety ordering so always-blocked literal IPs such as link-local metadata addresses report the stronger never-allowed reason before the production HTTP scheme check.
- Makes unit-test setup hermetic by overriding shell-loaded runtime env values that can leak from dotenv plugins.
- Makes CI install steps explicit with `npm ci --include=dev` so local `act` runs do not omit lint/test tooling when the caller shell has `NODE_ENV=production`.
- Adds the required first-level `README.md` boundary docs for `lib/*` and `components/*` directories.

## Standards Covered

- Three-layer route flow remains route-owned: auth, CSRF, repository mutation, audit, response.
- State-changing advisory acknowledgement now writes an audit row.
- Client mutations use the project CSRF wrapper.
- Runtime environment reads are further centralized in `lib/env.ts`.
- Unit tests no longer depend on the developer shell env.
- Directory README coverage now matches the documented contributor standard.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run test` - 93 files passed, 968 tests passed, 9 skipped
- `npm run ci:local`
- `npm run test:integration` - 41 files passed, 221 tests passed, 6 skipped

## Notes

`AGENTS.md` remains untracked locally and is not part of this PR.