### PR TITLE
feat: improve TSIG key zone workflows

### DIFF
--- a/app/(app)/admin/tsig-keys/_components/tsig-actions.tsx
+++ b/app/(app)/admin/tsig-keys/_components/tsig-actions.tsx
@@ -17,7 +17,7 @@
 
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
-import { Plus } from "lucide-react";
+import { Pencil, Plus, Trash2, UploadCloud } from "lucide-react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { useDialog } from "@/components/ui/dialog";
 import { mutate } from "@/lib/client/api-fetch";
@@ -29,6 +29,9 @@ interface Row {
   id: string;
   name: string;
   algorithm: string;
+  zoneCount: number;
+  zones: string[];
+  canEditZones: boolean;
 }
 
 interface Props {
@@ -40,24 +43,41 @@ interface Props {
   isPrimary: boolean;
   /** The primary's secondaries (for API install) - empty unless `isPrimary`. */
   secondaries: InstallSecondary[];
-  /** The primary's authoritative zone names (for in-flow key activation). */
+  /** Primary whose zone-transfer settings back this key correlation view. */
+  correlationServer: { slug: string; name: string } | null;
+  /** The correlation primary's authoritative zone names. */
   zones: string[];
 }
 
-type WizardState = { mode: "create" } | { mode: "existing"; keyId: string; keyName: string };
+type WizardState =
+  | { mode: "create" }
+  | {
+      mode: "existing";
+      keyId: string;
+      keyName: string;
+      startStep: "install" | "zones";
+      serverSlug: string;
+      configuredZones: string[];
+    };
 
-export function TsigActions({ serverSlug, rows, isPrimary, secondaries, zones }: Props) {
+export function TsigActions({
+  serverSlug,
+  rows,
+  isPrimary,
+  secondaries,
+  correlationServer,
+  zones,
+}: Props) {
   const router = useRouter();
   const { confirm, toast } = useDialog();
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [wizard, setWizard] = useState<WizardState | null>(null);
 
-  // Per-row "Set up" only makes sense from a primary with somewhere to install
-  // (managed secondaries) or zones to activate the key for.
-  const canInstall = isPrimary && (secondaries.length > 0 || zones.length > 0);
+  const canInstall = isPrimary && secondaries.length > 0;
+  const canEditZones = correlationServer !== null && zones.length > 0;
 
   async function handleDelete(row: Row) {
-    const { confirmed, checked: cascade } = await confirm({
+    const deletePrompt = {
       title: `Delete TSIG key ${row.name}?`,
       description: (
         <span className="flex items-start gap-2">
@@ -84,12 +104,19 @@ export function TsigActions({ serverSlug, rows, isPrimary, secondaries, zones }:
       confirmLabel: "Delete key",
       variant: "danger",
       dismissOnBackdrop: false,
-      checkbox: {
-        label: "Also delete key from all zones configured to use it, and cleanup secondaries",
-        defaultChecked: true,
-        warningWhenUnchecked: "Zones still referencing this key will reject transfers",
-      },
-    });
+    } as const;
+    const result = isPrimary
+      ? await confirm({
+          ...deletePrompt,
+          checkbox: {
+            label: "Also delete key from all zones configured to use it, and cleanup secondaries",
+            defaultChecked: true,
+            warningWhenUnchecked: "Zones still referencing this key will reject transfers",
+          },
+        })
+      : await confirm(deletePrompt);
+    const confirmed = typeof result === "boolean" ? result : result.confirmed;
+    const cascade = typeof result === "boolean" ? false : result.checked;
     if (!confirmed) return;
     setDeletingId(row.id);
     try {
@@ -98,7 +125,7 @@ export function TsigActions({ serverSlug, rows, isPrimary, secondaries, zones }:
         window.location.origin,
       );
       url.searchParams.set("serverSlug", serverSlug);
-      url.searchParams.set("cascade", cascade ? "true" : "false");
+      url.searchParams.set("cascade", isPrimary && cascade ? "true" : "false");
       const result = await mutate(url.pathname + url.search, { method: "DELETE" });
       if (!result.ok) {
         toast({ kind: "error", title: "Delete failed", description: result.error });
@@ -141,20 +168,45 @@ export function TsigActions({ serverSlug, rows, isPrimary, secondaries, zones }:
           serverSlug={serverSlug}
           keys={keys}
           canInstall={canInstall}
+          canEditZones={canEditZones}
           busyDeleteId={deletingId}
           onDelete={handleDelete}
-          onSetUp={(row) => setWizard({ mode: "existing", keyId: row.id, keyName: row.name })}
+          onInstall={(row) =>
+            setWizard({
+              mode: "existing",
+              keyId: row.id,
+              keyName: row.name,
+              startStep: "install",
+              serverSlug,
+              configuredZones: row.zones,
+            })
+          }
+          onEditZones={(row) =>
+            setWizard({
+              mode: "existing",
+              keyId: row.id,
+              keyName: row.name,
+              startStep: "zones",
+              serverSlug: correlationServer?.slug ?? serverSlug,
+              configuredZones: row.zones,
+            })
+          }
         />
       ) : null}
 
       {wizard ? (
         <TsigKeyWizard
-          serverSlug={serverSlug}
+          serverSlug={wizard.mode === "existing" ? wizard.serverSlug : serverSlug}
           secondaries={secondaries}
           zones={zones}
           existing={
             wizard.mode === "existing"
-              ? { keyId: wizard.keyId, keyName: wizard.keyName }
+              ? {
+                  keyId: wizard.keyId,
+                  keyName: wizard.keyName,
+                  startStep: wizard.startStep,
+                  configuredZones: wizard.configuredZones,
+                }
               : undefined
           }
           onChanged={() => router.refresh()}
@@ -172,23 +224,29 @@ function TsigKeysTable({
   serverSlug,
   keys,
   canInstall,
+  canEditZones,
   busyDeleteId,
   onDelete,
-  onSetUp,
+  onInstall,
+  onEditZones,
 }: {
   serverSlug: string;
   keys: Row[];
   canInstall: boolean;
+  canEditZones: boolean;
   busyDeleteId: string | null;
   onDelete: (row: Row) => void;
-  onSetUp: (row: Row) => void;
+  onInstall: (row: Row) => void;
+  onEditZones: (row: Row) => void;
 }) {
   const columns = useMemo<Array<ColumnDef<Row, unknown>>>(
     () => [
       {
         accessorKey: "name",
         header: "Name",
-        cell: (ctx) => <span className="font-mono text-xs">{ctx.getValue<string>()}</span>,
+        cell: (ctx) => (
+          <span className="font-mono text-xs break-all">{ctx.getValue<string>()}</span>
+        ),
       },
       {
         accessorKey: "algorithm",
@@ -200,6 +258,46 @@ function TsigKeysTable({
         ),
       },
       {
+        accessorKey: "zoneCount",
+        header: "Domains",
+        cell: (ctx) => {
+          const row = ctx.row.original;
+          return (
+            <div className="max-w-sm space-y-1">
+              <span
+                className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${
+                  row.zoneCount > 0
+                    ? "bg-[color:var(--color-accent)]/15 text-[color:var(--color-accent)]"
+                    : "bg-[color:var(--color-bg-muted)] text-[color:var(--color-fg-muted)]"
+                }`}
+              >
+                {row.zoneCount === 0
+                  ? "Not applied"
+                  : `${row.zoneCount} domain${row.zoneCount === 1 ? "" : "s"}`}
+              </span>
+              {row.zones.length > 0 ? (
+                <div className="flex flex-wrap gap-1">
+                  {row.zones.slice(0, 3).map((zone) => (
+                    <span
+                      key={zone}
+                      title={zone}
+                      className="max-w-44 truncate rounded bg-[color:var(--color-bg-subtle)] px-1.5 py-0.5 font-mono text-[0.625rem] text-[color:var(--color-fg-muted)]"
+                    >
+                      {zone}
+                    </span>
+                  ))}
+                  {row.zones.length > 3 ? (
+                    <span className="rounded bg-[color:var(--color-bg-subtle)] px-1.5 py-0.5 text-[0.625rem] text-[color:var(--color-fg-muted)]">
+                      +{row.zones.length - 3}
+                    </span>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          );
+        },
+      },
+      {
         id: "actions",
         header: "",
         enableSorting: false,
@@ -207,21 +305,33 @@ function TsigKeysTable({
           const row = ctx.row.original;
           return (
             <div className="flex justify-end gap-1.5">
+              {canEditZones && row.canEditZones ? (
+                <button
+                  type="button"
+                  onClick={() => onEditZones(row)}
+                  className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border)] px-2 py-1 text-xs hover:bg-[color:var(--color-bg-muted)]"
+                >
+                  <Pencil className="h-3.5 w-3.5" aria-hidden />
+                  Edit
+                </button>
+              ) : null}
               {canInstall ? (
                 <button
                   type="button"
-                  onClick={() => onSetUp(row)}
-                  className="rounded border border-[color:var(--color-border)] px-2 py-1 text-xs hover:bg-[color:var(--color-bg-muted)]"
+                  onClick={() => onInstall(row)}
+                  className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border)] px-2 py-1 text-xs hover:bg-[color:var(--color-bg-muted)]"
                 >
-                  Set up
+                  <UploadCloud className="h-3.5 w-3.5" aria-hidden />
+                  Install
                 </button>
               ) : null}
               <button
                 type="button"
                 onClick={() => onDelete(row)}
                 disabled={busyDeleteId === row.id}
-                className="rounded border border-[color:var(--color-error)] px-2 py-1 text-xs text-[color:var(--color-error)] hover:bg-[color:var(--color-error)]/10 disabled:opacity-50"
+                className="inline-flex items-center gap-1 rounded border border-[color:var(--color-error)] px-2 py-1 text-xs text-[color:var(--color-error)] hover:bg-[color:var(--color-error)]/10 disabled:opacity-50"
               >
+                <Trash2 className="h-3.5 w-3.5" aria-hidden />
                 {busyDeleteId === row.id ? "Deleting…" : "Delete"}
               </button>
             </div>
@@ -229,7 +339,7 @@ function TsigKeysTable({
         },
       },
     ],
-    [canInstall, busyDeleteId, onDelete, onSetUp],
+    [canEditZones, canInstall, busyDeleteId, onDelete, onEditZones, onInstall],
   );
 
   return (

--- a/app/(app)/admin/tsig-keys/_components/tsig-key-wizard.tsx
+++ b/app/(app)/admin/tsig-keys/_components/tsig-key-wizard.tsx
@@ -22,7 +22,8 @@
  * say, adding a secondary.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown, ShieldCheck } from "lucide-react";
 import { apiFetch, mutate } from "@/lib/client/api-fetch";
 import { useDialog } from "@/components/ui/dialog";
 import { SelectMenu, type SelectOption } from "@/components/ui/select-menu";
@@ -86,7 +87,12 @@ interface Props {
   /** The primary's authoritative zone names (Master/Primary) - for activation. */
   zones: string[];
   /** Set to (re)install an existing key - the wizard skips the Generate step. */
-  existing?: { keyId: string; keyName: string };
+  existing?: {
+    keyId: string;
+    keyName: string;
+    startStep?: "install" | "zones";
+    configuredZones?: string[];
+  };
   onClose: () => void;
   /** Called after a key is created so the table refreshes behind the modal. */
   onChanged: () => void;
@@ -102,7 +108,12 @@ export function TsigKeyWizard({
 }: Props) {
   const { toast } = useDialog();
 
-  const [step, setStep] = useState<Step>(existing ? "install" : "generate");
+  const initialStep: Step = existing
+    ? existing.startStep === "zones" && zones.length > 0
+      ? "zones"
+      : "install"
+    : "generate";
+  const [step, setStep] = useState<Step>(initialStep);
   const [key, setKey] = useState<{ id: string; name: string } | null>(
     existing ? { id: existing.keyId, name: existing.keyName } : null,
   );
@@ -120,7 +131,13 @@ export function TsigKeyWizard({
   const [loadingScript, setLoadingScript] = useState(false);
 
   // Step 3 - zones.
-  const [selectedZones, setSelectedZones] = useState<Set<string>>(new Set());
+  const configuredZones = useMemo(
+    () => new Set(existing?.configuredZones ?? []),
+    [existing?.configuredZones],
+  );
+  const [selectedZones, setSelectedZones] = useState<Set<string>>(
+    () => new Set(existing?.configuredZones ?? []),
+  );
   const [activating, setActivating] = useState(false);
 
   const managed = secondaries.filter((s) => s.supportsTsigApi).length;
@@ -225,43 +242,69 @@ export function TsigKeyWizard({
     }
   }
 
-  async function applyZones() {
-    if (!key || selectedZones.size === 0) return;
-    setActivating(true);
-    try {
-      const targets = [...selectedZones];
-      let failed = 0;
-      for (const zone of targets) {
-        const res = await mutate(
-          `/api/admin/pdns/zones/${encodeURIComponent(zone)}/tsig-transfer`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            // Additive - never drops other keys already securing the zone.
-            body: JSON.stringify({ serverSlug, keyName: key.name, mode: "add" }),
-          },
-        );
-        if (!res.ok) failed += 1;
-      }
-      toast({
-        kind: failed > 0 ? "error" : "success",
-        title: failed > 0 ? "Some zones failed" : "Zones secured",
-        description: `${targets.length - failed}/${targets.length} zone(s) now require this key for AXFR.`,
-      });
-      setSelectedZones(new Set());
-    } finally {
-      setActivating(false);
+  async function mapLimit<T, R>(
+    items: readonly T[],
+    limit: number,
+    fn: (item: T) => Promise<R>,
+  ): Promise<R[]> {
+    const out: R[] = [];
+    for (let i = 0; i < items.length; i += limit) {
+      out.push(...(await Promise.all(items.slice(i, i + limit).map(fn))));
     }
+    return out;
   }
 
-  const allZonesSelected = zones.length > 0 && selectedZones.size === zones.length;
-  function toggleZone(zone: string) {
-    setSelectedZones((prev) => {
-      const next = new Set(prev);
-      if (next.has(zone)) next.delete(zone);
-      else next.add(zone);
-      return next;
+  const addedZones = useMemo(
+    () => [...selectedZones].filter((zone) => !configuredZones.has(zone)),
+    [configuredZones, selectedZones],
+  );
+  const removedZones = useMemo(
+    () => [...configuredZones].filter((zone) => !selectedZones.has(zone)),
+    [configuredZones, selectedZones],
+  );
+  const changeCount = addedZones.length + removedZones.length;
+  const hasSelectionChanges = changeCount > 0;
+
+  async function applyZonesInBackground(
+    changes: Array<{ zone: string; mode: "add" | "remove" }>,
+    keyName: string,
+  ) {
+    const results = await mapLimit(changes, 6, async ({ zone, mode }) => {
+      const res = await mutate(`/api/admin/pdns/zones/${encodeURIComponent(zone)}/tsig-transfer`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        // Non-clobbering: the route adds/removes only this key from each zone.
+        body: JSON.stringify({ serverSlug, keyName, mode }),
+      });
+      return res.ok;
     });
+    const failed = results.filter((ok) => !ok).length;
+    toast({
+      kind: failed > 0 ? "error" : "success",
+      title: failed > 0 ? "Some domains failed" : `Key ${keyName} applied`,
+      description:
+        failed > 0
+          ? `${changes.length - failed}/${changes.length} domain changes completed.`
+          : `Key ${keyName} updated on ${changes.length} domain${changes.length === 1 ? "" : "s"} successfully.`,
+    });
+    onChanged();
+  }
+
+  function applyZones() {
+    if (!key || !hasSelectionChanges) return;
+    setActivating(true);
+    const changes = [
+      ...addedZones.map((zone) => ({ zone, mode: "add" as const })),
+      ...removedZones.map((zone) => ({ zone, mode: "remove" as const })),
+    ];
+    const keyName = key.name;
+    toast({
+      kind: "info",
+      title: "Applying TSIG key",
+      description: `Started ${changes.length} domain change${changes.length === 1 ? "" : "s"}. You can keep working.`,
+    });
+    onClose();
+    void applyZonesInBackground(changes, keyName);
   }
 
   const stepNo = step === "generate" ? 1 : step === "install" ? 2 : 3;
@@ -272,6 +315,7 @@ export function TsigKeyWizard({
       : step === "install"
         ? "Install on secondaries"
         : "Secure zones";
+  const modalWidth = step === "zones" ? "max-w-4xl" : "max-w-lg";
 
   return (
     <div className="fixed inset-0 z-[100] overflow-y-auto">
@@ -281,7 +325,7 @@ export function TsigKeyWizard({
           role="dialog"
           aria-modal="true"
           aria-label="Add TSIG key"
-          className="relative w-full max-w-lg rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-6 shadow-xl"
+          className={`relative w-full ${modalWidth} rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-6 shadow-xl`}
         >
           <div className="flex items-baseline justify-between">
             <h2 className="text-lg font-semibold">{heading}</h2>
@@ -410,44 +454,63 @@ export function TsigKeyWizard({
             ) : null}
 
             {step === "zones" ? (
-              <div className="space-y-3">
-                <div className="flex flex-wrap items-baseline justify-between gap-x-3">
+              <div className="space-y-4">
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <div className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] p-3">
+                    <div className="text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">
+                      Domains
+                    </div>
+                    <div className="mt-1 text-lg font-semibold">{zones.length}</div>
+                  </div>
+                  <div className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] p-3">
+                    <div className="text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">
+                      Selected
+                    </div>
+                    <div className="mt-1 text-lg font-semibold">{selectedZones.size}</div>
+                  </div>
+                  <div className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] p-3">
+                    <div className="text-[0.625rem] font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">
+                      Key
+                    </div>
+                    <div className="mt-1 truncate font-mono text-sm" title={key?.name}>
+                      {key?.name}
+                    </div>
+                  </div>
+                </div>
+                <div className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] px-3 py-2 text-xs text-[color:var(--color-fg-muted)]">
+                  {hasSelectionChanges ? (
+                    <>
+                      {addedZones.length} add{addedZones.length === 1 ? "" : "s"},{" "}
+                      {removedZones.length} remove{removedZones.length === 1 ? "" : "s"} pending.
+                    </>
+                  ) : (
+                    "Selection matches the configured domains."
+                  )}
+                </div>
+                <div className="space-y-2">
                   <p className="text-xs text-[color:var(--color-fg-muted)]">
                     Sets <code>master_tsig_key_ids</code> on the primary and{" "}
                     <code>slave_tsig_key_ids</code> on the secondaries that host each zone.
                   </p>
-                  <Checkbox
-                    checked={allZonesSelected}
-                    onChange={(c) => setSelectedZones(c ? new Set(zones) : new Set())}
-                    label={
-                      <span className="text-xs text-[color:var(--color-fg-muted)]">
-                        Select all ({zones.length})
-                      </span>
-                    }
+                  <ZoneMultiSelect
+                    zones={zones}
+                    selected={selectedZones}
+                    configured={configuredZones}
+                    onChange={setSelectedZones}
                   />
-                </div>
-                <div className="grid max-h-56 grid-cols-1 gap-x-4 gap-y-1.5 overflow-auto sm:grid-cols-2 lg:grid-cols-3">
-                  {zones.map((z) => (
-                    <Checkbox
-                      key={z}
-                      checked={selectedZones.has(z)}
-                      onChange={() => toggleZone(z)}
-                      className="min-w-0"
-                      label={
-                        <span className="truncate font-mono text-xs" title={z}>
-                          {z}
-                        </span>
-                      }
-                    />
-                  ))}
                 </div>
                 <button
                   type="button"
                   onClick={applyZones}
-                  disabled={activating || selectedZones.size === 0}
-                  className="rounded-md border border-[color:var(--color-border)] px-3 py-1.5 text-sm hover:bg-[color:var(--color-bg-muted)] disabled:opacity-50"
+                  disabled={activating || !hasSelectionChanges}
+                  className={`inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium ${
+                    hasSelectionChanges
+                      ? "bg-[color:var(--color-accent)] text-[color:var(--color-accent-fg)] hover:opacity-95 disabled:opacity-50"
+                      : "border border-[color:var(--color-border)] bg-[color:var(--color-bg)] text-[color:var(--color-fg-muted)]"
+                  }`}
                 >
-                  {activating ? "Applying…" : `Apply to selected (${selectedZones.size})`}
+                  <ShieldCheck className="h-4 w-4" aria-hidden />
+                  {activating ? "Applying…" : `Apply changes (${changeCount})`}
                 </button>
               </div>
             ) : null}
@@ -477,13 +540,170 @@ export function TsigKeyWizard({
 
             {step === "zones" ? (
               <>
-                <FooterGhost onClick={() => setStep("install")}>← Back</FooterGhost>
+                {existing?.startStep === "zones" ? null : (
+                  <FooterGhost onClick={() => setStep("install")}>← Back</FooterGhost>
+                )}
                 <FooterPrimary onClick={onClose}>Done</FooterPrimary>
               </>
             ) : null}
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+function ZoneMultiSelect({
+  zones,
+  selected,
+  configured,
+  onChange,
+}: {
+  zones: string[];
+  selected: Set<string>;
+  configured: Set<string>;
+  onChange: (next: Set<string>) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      if (rootRef.current?.contains(e.target as Node)) return;
+      setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const filteredZones = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return zones;
+    return zones.filter((zone) => zone.toLowerCase().includes(q));
+  }, [query, zones]);
+
+  const selectedPreview = useMemo(() => [...selected].sort(), [selected]);
+  const allSelected = zones.length > 0 && selected.size === zones.length;
+
+  function toggleZone(zone: string) {
+    const next = new Set(selected);
+    if (next.has(zone)) next.delete(zone);
+    else next.add(zone);
+    onChange(next);
+  }
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="flex min-h-12 w-full items-center justify-between gap-3 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2 text-left text-sm hover:border-[color:var(--color-fg-muted)]"
+      >
+        <span className="min-w-0">
+          <span className="block font-medium">
+            {selected.size === 0
+              ? "Choose domains"
+              : `${selected.size} domain${selected.size === 1 ? "" : "s"} selected`}
+          </span>
+          <span className="block text-xs text-[color:var(--color-fg-muted)]">
+            {zones.length} available
+          </span>
+        </span>
+        <ChevronDown className="h-4 w-4 shrink-0 text-[color:var(--color-fg-muted)]" aria-hidden />
+      </button>
+
+      {selectedPreview.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {selectedPreview.slice(0, 8).map((zone) => (
+            <span
+              key={zone}
+              title={zone}
+              className="max-w-full truncate rounded bg-[color:var(--color-accent)]/10 px-2 py-1 font-mono text-[0.7rem] text-[color:var(--color-accent)] sm:max-w-64"
+            >
+              {zone}
+            </span>
+          ))}
+          {selectedPreview.length > 8 ? (
+            <span className="rounded bg-[color:var(--color-bg-subtle)] px-2 py-1 text-[0.7rem] text-[color:var(--color-fg-muted)]">
+              +{selectedPreview.length - 8}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+
+      {open ? (
+        <div className="absolute z-[210] mt-2 w-full rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] shadow-xl">
+          <div className="border-b border-[color:var(--color-border)] p-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Filter domains"
+                className="min-w-0 flex-1 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2 font-mono text-sm focus:ring-2 focus:ring-[color:var(--color-accent)] focus:outline-none"
+              />
+              <button
+                type="button"
+                onClick={() => onChange(allSelected ? new Set() : new Set(zones))}
+                className="rounded-md border border-[color:var(--color-border)] px-3 py-2 text-xs font-medium hover:bg-[color:var(--color-bg-subtle)]"
+              >
+                {allSelected ? "Clear all" : `Select all (${zones.length})`}
+              </button>
+              {selected.size > 0 && !allSelected ? (
+                <button
+                  type="button"
+                  onClick={() => onChange(new Set())}
+                  className="rounded-md border border-[color:var(--color-border)] px-3 py-2 text-xs hover:bg-[color:var(--color-bg-subtle)]"
+                >
+                  Clear
+                </button>
+              ) : null}
+            </div>
+          </div>
+          <div role="listbox" className="max-h-80 overflow-auto p-2">
+            {filteredZones.length === 0 ? (
+              <p className="px-2 py-6 text-center text-sm text-[color:var(--color-fg-muted)]">
+                No domains match.
+              </p>
+            ) : (
+              filteredZones.map((zone) => (
+                <Checkbox
+                  key={zone}
+                  checked={selected.has(zone)}
+                  onChange={() => toggleZone(zone)}
+                  className="flex w-full min-w-0 items-start rounded px-2 py-2 hover:bg-[color:var(--color-bg-subtle)]"
+                  label={
+                    <span className="flex min-w-0 flex-1 items-start gap-2">
+                      <span
+                        className="min-w-0 flex-1 font-mono text-xs leading-5 break-all"
+                        title={zone}
+                      >
+                        {zone}
+                      </span>
+                      {configured.has(zone) ? (
+                        <span className="shrink-0 rounded bg-[color:var(--color-accent)]/10 px-1.5 py-0.5 text-[0.625rem] font-medium text-[color:var(--color-accent)]">
+                          configured
+                        </span>
+                      ) : null}
+                    </span>
+                  }
+                />
+              ))
+            )}
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/app/(app)/admin/tsig-keys/_components/tsig-keys-readonly.tsx
+++ b/app/(app)/admin/tsig-keys/_components/tsig-keys-readonly.tsx
@@ -15,6 +15,8 @@ interface Row {
   id: string;
   name: string;
   algorithm: string;
+  zoneCount: number;
+  zones: string[];
 }
 
 export function TsigKeysReadOnly({ serverSlug, rows }: { serverSlug: string; rows: Row[] }) {
@@ -23,7 +25,9 @@ export function TsigKeysReadOnly({ serverSlug, rows }: { serverSlug: string; row
       {
         accessorKey: "name",
         header: "Name",
-        cell: (ctx) => <span className="font-mono text-xs">{ctx.getValue<string>()}</span>,
+        cell: (ctx) => (
+          <span className="font-mono text-xs break-all">{ctx.getValue<string>()}</span>
+        ),
       },
       {
         accessorKey: "algorithm",
@@ -33,6 +37,46 @@ export function TsigKeysReadOnly({ serverSlug, rows }: { serverSlug: string; row
             {ctx.getValue<string>()}
           </span>
         ),
+      },
+      {
+        accessorKey: "zoneCount",
+        header: "Domains",
+        cell: (ctx) => {
+          const row = ctx.row.original;
+          return (
+            <div className="max-w-sm space-y-1">
+              <span
+                className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${
+                  row.zoneCount > 0
+                    ? "bg-[color:var(--color-accent)]/15 text-[color:var(--color-accent)]"
+                    : "bg-[color:var(--color-bg-muted)] text-[color:var(--color-fg-muted)]"
+                }`}
+              >
+                {row.zoneCount === 0
+                  ? "Not applied"
+                  : `${row.zoneCount} domain${row.zoneCount === 1 ? "" : "s"}`}
+              </span>
+              {row.zones.length > 0 ? (
+                <div className="flex flex-wrap gap-1">
+                  {row.zones.slice(0, 3).map((zone) => (
+                    <span
+                      key={zone}
+                      title={zone}
+                      className="max-w-44 truncate rounded bg-[color:var(--color-bg-subtle)] px-1.5 py-0.5 font-mono text-[0.625rem] text-[color:var(--color-fg-muted)]"
+                    >
+                      {zone}
+                    </span>
+                  ))}
+                  {row.zones.length > 3 ? (
+                    <span className="rounded bg-[color:var(--color-bg-subtle)] px-1.5 py-0.5 text-[0.625rem] text-[color:var(--color-fg-muted)]">
+                      +{row.zones.length - 3}
+                    </span>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          );
+        },
       },
       {
         accessorKey: "id",

--- a/app/(app)/admin/tsig-keys/page.tsx
+++ b/app/(app)/admin/tsig-keys/page.tsx
@@ -19,9 +19,12 @@ import Link from "next/link";
 import { requireUserForPage } from "@/lib/auth/require-user";
 import { findServerToInspect, listAllPdnsServers } from "@/lib/db/repositories/pdns-servers";
 import { getBackendGateway } from "@/lib/realtime/backend-gateway";
+import { listEligibleTsigKeys } from "@/lib/realtime/tsig-eligibility";
 import { listPrimarySecondaries } from "@/lib/realtime/tsig-replication";
 import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
+import { derivedParentOf } from "@/lib/pdns/topology-cache";
 import { isWriteCapable } from "@/lib/pdns/capabilities";
+import { stripTrailingDot } from "@/lib/pdns/tsig";
 import { readCachedZones } from "@/lib/pdns/zone-state-cache";
 import { PdnsAuthError } from "@/lib/pdns/errors";
 import { logger } from "@/lib/logger";
@@ -79,26 +82,51 @@ export default async function TsigKeysPage({ searchParams }: PageProps) {
     );
   }
 
-  const sorted = keys ? [...keys].sort((a, b) => a.name.localeCompare(b.name)) : null;
-
-  // Replication targets (only meaningful when this backend is a primary): its
-  // secondaries (group ∪ derived) for API install, and its authoritative zones
-  // for in-flow key activation. Warm the broker store so the zone list is fresh.
+  // Replication targets: API install only makes sense when inspecting a primary.
+  // Zone correlation is primary-owned, but secondaries should still display and
+  // edit the same primary-side domain list as a convenience reference.
   const isPrimary = isWriteCapable(selected.capabilities);
   let installSecondaries: Array<{ slug: string; name: string; supportsTsigApi: boolean }> = [];
-  let primaryZones: string[] = [];
-  if (canManage && isPrimary) {
-    await ensureBackendsObserved();
-    installSecondaries = (await listPrimarySecondaries(selected)).map((s) => ({
-      slug: s.slug,
-      name: s.name,
-      supportsTsigApi: !!s.versionCache?.capabilities.supportsTsigApi,
-    }));
-    primaryZones = [...(readCachedZones(selected.id)?.zones.values() ?? [])]
+  let correlationServer: { slug: string; name: string } | null = null;
+  let correlationZones: string[] = [];
+  let keyUsage = new Map<string, { zoneCount: number; zones: string[] }>();
+  await ensureBackendsObserved();
+  const correlationPrimary = resolveCorrelationPrimary(selected, servers);
+  if (correlationPrimary) {
+    correlationServer = { slug: correlationPrimary.slug, name: correlationPrimary.name };
+    if (canManage && selected.id === correlationPrimary.id) {
+      installSecondaries = (await listPrimarySecondaries(selected)).map((s) => ({
+        slug: s.slug,
+        name: s.name,
+        supportsTsigApi: !!s.versionCache?.capabilities.supportsTsigApi,
+      }));
+    }
+    correlationZones = [...(readCachedZones(correlationPrimary.id)?.zones.values() ?? [])]
       .filter((z) => PRIMARY_KINDS.has(z.kind.toLowerCase()))
       .map((z) => z.name)
       .sort();
+    if (keys) {
+      const usage = await listEligibleTsigKeys({
+        keyHosts: [correlationPrimary],
+        zoneHosts: [correlationPrimary],
+      });
+      keyUsage = new Map(usage.map((u) => [u.name, { zoneCount: u.zoneCount, zones: u.zones }]));
+    }
   }
+
+  const sorted = keys
+    ? [...keys]
+        .map((key) => {
+          const usage = keyUsage.get(stripTrailingDot(key.name));
+          return {
+            ...key,
+            zoneCount: usage?.zoneCount ?? 0,
+            zones: usage?.zones ?? [],
+            canEditZones: usage !== undefined,
+          };
+        })
+        .sort((a, b) => a.name.localeCompare(b.name))
+    : null;
 
   return (
     <div className="space-y-6">
@@ -149,7 +177,8 @@ export default async function TsigKeysPage({ searchParams }: PageProps) {
           rows={sorted}
           isPrimary={isPrimary}
           secondaries={installSecondaries}
-          zones={primaryZones}
+          correlationServer={correlationServer}
+          zones={correlationZones}
         />
       ) : fetchError ? null : (
         <TsigKeysReadOnly serverSlug={selected.slug} rows={sorted ?? []} />
@@ -161,4 +190,27 @@ export default async function TsigKeysPage({ searchParams }: PageProps) {
 async function loadKeys(selected: Awaited<ReturnType<typeof findServerToInspect>> & object) {
   const client = getBackendGateway(selected);
   return client.listTsigKeys();
+}
+
+function resolveCorrelationPrimary(
+  selected: NonNullable<Awaited<ReturnType<typeof findServerToInspect>>>,
+  servers: Awaited<ReturnType<typeof listAllPdnsServers>>,
+) {
+  if (isWriteCapable(selected.capabilities)) return selected;
+
+  const active = servers.filter((s) => s.disabledAt === null);
+  const derivedParentId = derivedParentOf(selected.id);
+  const derivedParent = derivedParentId
+    ? active.find((s) => s.id === derivedParentId && isWriteCapable(s.capabilities))
+    : null;
+  if (derivedParent) return derivedParent;
+
+  if (selected.clusterId) {
+    const peers = active.filter(
+      (s) => s.clusterId === selected.clusterId && isWriteCapable(s.capabilities),
+    );
+    if (peers.length === 1) return peers[0]!;
+  }
+
+  return null;
 }

--- a/app/(app)/zones/_components/create-zone-form.tsx
+++ b/app/(app)/zones/_components/create-zone-form.tsx
@@ -58,6 +58,8 @@ export interface BackendOption {
    * operator sees the full replication topology before creating a zone.
    */
   secondaries: Array<{ slug: string; name: string }>;
+  /** Keys present on every backend needed for transfer authentication. */
+  tsigKeys: Array<{ name: string; zoneCount: number }>;
 }
 
 interface TemplateOption {
@@ -151,6 +153,11 @@ export function CreateZoneForm(props: Props) {
   const backendSelection = backendKey ? parseKey(backendKey) : null;
   const [name, setName] = useState("");
   const [kind, setKind] = useState<(typeof KINDS)[number]["value"]>("Native");
+  const selectedBackend = backendSelection
+    ? (props.backends.find(
+        (b) => b.kind === backendSelection.kind && b.slug === backendSelection.slug,
+      ) ?? null)
+    : null;
 
   // Compute the template the form should pre-apply for a given backend
   // selection - the first template registered as the default for any
@@ -187,12 +194,19 @@ export function CreateZoneForm(props: Props) {
   const [responsibleEmail, setResponsibleEmail] = useState("");
   const [nameservers, setNameservers] = useState<string[]>([""]);
   const [masters, setMasters] = useState<string[]>([]);
+  const [selectedTsigKey, setSelectedTsigKey] = useState("");
+  const tsigTouched = useRef(false);
+  const tsigScopeRef = useRef(`${backendKey}:${kind}`);
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({});
 
   const isSecondary = kind === "Secondary";
+  const eligibleTsigKeys = useMemo(
+    () => (kind === "Primary" ? (selectedBackend?.tsigKeys ?? []) : []),
+    [kind, selectedBackend],
+  );
 
   const selectedTemplate = props.templates.find((t) => t.id === templateId);
 
@@ -241,6 +255,21 @@ export function CreateZoneForm(props: Props) {
     // state would re-fire it on unrelated renders and clobber user edits.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [backendKey]);
+
+  useEffect(() => {
+    const scope = `${backendKey}:${kind}`;
+    if (tsigScopeRef.current !== scope) {
+      tsigScopeRef.current = scope;
+      tsigTouched.current = false;
+    }
+    if (!tsigTouched.current) {
+      setSelectedTsigKey(eligibleTsigKeys[0]?.name ?? "");
+      return;
+    }
+    if (selectedTsigKey && !eligibleTsigKeys.some((key) => key.name === selectedTsigKey)) {
+      setSelectedTsigKey("");
+    }
+  }, [backendKey, eligibleTsigKeys, kind, selectedTsigKey]);
 
   function addNs() {
     setNameservers([...nameservers, ""]);
@@ -316,6 +345,7 @@ export function CreateZoneForm(props: Props) {
     };
     if (templateId) body["templateId"] = templateId;
     if (responsibleEmail) body["responsibleEmail"] = responsibleEmail;
+    if (kind === "Primary" && selectedTsigKey) body["tsigKeyName"] = selectedTsigKey;
 
     try {
       const res = await apiFetch("/api/admin/pdns/zones", {
@@ -345,12 +375,6 @@ export function CreateZoneForm(props: Props) {
       </div>
     );
   }
-
-  const selectedBackend = backendSelection
-    ? (props.backends.find(
-        (b) => b.kind === backendSelection.kind && b.slug === backendSelection.slug,
-      ) ?? null)
-    : null;
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6" autoComplete="off">
@@ -470,6 +494,27 @@ export function CreateZoneForm(props: Props) {
           </div>
         ) : null}
       </Section>
+
+      {kind === "Primary" && eligibleTsigKeys.length > 0 ? (
+        <Section
+          title="TSIG keys"
+          subtitle="Only keys present on the primary and every secondary are selectable."
+        >
+          <TsigKeySection
+            keys={eligibleTsigKeys}
+            selected={selectedTsigKey}
+            onSelect={(next) => {
+              tsigTouched.current = true;
+              setSelectedTsigKey(next);
+            }}
+          />
+          {fieldErrors["tsigKeyName"] ? (
+            <p className="text-xs text-[color:var(--color-error)]" role="alert">
+              {fieldErrors["tsigKeyName"].join(" ")}
+            </p>
+          ) : null}
+        </Section>
+      ) : null}
 
       {isSecondary ? (
         <Section
@@ -651,6 +696,74 @@ function SecondariesList({ secondaries }: { secondaries: Array<{ slug: string; n
         </li>
       ))}
     </ul>
+  );
+}
+
+function TsigKeySection({
+  keys,
+  selected,
+  onSelect,
+}: {
+  keys: Array<{ name: string; zoneCount: number }>;
+  selected: string;
+  onSelect: (next: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={() => onSelect("")}
+        aria-pressed={selected === ""}
+        className={`flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left text-sm ${
+          selected === ""
+            ? "border-[color:var(--color-accent)] bg-[color:var(--color-accent)]/10"
+            : "border-[color:var(--color-border)] hover:bg-[color:var(--color-bg-subtle)]"
+        }`}
+      >
+        <span
+          aria-hidden
+          className={`h-2.5 w-2.5 shrink-0 rounded-full ${
+            selected === "" ? "bg-[color:var(--color-accent)]" : "bg-[color:var(--color-border)]"
+          }`}
+        />
+        <span className="min-w-0">
+          <span className="block font-medium">No TSIG key</span>
+          <span className="block text-xs text-[color:var(--color-fg-muted)]">
+            Create the zone without transfer authentication.
+          </span>
+        </span>
+      </button>
+      {keys.map((key, index) => {
+        const active = selected === key.name;
+        return (
+          <button
+            key={key.name}
+            type="button"
+            onClick={() => onSelect(key.name)}
+            aria-pressed={active}
+            className={`flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left text-sm ${
+              active
+                ? "border-[color:var(--color-accent)] bg-[color:var(--color-accent)]/10"
+                : "border-[color:var(--color-border)] hover:bg-[color:var(--color-bg-subtle)]"
+            }`}
+          >
+            <span
+              aria-hidden
+              className={`h-2.5 w-2.5 shrink-0 rounded-full ${
+                active ? "bg-[color:var(--color-accent)]" : "bg-[color:var(--color-border)]"
+              }`}
+            />
+            <span className="min-w-0 flex-1">
+              <span className="block font-mono text-xs break-all">{key.name}</span>
+              <span className="mt-0.5 block text-xs text-[color:var(--color-fg-muted)]">
+                {key.zoneCount} existing domain{key.zoneCount === 1 ? "" : "s"} use this key
+                {index === 0 ? " - default" : ""}
+              </span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
   );
 }
 

--- a/app/(app)/zones/new/page.tsx
+++ b/app/(app)/zones/new/page.tsx
@@ -10,6 +10,8 @@
 import { requireUserForPage } from "@/lib/auth/require-user";
 import { listSelectableBackends } from "@/lib/db/repositories/selectable-backends";
 import { listAllZoneTemplates } from "@/lib/db/repositories/zone-templates";
+import { listEligibleTsigKeys } from "@/lib/realtime/tsig-eligibility";
+import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
 import { CreateZoneForm, type BackendOption } from "../_components/create-zone-form";
 
 export const metadata = { title: "Create zone" };
@@ -19,7 +21,8 @@ export default async function NewZonePage({
 }: {
   searchParams: Promise<{ server?: string; cluster?: string; template?: string }>;
 }) {
-  await requireUserForPage({ can: "zone.create" });
+  const { globalPermissions } = await requireUserForPage({ can: "zone.create" });
+  const canReadTsig = globalPermissions.has("tsig.read");
   const {
     server: requestedServerSlug,
     cluster: requestedClusterSlug,
@@ -30,6 +33,34 @@ export default async function NewZonePage({
     listSelectableBackends(),
     listAllZoneTemplates(),
   ]);
+  if (canReadTsig) {
+    await ensureBackendsObserved();
+  }
+
+  const tsigKeysByBackend = new Map<string, Array<{ name: string; zoneCount: number }>>();
+  if (canReadTsig) {
+    const entries = await Promise.all(
+      backends.map(async (b) => {
+        const backendKey =
+          b.kind === "cluster" ? `cluster:${b.cluster.slug}` : `server:${b.server.slug}`;
+        const eligible =
+          b.kind === "cluster"
+            ? await listEligibleTsigKeys({
+                keyHosts: [...b.peers, ...b.secondaries],
+                zoneHosts: b.peers,
+              })
+            : await listEligibleTsigKeys({
+                keyHosts: [b.server, ...b.secondaries],
+                zoneHosts: [b.server],
+              });
+        return [
+          backendKey,
+          eligible.map((k) => ({ name: k.name, zoneCount: k.zoneCount })),
+        ] as const;
+      }),
+    );
+    for (const [backendKey, keys] of entries) tsigKeysByBackend.set(backendKey, keys);
+  }
 
   // Collapse SelectableBackend[] into the form's option shape. A cluster
   // is ONE option (not its peers) - the write_strategy picks the peer at
@@ -47,6 +78,7 @@ export default async function NewZonePage({
           isDefault: false,
           primaryIds: b.peers.map((peer) => peer.id),
           secondaries: [],
+          tsigKeys: tsigKeysByBackend.get(`cluster:${b.cluster.slug}`) ?? [],
         }
       : {
           kind: "server",
@@ -55,6 +87,7 @@ export default async function NewZonePage({
           isDefault: b.server.isDefault,
           primaryIds: [b.server.id],
           secondaries: b.secondaries.map((s) => ({ slug: s.slug, name: s.name })),
+          tsigKeys: tsigKeysByBackend.get(`server:${b.server.slug}`) ?? [],
         },
   );
 

--- a/app/api/admin/pdns/zones/route.ts
+++ b/app/api/admin/pdns/zones/route.ts
@@ -25,6 +25,8 @@ import { findDefaultPdnsServer, findPdnsServerBySlug } from "@/lib/db/repositori
 import { findClusterBySlug, listActivePeersForCluster } from "@/lib/db/repositories/pdns-clusters";
 import { findZoneTemplateById } from "@/lib/db/repositories/zone-templates";
 import { getBackendGateway } from "@/lib/realtime/backend-gateway";
+import { assertTsigKeyPresentOnPrimaryAndSecondaries } from "@/lib/realtime/tsig-eligibility";
+import { setZoneTransferKey } from "@/lib/realtime/tsig-replication";
 import { choosePeer } from "@/lib/pdns/cluster-picker";
 import { expandTemplateName } from "@/lib/validators/zone-templates";
 import { serializeSoaContent } from "@/lib/validators/soa";
@@ -33,7 +35,7 @@ import { redact } from "@/lib/errors/redact";
 import { logger } from "@/lib/logger";
 import { publishZoneEvent } from "@/lib/realtime/event-bus";
 import { scheduleImmediatePoll } from "@/lib/realtime/zone-poller";
-import { ConflictError, ValidationError } from "@/lib/errors";
+import { ConflictError, ForbiddenError, ValidationError } from "@/lib/errors";
 import { errorResponse } from "@/lib/http/error-response";
 
 const KIND_VALUES = ["Native", "Master", "Primary", "Slave", "Secondary"] as const;
@@ -81,11 +83,18 @@ const createZoneSchema = z.object({
     .max(320)
     .regex(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, "Looks like it isn't a valid email.")
     .optional(),
+  /** Optional transfer-auth key, validated against the target backend before create. */
+  tsigKeyName: z
+    .string()
+    .min(1)
+    .max(255)
+    .regex(/^[A-Za-z0-9.-]+$/, "Invalid key name.")
+    .optional(),
 });
 
 export async function POST(request: Request): Promise<Response> {
   try {
-    const { user } = await requireUser({ can: "zone.create" });
+    const { user, globalPermissions } = await requireUser({ can: "zone.create" });
     await requireCsrf(request);
 
     let input;
@@ -139,6 +148,7 @@ export async function POST(request: Request): Promise<Response> {
 
     // ── Slave / Secondary requires master IPs ──────────────────────────────
     const isSecondary = input.kind === "Slave" || input.kind === "Secondary";
+    const isTransferPrimary = input.kind === "Master" || input.kind === "Primary";
     if (isSecondary && input.masters.length === 0) {
       throw new ValidationError(
         "Secondary / Slave zones need at least one primary master IP to pull from.",
@@ -148,6 +158,15 @@ export async function POST(request: Request): Promise<Response> {
       throw new ValidationError(
         "Master / Primary / Native zones can't have a `masters` list - that field is only meaningful for Secondary.",
       );
+    }
+    if (input.tsigKeyName) {
+      if (!globalPermissions.has("tsig.read")) {
+        throw new ForbiddenError("Missing permission: tsig.read");
+      }
+      if (!isTransferPrimary) {
+        throw new ValidationError("TSIG keys can only be applied to Primary / Master zones.");
+      }
+      await assertTsigKeyPresentOnPrimaryAndSecondaries(server, input.tsigKeyName);
     }
 
     // ── Template resolution ────────────────────────────────────────────────
@@ -319,6 +338,22 @@ export async function POST(request: Request): Promise<Response> {
       }
     }
 
+    const tsigResult = input.tsigKeyName
+      ? await setZoneTransferKey(server, zoneName, input.tsigKeyName, "add")
+      : null;
+    if (tsigResult && (!tsigResult.primaryOk || tsigResult.secondaries.some((s) => !s.ok))) {
+      logger.warn(
+        {
+          server: server.slug,
+          zone: zoneName,
+          keyName: input.tsigKeyName,
+          primaryOk: tsigResult.primaryOk,
+          secondaries: tsigResult.secondaries,
+        },
+        "zone.create.tsig-transfer.partial",
+      );
+    }
+
     const hdrs = await headers();
     await appendAudit({
       actor: { type: "user", id: user.id },
@@ -331,9 +366,28 @@ export async function POST(request: Request): Promise<Response> {
         nameservers: normalizedNs,
         masters: isSecondary ? input.masters : [],
         rrsetCount: rrsets.length,
+        tsigKeyName: input.tsigKeyName ?? null,
       },
       request: getRequestContext(hdrs),
     });
+    if (input.tsigKeyName && tsigResult) {
+      await appendAudit({
+        actor: { type: "user", id: user.id },
+        action: "zone.tsig-transfer.set",
+        resource: { type: "zone", id: `${server.slug}:${zoneName}` },
+        after: {
+          keyName: input.tsigKeyName,
+          mode: "add",
+          primaryOk: tsigResult.primaryOk,
+          secondaries: tsigResult.secondaries.map((s) => ({
+            server: s.serverSlug,
+            hosted: s.hosted,
+            ok: s.ok,
+          })),
+        },
+        request: getRequestContext(hdrs),
+      });
+    }
 
     // Auto-NOTIFY freshly-created Master/Primary zones so secondaries
     // pick up the new zone immediately instead of waiting for refresh.

--- a/lib/pdns/client.ts
+++ b/lib/pdns/client.ts
@@ -178,12 +178,13 @@ export class PdnsClient {
     return pdnsZoneListSchema.parse(body);
   }
 
-  /** `GET /servers/{id}/zones/{zoneId}` - detail incl. `rrsets`. */
-  public async getZone(zoneName: string): Promise<PdnsZoneDetail> {
+  /** `GET /servers/{id}/zones/{zoneId}` - detail, with optional `rrsets` elision. */
+  public async getZone(zoneName: string, opts?: { rrsets?: boolean }): Promise<PdnsZoneDetail> {
     const id = normalizeZoneId(zoneName);
+    const query = opts?.rrsets === undefined ? "" : `?rrsets=${opts.rrsets ? "true" : "false"}`;
     const body = await this.request<unknown>({
       method: "GET",
-      path: `/servers/${encodeURIComponent(this.serverId)}/zones/${encodeURIComponent(id)}`,
+      path: `/servers/${encodeURIComponent(this.serverId)}/zones/${encodeURIComponent(id)}${query}`,
       op: "zones.get",
     });
     return pdnsZoneDetailSchema.parse(body);

--- a/lib/realtime/tsig-eligibility.test.ts
+++ b/lib/realtime/tsig-eligibility.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PdnsServer } from "@/lib/db/schema";
+import { listEligibleTsigKeys } from "./tsig-eligibility";
+
+const mocks = vi.hoisted(() => ({
+  clients: new Map<
+    string,
+    {
+      listTsigKeys: ReturnType<typeof vi.fn>;
+      listZones: ReturnType<typeof vi.fn>;
+      getZone: ReturnType<typeof vi.fn>;
+    }
+  >(),
+}));
+
+vi.mock("./backend-gateway", () => ({
+  getBackendGateway: (server: { id: string }) => {
+    const client = mocks.clients.get(server.id);
+    if (!client) throw new Error(`missing mock client for ${server.id}`);
+    return client;
+  },
+}));
+
+vi.mock("./tsig-replication", () => ({
+  listPrimarySecondaries: vi.fn(),
+}));
+
+function server(id: string): PdnsServer {
+  return { id, slug: id, name: id } as PdnsServer;
+}
+
+function client({
+  keys,
+  zones = [],
+}: {
+  keys: string[];
+  zones?: Array<{ name: string; kind: string; masterTsigKeyIds?: string[] }>;
+}) {
+  const zoneByName = new Map(zones.map((z) => [z.name, z]));
+  return {
+    listTsigKeys: vi.fn(() => Promise.resolve(keys.map((name) => ({ name })))),
+    listZones: vi.fn(() =>
+      Promise.resolve(
+        zones.map((z) => ({
+          id: z.name,
+          name: z.name,
+          kind: z.kind,
+        })),
+      ),
+    ),
+    getZone: vi.fn((zoneName: string) => {
+      const z = zoneByName.get(zoneName);
+      if (!z) throw new Error(`missing zone ${zoneName}`);
+      return Promise.resolve({
+        id: z.name,
+        name: z.name,
+        kind: z.kind,
+        master_tsig_key_ids: z.masterTsigKeyIds ?? [],
+      });
+    }),
+  };
+}
+
+describe("listEligibleTsigKeys", () => {
+  beforeEach(() => {
+    mocks.clients.clear();
+  });
+
+  it("counts configured domains from zone details fetched without rrsets", async () => {
+    const primary = server("primary");
+    const secondary = server("secondary");
+    const primaryClient = client({
+      keys: ["shared", "primary-only"],
+      zones: [
+        { name: "one.example.", kind: "Master", masterTsigKeyIds: ["shared."] },
+        { name: "two.example.", kind: "Primary", masterTsigKeyIds: ["other"] },
+        { name: "mirror.example.", kind: "Secondary", masterTsigKeyIds: ["shared"] },
+      ],
+    });
+    const secondaryClient = client({ keys: ["shared"] });
+    mocks.clients.set(primary.id, primaryClient);
+    mocks.clients.set(secondary.id, secondaryClient);
+
+    await expect(
+      listEligibleTsigKeys({
+        keyHosts: [primary, secondary],
+        zoneHosts: [primary],
+      }),
+    ).resolves.toEqual([{ name: "shared", zoneCount: 1, zones: ["one.example."] }]);
+
+    expect(primaryClient.listZones).toHaveBeenCalledTimes(1);
+    expect(primaryClient.getZone).toHaveBeenCalledTimes(2);
+    expect(primaryClient.getZone).toHaveBeenCalledWith("one.example.", { rrsets: false });
+    expect(primaryClient.getZone).toHaveBeenCalledWith("two.example.", { rrsets: false });
+  });
+});

--- a/lib/realtime/tsig-eligibility.ts
+++ b/lib/realtime/tsig-eligibility.ts
@@ -1,0 +1,179 @@
+/**
+ * lib/realtime/tsig-eligibility.ts
+ *
+ * Shared TSIG key eligibility logic for workflows that need to preselect or
+ * validate a key before applying it to zone transfers. A key is eligible only
+ * when the same key name exists on every backend that must participate.
+ */
+
+import "server-only";
+import type { PdnsServer } from "@/lib/db/schema";
+import { ValidationError } from "@/lib/errors";
+import { stripTrailingDot } from "@/lib/pdns/tsig";
+import type { PdnsZoneSummary } from "@/lib/pdns/types";
+import { logger } from "@/lib/logger";
+import { redact } from "@/lib/errors/redact";
+import { getBackendGateway } from "./backend-gateway";
+import { listPrimarySecondaries } from "./tsig-replication";
+
+const AUTHORITATIVE_KINDS = new Set(["master", "primary"]);
+
+export interface EligibleTsigKey {
+  name: string;
+  zoneCount: number;
+  zones: string[];
+}
+
+interface TsigEligibilityOptions {
+  /** Every backend in this set must already hold the key. */
+  keyHosts: readonly PdnsServer[];
+  /** Authoritative backends whose zones contribute usage counts. */
+  zoneHosts: readonly PdnsServer[];
+}
+
+/** Run an async mapper over `items` at most `limit` at a time. */
+async function mapLimit<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const out: R[] = [];
+  for (let i = 0; i < items.length; i += limit) {
+    out.push(...(await Promise.all(items.slice(i, i + limit).map(fn))));
+  }
+  return out;
+}
+
+function uniqueServers(servers: readonly PdnsServer[]): PdnsServer[] {
+  return [...new Map(servers.map((s) => [s.id, s])).values()];
+}
+
+async function listKeyNames(server: PdnsServer): Promise<Set<string>> {
+  const keys = await getBackendGateway(server).listTsigKeys();
+  return new Set(keys.map((k) => stripTrailingDot(k.name)));
+}
+
+function intersectKeySets(sets: ReadonlyArray<Set<string>>): Set<string> {
+  if (sets.length === 0) return new Set();
+  const [first, ...rest] = sets;
+  return new Set([...first!].filter((name) => rest.every((set) => set.has(name))));
+}
+
+async function authoritativeZones(server: PdnsServer): Promise<PdnsZoneSummary[]> {
+  const zones = await getBackendGateway(server)
+    .listZones()
+    .catch((err: unknown) => {
+      logger.warn(
+        {
+          server: server.slug,
+          err: err instanceof Error ? redact(err.message) : "unknown",
+        },
+        "tsig.eligibility.zone-list.failed",
+      );
+      return [];
+    });
+
+  return zones.filter((z) => AUTHORITATIVE_KINDS.has(z.kind.toLowerCase()));
+}
+
+async function countZonesByKey(
+  zoneHosts: readonly PdnsServer[],
+  candidateNames: ReadonlySet<string>,
+): Promise<Map<string, Set<string>>> {
+  const zonesByKey = new Map<string, Set<string>>();
+
+  for (const host of uniqueServers(zoneHosts)) {
+    const client = getBackendGateway(host);
+    const zoneNames = (await authoritativeZones(host)).map((z) => z.name).sort();
+    const details = await mapLimit(zoneNames, 8, async (zoneName) => {
+      try {
+        return await client.getZone(zoneName, { rrsets: false });
+      } catch (err) {
+        logger.warn(
+          {
+            server: host.slug,
+            zone: zoneName,
+            err: err instanceof Error ? redact(err.message) : "unknown",
+          },
+          "tsig.eligibility.zone-detail.failed",
+        );
+        return null;
+      }
+    });
+
+    for (const zone of details) {
+      if (!zone) continue;
+      for (const raw of zone.master_tsig_key_ids ?? []) {
+        const keyName = stripTrailingDot(raw);
+        if (!candidateNames.has(keyName)) continue;
+        const set = zonesByKey.get(keyName) ?? new Set<string>();
+        set.add(zone.name);
+        zonesByKey.set(keyName, set);
+      }
+    }
+  }
+
+  return zonesByKey;
+}
+
+export async function listEligibleTsigKeys({
+  keyHosts,
+  zoneHosts,
+}: TsigEligibilityOptions): Promise<EligibleTsigKey[]> {
+  const hosts = uniqueServers(keyHosts);
+  if (hosts.length === 0) return [];
+
+  let keySets: Array<Set<string>>;
+  try {
+    keySets = await Promise.all(hosts.map((host) => listKeyNames(host)));
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? redact(err.message) : "unknown" },
+      "tsig.eligibility.key-list.failed",
+    );
+    return [];
+  }
+
+  const commonNames = intersectKeySets(keySets);
+  if (commonNames.size === 0) return [];
+
+  const counts = await countZonesByKey(zoneHosts.length > 0 ? zoneHosts : hosts, commonNames);
+  return [...commonNames]
+    .map((name) => {
+      const zones = [...(counts.get(name) ?? new Set<string>())].sort();
+      return { name, zoneCount: zones.length, zones };
+    })
+    .sort((a, b) => b.zoneCount - a.zoneCount || a.name.localeCompare(b.name));
+}
+
+export async function assertTsigKeyPresentOnAll(
+  hosts: readonly PdnsServer[],
+  keyName: string,
+): Promise<void> {
+  const normalized = stripTrailingDot(keyName);
+  const missing: Array<{ slug: string; name: string }> = [];
+
+  for (const host of uniqueServers(hosts)) {
+    try {
+      const keys = await listKeyNames(host);
+      if (!keys.has(normalized)) missing.push({ slug: host.slug, name: host.name });
+    } catch {
+      missing.push({ slug: host.slug, name: host.name });
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new ValidationError(
+      "TSIG key must exist on the primary and every secondary before it can be applied to a new Primary zone.",
+      { missingBackends: missing },
+    );
+  }
+}
+
+export async function assertTsigKeyPresentOnPrimaryAndSecondaries(
+  primary: PdnsServer,
+  keyName: string,
+): Promise<void> {
+  const secondaries = await listPrimarySecondaries(primary);
+  await assertTsigKeyPresentOnAll([primary, ...secondaries], keyName);
+}

--- a/tests/integration/admin/tsig-keys.test.ts
+++ b/tests/integration/admin/tsig-keys.test.ts
@@ -170,6 +170,35 @@ async function backendZone(
   };
 }
 
+/** Raw PDNS getZone with rrsets=false - validates the lightweight detail path
+ *  used for TSIG correlation across the compatibility matrix. */
+async function backendZoneWithoutRrsets(
+  b: PdnsBackend,
+  zoneId: string,
+): Promise<{
+  master_tsig_key_ids: string[];
+  slave_tsig_key_ids: string[];
+  hasRrsets: boolean;
+} | null> {
+  const res = await fetch(
+    `${b.baseUrl}/servers/localhost/zones/${encodeURIComponent(zoneId)}?rrsets=false`,
+    {
+      headers: { "X-API-Key": b.apiKey },
+    },
+  );
+  if (!res.ok) return null;
+  const z = (await res.json()) as {
+    master_tsig_key_ids?: string[];
+    slave_tsig_key_ids?: string[];
+    rrsets?: unknown;
+  };
+  return {
+    master_tsig_key_ids: (z.master_tsig_key_ids ?? []).map(stripTrailingDot),
+    slave_tsig_key_ids: (z.slave_tsig_key_ids ?? []).map(stripTrailingDot),
+    hasRrsets: Object.hasOwn(z, "rrsets"),
+  };
+}
+
 /** Raw PDNS getTsigKey - returns the base64 secret (for replication-fidelity checks). */
 async function backendTsigSecret(b: PdnsBackend, id: string): Promise<string | null> {
   const res = await fetch(`${b.baseUrl}/servers/localhost/tsigkeys/${encodeURIComponent(id)}`, {
@@ -312,6 +341,9 @@ describe("/api/admin/pdns/zones/[zoneId]/tsig-transfer", () => {
       expect(add1.primaryOk).toBe(true);
       let z = await backendZone(primary, zone);
       expect(z?.master_tsig_key_ids ?? []).toContain(k1);
+      const lightweight = await backendZoneWithoutRrsets(primary, zone);
+      expect(lightweight?.hasRrsets).toBe(false);
+      expect(lightweight?.master_tsig_key_ids ?? []).toContain(k1);
 
       // Add k2 - k1 must be preserved (non-clobber).
       await transfer(k2, "add");
@@ -331,6 +363,88 @@ describe("/api/admin/pdns/zones/[zoneId]/tsig-transfer", () => {
       await deleteBackendTsig(primary, k2);
     }
   }, 30_000);
+});
+
+describe("POST /api/admin/pdns/zones with tsigKeyName", () => {
+  beforeEach(async () => {
+    await resetState();
+  });
+
+  it("applies an eligible TSIG key to the new Primary zone", async () => {
+    const admin = await loginAsBootstrap();
+    const primary = PDNS_BY_TOPOLOGY.psPrimary;
+    await admin.call("/api/admin/pdns-servers/refresh-all", { method: "POST" });
+
+    const name = uniqueTsigName("create-zone");
+    const zone = `create-tsig-${Date.now().toString(36)}.example.`;
+    const created = await admin.sendJson<TsigCreateResponse>("POST", "/api/admin/pdns/tsig-keys", {
+      serverSlug: primary.slug,
+      name,
+      algorithm: "hmac-sha256",
+    });
+
+    try {
+      await admin.sendJson<InstallResponse>(
+        "POST",
+        `/api/admin/pdns/tsig-keys/${encodeURIComponent(created.tsigKey.id)}/install`,
+        { serverSlug: primary.slug },
+      );
+      await admin.sendJson("POST", "/api/admin/pdns/zones", {
+        serverSlug: primary.slug,
+        name: zone,
+        kind: "Master",
+        nameservers: ["ns1.example."],
+        tsigKeyName: name,
+      });
+
+      expect((await backendZone(primary, zone))?.master_tsig_key_ids ?? []).toContain(name);
+      const rows = await dbQuery<{ action: string; after: { keyName?: string } }>(
+        "SELECT action, after FROM audit_log WHERE resource_id = $1 ORDER BY ts",
+        [`${primary.slug}:${zone}`],
+      );
+      expect(rows.map((r) => r.action)).toContain("zone.tsig-transfer.set");
+      expect(rows.find((r) => r.action === "zone.tsig-transfer.set")?.after.keyName).toBe(name);
+    } finally {
+      await deleteBackendZone(primary, zone);
+      await deleteBackendTsig(primary, name);
+      for (const s of PDNS_BY_TOPOLOGY.psSecondaries) await deleteBackendTsig(s, name);
+    }
+  }, 45_000);
+
+  it("rejects a TSIG key that is not installed on every secondary", async () => {
+    const admin = await loginAsBootstrap();
+    const primary = PDNS_BY_TOPOLOGY.psPrimary;
+    await admin.call("/api/admin/pdns-servers/refresh-all", { method: "POST" });
+
+    const name = uniqueTsigName("missing-secondary");
+    const zone = `missing-tsig-${Date.now().toString(36)}.example.`;
+    await admin.sendJson<TsigCreateResponse>("POST", "/api/admin/pdns/tsig-keys", {
+      serverSlug: primary.slug,
+      name,
+      algorithm: "hmac-sha256",
+    });
+
+    try {
+      const res = await admin.call("/api/admin/pdns/zones", {
+        method: "POST",
+        json: {
+          serverSlug: primary.slug,
+          name: zone,
+          kind: "Master",
+          nameservers: ["ns1.example."],
+          tsigKeyName: name,
+        },
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error?: string };
+      expect(body.error ?? "").toMatch(/primary and every secondary/i);
+      expect(await backendZone(primary, zone)).toBeNull();
+    } finally {
+      await deleteBackendZone(primary, zone);
+      await deleteBackendTsig(primary, name);
+      for (const s of PDNS_BY_TOPOLOGY.psSecondaries) await deleteBackendTsig(s, name);
+    }
+  }, 45_000);
 });
 
 describe("DELETE /api/admin/pdns/tsig-keys/[id]?cascade=true", () => {
@@ -515,6 +629,12 @@ describe("TSIG mutations keep AXFR replication working (ps topology)", () => {
       // The app configured TSIG transfer on BOTH sides (read fresh off PDNS).
       expect((await backendZone(primary, zone))?.master_tsig_key_ids ?? []).toContain(name);
       expect((await backendZone(secondary, zone))?.slave_tsig_key_ids ?? []).toContain(name);
+      const primaryLightweight = await backendZoneWithoutRrsets(primary, zone);
+      const secondaryLightweight = await backendZoneWithoutRrsets(secondary, zone);
+      expect(primaryLightweight?.hasRrsets).toBe(false);
+      expect(secondaryLightweight?.hasRrsets).toBe(false);
+      expect(primaryLightweight?.master_tsig_key_ids ?? []).toContain(name);
+      expect(secondaryLightweight?.slave_tsig_key_ids ?? []).toContain(name);
 
       // ADD: edit a record on the primary; it must reach the secondary over AXFR.
       await upsertA(a1, "192.0.2.81");

--- a/tests/integration/helpers/pdns.ts
+++ b/tests/integration/helpers/pdns.ts
@@ -108,6 +108,8 @@ export interface PdnsZone {
   kind: string;
   serial?: number;
   rrsets?: PdnsRRset[];
+  master_tsig_key_ids?: string[];
+  slave_tsig_key_ids?: string[];
 }
 
 async function pdnsCall(


### PR DESCRIPTION
## Summary

- Redesign the TSIG secure-zones wizard step with a wider searchable multi-select, selected/configured state, select-all/clear controls, and clearer apply action.
- Show primary-owned zone correlation on TSIG key rows, including when viewing replicated secondary key holders, with Edit opening the same zone-selection flow against the primary.
- Keep delete behavior backend-specific while install/edit zone correlation remains primary-driven.
- Add TSIG key selection to new Primary zone creation, validating that the chosen key exists on the primary and all secondaries before applying it.
- Move TSIG usage counting onto lightweight PowerDNS zone detail reads with `rrsets=false`, avoiding full RRset payloads while preserving 4.6-5.0 compatibility coverage.

## Compatibility

- The repo already runs PDNS compatibility workflows for 4.6, 4.7, 4.8, 4.9, and 5.0 via `PDNS_AUTH_IMAGE`.
- Added integration assertions that `GET /zones/{id}?rrsets=false` returns `master_tsig_key_ids` / `slave_tsig_key_ids` and omits `rrsets`; those assertions run in the compatibility matrix.

## Verification

- `npm run ci:local`
- `npm run test:integration`
- `npm run test:integration -- tests/integration/admin/tsig-keys.test.ts`
- `npx vitest run lib/realtime/tsig-eligibility.test.ts`

Closes #98
Closes #99