### PR TITLE
release: 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.4.3] - 2026-06-04
+
+Feature and hardening release. No migration and no breaking changes. Adds TSIG
+key selection for creation-style zone workflows, extends the Settings read-only
+lock to Backup & Restore, and captures repository standards cleanup. See
+[Upgrading -> 1.4.3](./docs/09-UPGRADING.md#upgrading-to-143-from-142).
+
 ### Added - TSIG key zone workflows (#100, #101)
 
 The TSIG Keys admin page now shows each key's zone correlation, including mirrored
@@ -1187,7 +1194,8 @@ First production release.
 - **Distribution** - multi-arch (`linux/amd64` + `linux/arm64`) image published to Docker Hub as
   `jseifeddine/powerdns-authadmin`, plus a one-command minimal-demo stack.
 
-[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.4.2...HEAD
+[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.4.3...HEAD
+[1.4.3]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.4.0...v1.4.1
 [1.1.5]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.1.4...v1.1.5

--- a/docs/09-UPGRADING.md
+++ b/docs/09-UPGRADING.md
@@ -37,6 +37,19 @@ half-migrated schema; fix the cause and restart.
 
 ## Version-specific notes
 
+### Upgrading to 1.4.3 (from 1.4.2)
+
+No migration and no breaking changes - pull the new tag and recreate the
+container as above. The release improves TSIG key workflows by showing and
+editing zone correlations on TSIG keys, selecting eligible keys when creating or
+importing Primary / Master zones, and applying import-time transfer keys through
+the same primary-plus-secondaries validation used by Add Zone.
+
+`SETTINGS_RO=true` now also blocks Settings Backup & Restore. Export and restore
+return 403 from the API while the UI shows the read-only lock and disables the
+download, upload, and restore controls. Normal deployments with `SETTINGS_RO`
+unset keep existing behaviour.
+
 ### Upgrading to 1.4.2 (from 1.4.1)
 
 No migration, no breaking changes, and no config or permission changes - pull the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerdns-authadmin",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@casl/ability": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": true,
   "description": "Modern, self-hosted DNS administration UI for PowerDNS - multi-team RBAC, real audit, real SSO. From-scratch rebuild of PowerDNS-Admin in Node.js + TypeScript.",
   "license": "MIT",


### PR DESCRIPTION
## What and why

Prepares the 1.4.3 patch release by promoting the current unreleased changelog entries, bumping package metadata, and adding upgrade notes for the release. This captures the TSIG workflow improvements, import-zone TSIG selection, Settings read-only backup/restore enforcement, and repo standards cleanup since 1.4.2.

Closes #104

## How

- Bumped `package.json` and `package-lock.json` to `1.4.3`.
- Added `CHANGELOG.md` entries and compare links for `v1.4.3`.
- Added `docs/09-UPGRADING.md` notes for upgrading from 1.4.2 to 1.4.3.
- Left `[Unreleased]` open for future changes.

## Tests

- `npm run format:check`
- `git diff --check`
- `npm run ci:local`
- `npm run test:integration`

## Threat-modeling

n/a

## Documentation

- Updated `CHANGELOG.md`.
- Updated `docs/09-UPGRADING.md`.

## Checklist

- [x] PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, ...)
- [x] Linked issue exists and is approved (no "I had a free afternoon" PRs)
- [x] `npm run validate` passes locally (lint + typecheck + format + test)
- [x] New code is documented (file-level + JSDoc on exports)
- [x] No secrets in code, config, logs, or fixture data
- [x] If user-visible: strings go through i18n (or PR opens an i18n follow-up)
