### PR TITLE
feat: secure import and settings backup flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added - TSIG key zone workflows (#100, #101)
+
+The TSIG Keys admin page now shows each key's zone correlation, including mirrored
+domain usage when viewing replicated key copies on secondaries. Operators can edit
+that correlation from the key row through the same clean multi-select domain picker
+used in the create-key wizard. Applying a key to zones now triggers the work in the
+background and reports the summary after completion instead of requiring the modal
+to remain open while each request finishes.
+
+The Add Zone flow now includes a TSIG Keys section for Primary / Master zones. A
+key is selectable only when it exists on the primary and every secondary that must
+participate in AXFR; the most-used eligible key is selected by default. The same
+selector is now available on Zone Import, so imported Master zones can be created
+with transfer authentication in one pass. Both create and import validate the key
+server-side before applying it and audit the resulting `zone.tsig-transfer.set`
+action.
+
+### Fixed - SETTINGS_RO now covers Backup & Restore (#102)
+
+`SETTINGS_RO=true` now blocks settings backup export and restore in the API as well
+as the UI. The Backup & Restore page shows the read-only deployment lock and
+disables download, upload, and restore controls, while the backend remains the
+security boundary for direct API calls.
+
+### Changed - repository standards and documentation polish (#97)
+
+Repo standards documentation was tightened after the standards audit: validator and
+RBAC guidance now more clearly describe ownership boundaries, environment handling,
+and contributor expectations. Integration coverage and local validation were kept
+aligned with the documented Node 24 workflow.
+
 ## [1.4.2] - 2026-06-02
 
 A cosmetic patch release. No migration, no breaking changes, no config or

--- a/app/(app)/admin/import-export/_components/import-export-client.tsx
+++ b/app/(app)/admin/import-export/_components/import-export-client.tsx
@@ -16,15 +16,17 @@
  * isn't allowed in this app - feedback memory.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Upload, Download, ArrowDownToLine, ArrowUpFromLine } from "lucide-react";
 import { apiFetch, mutate } from "@/lib/client/api-fetch";
+import { TsigKeySelector } from "@/components/domain/tsig-key-selector";
 import { SelectMenu } from "@/components/ui/select-menu";
 import { useDialog } from "@/components/ui/dialog";
 
 interface Backend {
   slug: string;
   label: string;
+  tsigKeys: Array<{ name: string; zoneCount: number }>;
 }
 
 interface ImportResult {
@@ -111,12 +113,39 @@ function TabButton({
 function ImportPanel({ backends }: { backends: Backend[] }) {
   const [server, setServer] = useState<string>(backends[0]?.slug ?? "");
   const [kind, setKind] = useState<ZoneKind>("Master");
+  const [selectedTsigKey, setSelectedTsigKey] = useState("");
+  const tsigTouched = useRef(false);
+  const tsigScopeRef = useRef(`${server}:${kind}`);
   const [zoneText, setZoneText] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [results, setResults] = useState<ImportResult[] | null>(null);
   const [diagnostics, setDiagnostics] = useState<ParseDiagnostic[]>([]);
   const [topError, setTopError] = useState<string | null>(null);
   const { toast } = useDialog();
+
+  const selectedBackend = useMemo(
+    () => backends.find((backend) => backend.slug === server) ?? null,
+    [backends, server],
+  );
+  const eligibleTsigKeys = useMemo(
+    () => (kind === "Master" ? (selectedBackend?.tsigKeys ?? []) : []),
+    [kind, selectedBackend],
+  );
+
+  useEffect(() => {
+    const scope = `${server}:${kind}`;
+    if (tsigScopeRef.current !== scope) {
+      tsigScopeRef.current = scope;
+      tsigTouched.current = false;
+    }
+    if (!tsigTouched.current) {
+      setSelectedTsigKey(eligibleTsigKeys[0]?.name ?? "");
+      return;
+    }
+    if (selectedTsigKey && !eligibleTsigKeys.some((key) => key.name === selectedTsigKey)) {
+      setSelectedTsigKey("");
+    }
+  }, [eligibleTsigKeys, kind, selectedTsigKey, server]);
 
   const handlePickFile = useCallback(async (file: File) => {
     setZoneText(await file.text());
@@ -137,7 +166,12 @@ function ImportPanel({ backends }: { backends: Backend[] }) {
       }>("/api/admin/pdns/zones/import", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ serverSlug: server, zoneText, kind }),
+        body: JSON.stringify({
+          serverSlug: server,
+          zoneText,
+          kind,
+          ...(kind === "Master" && selectedTsigKey ? { tsigKeyName: selectedTsigKey } : {}),
+        }),
       });
       if (!out.ok) {
         setTopError(out.error);
@@ -204,6 +238,27 @@ function ImportPanel({ backends }: { backends: Backend[] }) {
             />
           </Field>
         </div>
+
+        {kind === "Master" && eligibleTsigKeys.length > 0 ? (
+          <div className="mt-4 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-4">
+            <h3 className="text-sm font-medium tracking-wide text-[color:var(--color-fg-muted)] uppercase">
+              TSIG keys
+            </h3>
+            <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">
+              Only keys present on the primary and every secondary are selectable.
+            </p>
+            <div className="mt-3">
+              <TsigKeySelector
+                keys={eligibleTsigKeys}
+                selected={selectedTsigKey}
+                onSelect={(next) => {
+                  tsigTouched.current = true;
+                  setSelectedTsigKey(next);
+                }}
+              />
+            </div>
+          </div>
+        ) : null}
 
         <div className="mt-4">
           <Field label="Zonefile text">

--- a/app/(app)/admin/import-export/page.tsx
+++ b/app/(app)/admin/import-export/page.tsx
@@ -16,15 +16,46 @@
 import type { Metadata } from "next";
 import { requireUserForPage } from "@/lib/auth/require-user";
 import { listActivePdnsServers } from "@/lib/db/repositories/pdns-servers";
+import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
+import { listEligibleTsigKeys } from "@/lib/realtime/tsig-eligibility";
+import { listPrimarySecondaries } from "@/lib/realtime/tsig-replication";
 import { ImportExportClient } from "./_components/import-export-client";
 
 export const metadata: Metadata = { title: "Import / Export" };
 
 export default async function ImportExportPage() {
-  const { ability } = await requireUserForPage({ can: "zone.read" });
+  const { ability, globalPermissions } = await requireUserForPage({ can: "zone.read" });
   const canImport = ability.can("create", "Zone");
+  const canReadTsig = globalPermissions.has("tsig.read");
   const servers = await listActivePdnsServers();
-  const backends = servers.map((s) => ({ slug: s.slug, label: s.name }));
+
+  if (canImport && canReadTsig) {
+    await ensureBackendsObserved();
+  }
+
+  const tsigKeysByServer = new Map<string, Array<{ name: string; zoneCount: number }>>();
+  if (canImport && canReadTsig) {
+    const entries = await Promise.all(
+      servers.map(async (server) => {
+        const secondaries = await listPrimarySecondaries(server);
+        const eligible = await listEligibleTsigKeys({
+          keyHosts: [server, ...secondaries],
+          zoneHosts: [server],
+        });
+        return [
+          server.slug,
+          eligible.map((key) => ({ name: key.name, zoneCount: key.zoneCount })),
+        ] as const;
+      }),
+    );
+    for (const [serverSlug, keys] of entries) tsigKeysByServer.set(serverSlug, keys);
+  }
+
+  const backends = servers.map((s) => ({
+    slug: s.slug,
+    label: s.name,
+    tsigKeys: tsigKeysByServer.get(s.slug) ?? [],
+  }));
 
   return (
     <div className="mx-auto max-w-4xl space-y-6">

--- a/app/(app)/admin/settings/backup/_components/backup-restore-wizard.tsx
+++ b/app/(app)/admin/settings/backup/_components/backup-restore-wizard.tsx
@@ -20,7 +20,7 @@
  */
 
 import { useRef, useState } from "react";
-import { Download, Upload, ArrowLeft, ShieldCheck, AlertTriangle } from "lucide-react";
+import { Download, Upload, ArrowLeft, ShieldCheck, AlertTriangle, Lock } from "lucide-react";
 import { useDialog } from "@/components/ui/dialog";
 import { mutate } from "@/lib/client/api-fetch";
 
@@ -30,7 +30,7 @@ type RestoreCounts = Record<string, { attempted: number; inserted: number; skipp
 
 const CONFIRM_PHRASE = "RESTORE";
 
-export function BackupRestoreWizard() {
+export function BackupRestoreWizard({ readOnly = false }: { readOnly?: boolean }) {
   const [step, setStep] = useState<Step>("choose");
   const [file, setFile] = useState<File | null>(null);
   const [bundlePreview, setBundlePreview] = useState<{
@@ -59,6 +59,10 @@ export function BackupRestoreWizard() {
   }
 
   async function handleFile(picked: File) {
+    if (readOnly) {
+      setRestoreError("Settings backup and restore are disabled on this deployment.");
+      return;
+    }
     setFile(picked);
     setRestoreError(null);
     try {
@@ -95,6 +99,10 @@ export function BackupRestoreWizard() {
   }
 
   async function handleRestore() {
+    if (readOnly) {
+      setRestoreError("Settings backup and restore are disabled on this deployment.");
+      return;
+    }
     if (!file || !bundlePreview) return;
     if (confirmPhrase !== CONFIRM_PHRASE) return;
     setSubmitting(true);
@@ -132,6 +140,13 @@ export function BackupRestoreWizard() {
         </p>
       </header>
 
+      {readOnly ? (
+        <ReadOnlyBanner>
+          Settings backup and restore are disabled on this deployment because{" "}
+          <Code>SETTINGS_RO</Code> is enabled.
+        </ReadOnlyBanner>
+      ) : null}
+
       {step !== "choose" ? (
         <button
           type="button"
@@ -142,9 +157,14 @@ export function BackupRestoreWizard() {
         </button>
       ) : null}
 
-      {step === "choose" ? <ChoosePicker onPick={(next) => setStep(next)} /> : null}
+      {step === "choose" ? (
+        <ChoosePicker readOnly={readOnly} onPick={(next) => setStep(next)} />
+      ) : null}
       {step === "backup" ? (
-        <BackupStep onToast={(text) => toast({ kind: "success", description: text })} />
+        <BackupStep
+          readOnly={readOnly}
+          onToast={(text) => toast({ kind: "success", description: text })}
+        />
       ) : null}
       {step === "restore-upload" ? (
         <RestoreUploadStep
@@ -152,6 +172,7 @@ export function BackupRestoreWizard() {
           fileInputRef={fileInputRef}
           bundlePreview={bundlePreview}
           restoreError={restoreError}
+          readOnly={readOnly}
           onPick={(f) => {
             void handleFile(f);
           }}
@@ -172,6 +193,7 @@ export function BackupRestoreWizard() {
           onRun={() => void handleRestore()}
           submitting={submitting}
           restoreError={restoreError}
+          readOnly={readOnly}
         />
       ) : null}
       {step === "restore-result" ? (
@@ -183,21 +205,31 @@ export function BackupRestoreWizard() {
 
 /* ---------- Step 1: choose ---------- */
 
-function ChoosePicker({ onPick }: { onPick: (next: Step) => void }) {
+function ChoosePicker({ readOnly, onPick }: { readOnly: boolean; onPick: (next: Step) => void }) {
   return (
     <div className="grid gap-3 sm:grid-cols-2">
       <ChooseCard
         title="Download backup"
-        body="Snapshot the app DB as a JSON file. Streams instantly; no server-side state."
+        body={
+          readOnly
+            ? "Disabled by SETTINGS_RO on this deployment."
+            : "Snapshot the app DB as a JSON file. Streams instantly; no server-side state."
+        }
         icon={<Download className="h-5 w-5" aria-hidden />}
         accent="accent"
+        disabled={readOnly}
         onClick={() => onPick("backup")}
       />
       <ChooseCard
         title="Restore from backup"
-        body="Upload a JSON file and merge its rows into the live DB. Existing rows untouched."
+        body={
+          readOnly
+            ? "Disabled by SETTINGS_RO on this deployment."
+            : "Upload a JSON file and merge its rows into the live DB. Existing rows untouched."
+        }
         icon={<Upload className="h-5 w-5" aria-hidden />}
         accent="warn"
+        disabled={readOnly}
         onClick={() => onPick("restore-upload")}
       />
     </div>
@@ -209,12 +241,14 @@ function ChooseCard({
   body,
   icon,
   accent,
+  disabled,
   onClick,
 }: {
   title: string;
   body: string;
   icon: React.ReactNode;
   accent: "accent" | "warn";
+  disabled?: boolean;
   onClick: () => void;
 }) {
   const accentBorder =
@@ -228,8 +262,9 @@ function ChooseCard({
   return (
     <button
       type="button"
+      disabled={disabled}
       onClick={onClick}
-      className={`flex flex-col items-start gap-3 rounded-lg border-2 ${accentBorder} bg-[color:var(--color-bg-subtle)] p-5 text-left transition-colors`}
+      className={`flex flex-col items-start gap-3 rounded-lg border-2 ${accentBorder} bg-[color:var(--color-bg-subtle)] p-5 text-left transition-colors disabled:cursor-not-allowed disabled:border-[color:var(--color-border)] disabled:opacity-60 disabled:hover:border-[color:var(--color-border)]`}
     >
       <span className={`inline-flex h-10 w-10 items-center justify-center rounded-md ${accentBg}`}>
         {icon}
@@ -242,7 +277,7 @@ function ChooseCard({
 
 /* ---------- Step 2A: backup ---------- */
 
-function BackupStep({ onToast }: { onToast: (text: string) => void }) {
+function BackupStep({ readOnly, onToast }: { readOnly: boolean; onToast: (text: string) => void }) {
   return (
     <div className="space-y-5">
       <Hero icon={<Download />} title="Download backup" tone="accent">
@@ -293,13 +328,23 @@ function BackupStep({ onToast }: { onToast: (text: string) => void }) {
         </ul>
       </Panel>
 
-      <a
-        href="/api/admin/backup/export"
-        onClick={() => onToast("Streaming pda-backup-<date>.json…")}
-        className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-[color:var(--color-accent)] px-4 py-2.5 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95 sm:w-auto sm:px-6"
-      >
-        <Download className="h-4 w-4" aria-hidden /> Download backup
-      </a>
+      {readOnly ? (
+        <button
+          type="button"
+          disabled
+          className="inline-flex w-full cursor-not-allowed items-center justify-center gap-2 rounded-md bg-[color:var(--color-accent)] px-4 py-2.5 text-sm font-medium text-[color:var(--color-accent-fg)] opacity-50 sm:w-auto sm:px-6"
+        >
+          <Download className="h-4 w-4" aria-hidden /> Download backup
+        </button>
+      ) : (
+        <a
+          href="/api/admin/backup/export"
+          onClick={() => onToast("Streaming pda-backup-<date>.json...")}
+          className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-[color:var(--color-accent)] px-4 py-2.5 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95 sm:w-auto sm:px-6"
+        >
+          <Download className="h-4 w-4" aria-hidden /> Download backup
+        </a>
+      )}
     </div>
   );
 }
@@ -311,6 +356,7 @@ function RestoreUploadStep({
   fileInputRef,
   bundlePreview,
   restoreError,
+  readOnly,
   onPick,
   onClear,
   onNext,
@@ -325,6 +371,7 @@ function RestoreUploadStep({
     totalRows: number;
   } | null;
   restoreError: string | null;
+  readOnly: boolean;
   onPick: (f: File) => void;
   onClear: () => void;
   onNext: () => void;
@@ -342,11 +389,12 @@ function RestoreUploadStep({
             ref={fileInputRef}
             type="file"
             accept="application/json,.json"
+            disabled={readOnly}
             onChange={(e) => {
               const picked = e.target.files?.[0];
               if (picked) onPick(picked);
             }}
-            className="block w-full text-sm file:mr-3 file:rounded file:border file:border-[color:var(--color-border)] file:bg-[color:var(--color-bg-subtle)] file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-[color:var(--color-fg)] hover:file:bg-[color:var(--color-bg-muted)]"
+            className="block w-full text-sm file:mr-3 file:rounded file:border file:border-[color:var(--color-border)] file:bg-[color:var(--color-bg-subtle)] file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-[color:var(--color-fg)] hover:file:bg-[color:var(--color-bg-muted)] disabled:cursor-not-allowed disabled:opacity-60"
           />
         </label>
         {file ? (
@@ -406,7 +454,7 @@ function RestoreUploadStep({
       <button
         type="button"
         onClick={onNext}
-        disabled={!bundlePreview}
+        disabled={readOnly || !bundlePreview}
         className="inline-flex items-center gap-2 rounded-md bg-[color:var(--color-accent)] px-4 py-2 text-sm font-medium text-[color:var(--color-accent-fg)] hover:opacity-95 disabled:opacity-50"
       >
         Continue →
@@ -424,6 +472,7 @@ function RestoreConfirmStep({
   onRun,
   submitting,
   restoreError,
+  readOnly,
 }: {
   bundlePreview: {
     rowCountsByTable: Array<[string, number]>;
@@ -434,8 +483,10 @@ function RestoreConfirmStep({
   onRun: () => void;
   submitting: boolean;
   restoreError: string | null;
+  readOnly: boolean;
 }) {
-  const canRun = !submitting && confirmPhrase === CONFIRM_PHRASE && bundlePreview !== null;
+  const canRun =
+    !readOnly && !submitting && confirmPhrase === CONFIRM_PHRASE && bundlePreview !== null;
   return (
     <div className="space-y-5">
       <Hero icon={<AlertTriangle />} title="Confirm restore" tone="warn">
@@ -471,6 +522,7 @@ function RestoreConfirmStep({
           value={confirmPhrase}
           onChange={(e) => onConfirmPhraseChange(e.target.value)}
           placeholder={CONFIRM_PHRASE}
+          disabled={readOnly}
           className="block w-full max-w-xs rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2 font-mono text-sm focus:ring-2 focus:ring-[color:var(--color-warn)] focus:outline-none"
           autoComplete="off"
         />
@@ -593,6 +645,15 @@ function Hero({
         <h2 className="text-base font-semibold">{title}</h2>
         <p className="text-sm text-[color:var(--color-fg-muted)]">{children}</p>
       </div>
+    </div>
+  );
+}
+
+function ReadOnlyBanner({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex gap-3 rounded-lg border border-[color:var(--color-warn)]/35 bg-[color:var(--color-warn)]/10 p-4 text-sm text-[color:var(--color-fg)]">
+      <Lock className="mt-0.5 h-4 w-4 shrink-0 text-[color:var(--color-warn-fg)]" aria-hidden />
+      <p>{children}</p>
     </div>
   );
 }

--- a/app/(app)/admin/settings/backup/page.tsx
+++ b/app/(app)/admin/settings/backup/page.tsx
@@ -9,6 +9,7 @@
 
 import type { Metadata } from "next";
 import { requireUserForPage } from "@/lib/auth/require-user";
+import { isSettingsReadOnly } from "@/lib/auth/settings-lock";
 import { ForbiddenError } from "@/lib/errors";
 import { BackupRestoreWizard } from "./_components/backup-restore-wizard";
 
@@ -19,5 +20,5 @@ export default async function BackupPage() {
   if (!globalPermissions.has("system.backup")) {
     throw new ForbiddenError("Missing system.backup.");
   }
-  return <BackupRestoreWizard />;
+  return <BackupRestoreWizard readOnly={isSettingsReadOnly()} />;
 }

--- a/app/(app)/zones/_components/create-zone-form.tsx
+++ b/app/(app)/zones/_components/create-zone-form.tsx
@@ -26,6 +26,7 @@
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { apiFetch } from "@/lib/client/api-fetch";
+import { TsigKeySelector } from "@/components/domain/tsig-key-selector";
 import { SelectMenu } from "@/components/ui/select-menu";
 
 /**
@@ -500,7 +501,7 @@ export function CreateZoneForm(props: Props) {
           title="TSIG keys"
           subtitle="Only keys present on the primary and every secondary are selectable."
         >
-          <TsigKeySection
+          <TsigKeySelector
             keys={eligibleTsigKeys}
             selected={selectedTsigKey}
             onSelect={(next) => {
@@ -696,74 +697,6 @@ function SecondariesList({ secondaries }: { secondaries: Array<{ slug: string; n
         </li>
       ))}
     </ul>
-  );
-}
-
-function TsigKeySection({
-  keys,
-  selected,
-  onSelect,
-}: {
-  keys: Array<{ name: string; zoneCount: number }>;
-  selected: string;
-  onSelect: (next: string) => void;
-}) {
-  return (
-    <div className="space-y-2">
-      <button
-        type="button"
-        onClick={() => onSelect("")}
-        aria-pressed={selected === ""}
-        className={`flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left text-sm ${
-          selected === ""
-            ? "border-[color:var(--color-accent)] bg-[color:var(--color-accent)]/10"
-            : "border-[color:var(--color-border)] hover:bg-[color:var(--color-bg-subtle)]"
-        }`}
-      >
-        <span
-          aria-hidden
-          className={`h-2.5 w-2.5 shrink-0 rounded-full ${
-            selected === "" ? "bg-[color:var(--color-accent)]" : "bg-[color:var(--color-border)]"
-          }`}
-        />
-        <span className="min-w-0">
-          <span className="block font-medium">No TSIG key</span>
-          <span className="block text-xs text-[color:var(--color-fg-muted)]">
-            Create the zone without transfer authentication.
-          </span>
-        </span>
-      </button>
-      {keys.map((key, index) => {
-        const active = selected === key.name;
-        return (
-          <button
-            key={key.name}
-            type="button"
-            onClick={() => onSelect(key.name)}
-            aria-pressed={active}
-            className={`flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left text-sm ${
-              active
-                ? "border-[color:var(--color-accent)] bg-[color:var(--color-accent)]/10"
-                : "border-[color:var(--color-border)] hover:bg-[color:var(--color-bg-subtle)]"
-            }`}
-          >
-            <span
-              aria-hidden
-              className={`h-2.5 w-2.5 shrink-0 rounded-full ${
-                active ? "bg-[color:var(--color-accent)]" : "bg-[color:var(--color-border)]"
-              }`}
-            />
-            <span className="min-w-0 flex-1">
-              <span className="block font-mono text-xs break-all">{key.name}</span>
-              <span className="mt-0.5 block text-xs text-[color:var(--color-fg-muted)]">
-                {key.zoneCount} existing domain{key.zoneCount === 1 ? "" : "s"} use this key
-                {index === 0 ? " - default" : ""}
-              </span>
-            </span>
-          </button>
-        );
-      })}
-    </div>
   );
 }
 

--- a/app/api/admin/backup/export/route.ts
+++ b/app/api/admin/backup/export/route.ts
@@ -21,6 +21,7 @@ import { headers } from "next/headers";
 import { appendAudit } from "@/lib/audit/log";
 import { getRequestContext } from "@/lib/client-ip";
 import { requireUser } from "@/lib/auth/require-user";
+import { assertSettingsBackupAllowed } from "@/lib/auth/settings-lock";
 import { db } from "@/lib/db";
 import {
   apiTokens,
@@ -51,6 +52,7 @@ export async function GET(): Promise<Response> {
     if (!globalPermissions.has("system.backup")) {
       throw new ForbiddenError("Missing system.backup.");
     }
+    assertSettingsBackupAllowed();
 
     // Pull every export-relevant table in parallel. Order doesn't matter
     // here - the export is a snapshot; restore handles dependency order.

--- a/app/api/admin/backup/restore/route.ts
+++ b/app/api/admin/backup/restore/route.ts
@@ -26,6 +26,7 @@ import { appendAudit } from "@/lib/audit/log";
 import { getRequestContext } from "@/lib/client-ip";
 import { requireUser } from "@/lib/auth/require-user";
 import { requireCsrf } from "@/lib/auth/csrf";
+import { assertSettingsBackupAllowed } from "@/lib/auth/settings-lock";
 import { db } from "@/lib/db";
 import {
   apiTokens,
@@ -87,6 +88,7 @@ export async function POST(request: Request): Promise<Response> {
       throw new ForbiddenError("Missing system.backup.");
     }
     await requireCsrf(request);
+    assertSettingsBackupAllowed();
 
     let bundle: BackupBundle;
     try {

--- a/app/api/admin/pdns/zones/import/route.ts
+++ b/app/api/admin/pdns/zones/import/route.ts
@@ -23,10 +23,12 @@ import { requireUser } from "@/lib/auth/require-user";
 import { requireCsrf } from "@/lib/auth/csrf";
 import { findPdnsServerBySlug } from "@/lib/db/repositories/pdns-servers";
 import { getBackendGateway } from "@/lib/realtime/backend-gateway";
+import { assertTsigKeyPresentOnPrimaryAndSecondaries } from "@/lib/realtime/tsig-eligibility";
+import { setZoneTransferKey } from "@/lib/realtime/tsig-replication";
 import { PdnsError } from "@/lib/pdns/errors";
 import { redact } from "@/lib/errors/redact";
 import { logger } from "@/lib/logger";
-import { ValidationError } from "@/lib/errors";
+import { ForbiddenError, ValidationError } from "@/lib/errors";
 import { errorResponse } from "@/lib/http/error-response";
 import { parseZonefile } from "@/lib/dns/zonefile-parser";
 
@@ -37,6 +39,12 @@ const importSchema = z.object({
     .min(1)
     .max(2 * 1024 * 1024), // 2 MiB cap - enough for a Fortune-500 worth of records
   kind: z.enum(["Master", "Primary", "Native"]).default("Master"),
+  tsigKeyName: z
+    .string()
+    .min(1)
+    .max(255)
+    .regex(/^[A-Za-z0-9.-]+$/, "Invalid key name.")
+    .optional(),
 });
 
 interface ZoneImportResult {
@@ -48,7 +56,7 @@ interface ZoneImportResult {
 
 export async function POST(request: Request): Promise<Response> {
   try {
-    const { user } = await requireUser({ can: "zone.create" });
+    const { user, globalPermissions } = await requireUser({ can: "zone.create" });
     await requireCsrf(request);
 
     let input;
@@ -64,6 +72,16 @@ export async function POST(request: Request): Promise<Response> {
     const server = await findPdnsServerBySlug(input.serverSlug);
     if (!server || server.disabledAt) {
       throw new ValidationError("Unknown or disabled PowerDNS backend.");
+    }
+    const isTransferPrimary = input.kind === "Master" || input.kind === "Primary";
+    if (input.tsigKeyName) {
+      if (!globalPermissions.has("tsig.read")) {
+        throw new ForbiddenError("Missing permission: tsig.read");
+      }
+      if (!isTransferPrimary) {
+        throw new ValidationError("TSIG keys can only be applied to Primary / Master zones.");
+      }
+      await assertTsigKeyPresentOnPrimaryAndSecondaries(server, input.tsigKeyName);
     }
 
     // Parse errors return 200 with `ok:false` rather than 4xx so the client
@@ -113,6 +131,21 @@ export async function POST(request: Request): Promise<Response> {
           kind: input.kind,
           rrsets: wireRrsets,
         });
+        const tsigResult = input.tsigKeyName
+          ? await setZoneTransferKey(server, zone.name, input.tsigKeyName, "add")
+          : null;
+        if (tsigResult && (!tsigResult.primaryOk || tsigResult.secondaries.some((s) => !s.ok))) {
+          logger.warn(
+            {
+              server: server.slug,
+              zone: zone.name,
+              keyName: input.tsigKeyName,
+              primaryOk: tsigResult.primaryOk,
+              secondaries: tsigResult.secondaries,
+            },
+            "pdns.zone.import.tsig-transfer.partial",
+          );
+        }
         results.push({
           name: zone.name,
           status: "created",
@@ -122,9 +155,32 @@ export async function POST(request: Request): Promise<Response> {
           actor: { type: "user", id: user.id },
           action: "zone.create",
           resource: { type: "zone", id: created.id },
-          after: { name: zone.name, source: "zonefile-import", rrsets: zone.rrsets.length },
+          after: {
+            name: zone.name,
+            source: "zonefile-import",
+            rrsets: zone.rrsets.length,
+            tsigKeyName: input.tsigKeyName ?? null,
+          },
           request: reqCtx,
         });
+        if (input.tsigKeyName && tsigResult) {
+          await appendAudit({
+            actor: { type: "user", id: user.id },
+            action: "zone.tsig-transfer.set",
+            resource: { type: "zone", id: `${server.slug}:${zone.name}` },
+            after: {
+              keyName: input.tsigKeyName,
+              mode: "add",
+              primaryOk: tsigResult.primaryOk,
+              secondaries: tsigResult.secondaries.map((s) => ({
+                server: s.serverSlug,
+                hosted: s.hosted,
+                ok: s.ok,
+              })),
+            },
+            request: reqCtx,
+          });
+        }
       } catch (err) {
         const message =
           err instanceof PdnsError

--- a/components/domain/tsig-key-selector.tsx
+++ b/components/domain/tsig-key-selector.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+/**
+ * components/domain/tsig-key-selector.tsx
+ *
+ * Shared selector for creation-style flows that can pre-apply a transfer TSIG
+ * key. The caller owns eligibility and defaulting; this component only renders
+ * the same operator-facing choice consistently across zone create/import.
+ */
+
+export interface SelectableTsigKey {
+  name: string;
+  zoneCount: number;
+}
+
+export function TsigKeySelector({
+  keys,
+  selected,
+  onSelect,
+}: {
+  keys: SelectableTsigKey[];
+  selected: string;
+  onSelect: (next: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={() => onSelect("")}
+        aria-pressed={selected === ""}
+        className={`flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left text-sm ${
+          selected === ""
+            ? "border-[color:var(--color-accent)] bg-[color:var(--color-accent)]/10"
+            : "border-[color:var(--color-border)] hover:bg-[color:var(--color-bg-subtle)]"
+        }`}
+      >
+        <span
+          aria-hidden
+          className={`h-2.5 w-2.5 shrink-0 rounded-full ${
+            selected === "" ? "bg-[color:var(--color-accent)]" : "bg-[color:var(--color-border)]"
+          }`}
+        />
+        <span className="min-w-0">
+          <span className="block font-medium">No TSIG key</span>
+          <span className="block text-xs text-[color:var(--color-fg-muted)]">
+            Create the zone without transfer authentication.
+          </span>
+        </span>
+      </button>
+      {keys.map((key, index) => {
+        const active = selected === key.name;
+        return (
+          <button
+            key={key.name}
+            type="button"
+            onClick={() => onSelect(key.name)}
+            aria-pressed={active}
+            className={`flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left text-sm ${
+              active
+                ? "border-[color:var(--color-accent)] bg-[color:var(--color-accent)]/10"
+                : "border-[color:var(--color-border)] hover:bg-[color:var(--color-bg-subtle)]"
+            }`}
+          >
+            <span
+              aria-hidden
+              className={`h-2.5 w-2.5 shrink-0 rounded-full ${
+                active ? "bg-[color:var(--color-accent)]" : "bg-[color:var(--color-border)]"
+              }`}
+            />
+            <span className="min-w-0 flex-1">
+              <span className="block font-mono text-xs break-all">{key.name}</span>
+              <span className="mt-0.5 block text-xs text-[color:var(--color-fg-muted)]">
+                {key.zoneCount} existing domain{key.zoneCount === 1 ? "" : "s"} use this key
+                {index === 0 ? " - default" : ""}
+              </span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/lib/auth/settings-lock.test.ts
+++ b/lib/auth/settings-lock.test.ts
@@ -16,7 +16,8 @@ const mockEnv: { SETTINGS_RO: boolean } = { SETTINGS_RO: false };
 
 vi.mock("@/lib/env", () => ({ env: mockEnv }));
 
-const { isSettingsReadOnly, assertSettingsMutable } = await import("./settings-lock");
+const { isSettingsReadOnly, assertSettingsMutable, assertSettingsBackupAllowed } =
+  await import("./settings-lock");
 
 beforeEach(() => {
   mockEnv.SETTINGS_RO = false;
@@ -42,5 +43,17 @@ describe("assertSettingsMutable", () => {
   it("throws ForbiddenError when the lock is on", () => {
     mockEnv.SETTINGS_RO = true;
     expect(() => assertSettingsMutable()).toThrow(ForbiddenError);
+  });
+});
+
+describe("assertSettingsBackupAllowed", () => {
+  it("does not throw when the lock is off", () => {
+    mockEnv.SETTINGS_RO = false;
+    expect(() => assertSettingsBackupAllowed()).not.toThrow();
+  });
+
+  it("throws ForbiddenError when the lock is on", () => {
+    mockEnv.SETTINGS_RO = true;
+    expect(() => assertSettingsBackupAllowed()).toThrow(ForbiddenError);
   });
 });

--- a/lib/auth/settings-lock.ts
+++ b/lib/auth/settings-lock.ts
@@ -1,19 +1,20 @@
 /**
  * lib/auth/settings-lock.ts
  *
- * The `SETTINGS_RO` global lock for the admin Settings page. When enabled
+ * The `SETTINGS_RO` global lock for the admin Settings area. When enabled
  * (intended for a public demo where visitors may hold a settings-capable role),
  * every runtime-mutable app setting is frozen: site name, branding, login intro,
- * support contact, lockout policy, and the password-reset toggle. This stops a
- * visitor from reconfiguring a shared install without having to strip the
- * `settings.write` permission from the demo role.
+ * support contact, lockout policy, and the password-reset toggle. Settings DB
+ * backup/restore is also disabled so the lock covers the whole settings
+ * administration surface. This stops a visitor from reconfiguring or snapshotting
+ * a shared install without having to strip admin permissions from the demo role.
  *
  * The lock is a pure env switch - no schema column, no migration - so it is a
  * no-op unless `SETTINGS_RO=true` and real deployments are entirely unaffected.
  *
  * Enforcement lives at the API route handler (the security boundary); the
- * matching UI affordance (disabled form + notice) is a convenience layer that
- * calls `isSettingsReadOnly` to avoid dead-end clicks.
+ * matching UI affordances (disabled form/actions + notices) are convenience
+ * layers that call `isSettingsReadOnly` to avoid dead-end clicks.
  */
 
 import { env } from "@/lib/env";
@@ -31,5 +32,16 @@ export function isSettingsReadOnly(): boolean {
 export function assertSettingsMutable(): void {
   if (isSettingsReadOnly()) {
     throw new ForbiddenError("Settings are read-only on this deployment and cannot be modified.");
+  }
+}
+
+/**
+ * Throw `ForbiddenError` when settings backup/restore is globally locked. The
+ * backup endpoints are separate from PATCH /settings, but they expose or mutate
+ * settings-area state and must obey the same deployment hardening switch.
+ */
+export function assertSettingsBackupAllowed(): void {
+  if (isSettingsReadOnly()) {
+    throw new ForbiddenError("Settings backup and restore are disabled on this deployment.");
   }
 }

--- a/tests/integration/admin/tsig-keys.test.ts
+++ b/tests/integration/admin/tsig-keys.test.ts
@@ -447,6 +447,63 @@ describe("POST /api/admin/pdns/zones with tsigKeyName", () => {
   }, 45_000);
 });
 
+describe("POST /api/admin/pdns/zones/import with tsigKeyName", () => {
+  beforeEach(async () => {
+    await resetState();
+  });
+
+  it("applies an eligible TSIG key to imported Master zones", async () => {
+    const admin = await loginAsBootstrap();
+    const primary = PDNS_BY_TOPOLOGY.psPrimary;
+    await admin.call("/api/admin/pdns-servers/refresh-all", { method: "POST" });
+
+    const name = uniqueTsigName("import-zone");
+    const zone = `import-tsig-${Date.now().toString(36)}.example.`;
+    const created = await admin.sendJson<TsigCreateResponse>("POST", "/api/admin/pdns/tsig-keys", {
+      serverSlug: primary.slug,
+      name,
+      algorithm: "hmac-sha256",
+    });
+
+    try {
+      await admin.sendJson<InstallResponse>(
+        "POST",
+        `/api/admin/pdns/tsig-keys/${encodeURIComponent(created.tsigKey.id)}/install`,
+        { serverSlug: primary.slug },
+      );
+
+      const result = await admin.sendJson<{
+        ok: boolean;
+        results: Array<{ name: string; status: string }>;
+      }>("POST", "/api/admin/pdns/zones/import", {
+        serverSlug: primary.slug,
+        kind: "Master",
+        tsigKeyName: name,
+        zoneText: `$ORIGIN ${zone}
+$TTL 3600
+@ IN SOA ns1.example. hostmaster.example. 1 3600 900 604800 3600
+@ IN NS ns1.example.
+www IN A 192.0.2.25`,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.results).toMatchObject([{ name: zone, status: "created" }]);
+      expect((await backendZone(primary, zone))?.master_tsig_key_ids ?? []).toContain(name);
+
+      const rows = await dbQuery<{ action: string; after: { keyName?: string } }>(
+        "SELECT action, after FROM audit_log WHERE resource_id = $1 ORDER BY ts",
+        [`${primary.slug}:${zone}`],
+      );
+      expect(rows.map((r) => r.action)).toContain("zone.tsig-transfer.set");
+      expect(rows.find((r) => r.action === "zone.tsig-transfer.set")?.after.keyName).toBe(name);
+    } finally {
+      await deleteBackendZone(primary, zone);
+      await deleteBackendTsig(primary, name);
+      for (const s of PDNS_BY_TOPOLOGY.psSecondaries) await deleteBackendTsig(s, name);
+    }
+  }, 45_000);
+});
+
 describe("DELETE /api/admin/pdns/tsig-keys/[id]?cascade=true", () => {
   beforeEach(async () => {
     await resetState({ skipPdns: true });


### PR DESCRIPTION
## What and why

Closes #101
Closes #102

Add the same eligible TSIG key selection to Zone Import that Add Zone already has, so imported Master zones can be created with transfer authentication when the key exists on the primary and all secondaries. Also extend SETTINGS_RO so it blocks settings backup export and restore in both the UI and backend.

## How

- Reused a shared TSIG key selector component across Add Zone and Zone Import.
- Hydrated eligible TSIG keys on the import page using the same primary plus secondaries rule and highest-use default ordering.
- Added `tsigKeyName` support to the zone import API, with server-side eligibility checks, transfer-key application, and audit logging.
- Added a SETTINGS_RO backup/restore guard and wired it into both backup API endpoints.
- Passed the readonly state into the Backup & Restore wizard to disable download, upload, and restore actions with a visible lock notice.
- Added an [Unreleased] changelog section covering post-1.4.2 work.

## Tests

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npx vitest run lib/auth/settings-lock.test.ts`
- `npm run test:integration -- tests/integration/admin/tsig-keys.test.ts`

## Threat-modeling

This touches the public API and PDNS transfer-key mutation paths. The import endpoint now treats TSIG application the same as zone creation: callers need `zone.create`, CSRF, and `tsig.read` before a key can be applied, and the backend verifies the key exists on the primary and every secondary before mutation. SETTINGS_RO is enforced at the API boundary for both export and restore, so disabling UI controls is convenience only; direct API calls still receive 403.

## Documentation

- Updated `CHANGELOG.md` with a new `[Unreleased]` section covering repository standards, TSIG workflow changes, import TSIG support, and SETTINGS_RO backup/restore coverage.

## Checklist

- [x] PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, ...)
- [x] Linked issue exists and is approved (no free-afternoon PRs)
- [x] `npm run validate` passes locally (lint + typecheck + format + test)
- [x] New code is documented (file-level + JSDoc on exports)
- [x] No secrets in code, config, logs, or fixture data
- [ ] If user-visible: strings go through i18n (or PR opens an i18n follow-up)