### PR TITLE
fix(saml): set request-state cookies SameSite=None so they survive the IdP POST

### DIFF
--- a/app/api/auth/saml/[slug]/login/route.ts
+++ b/app/api/auth/saml/[slug]/login/route.ts
@@ -53,10 +53,19 @@ export async function GET(
 
   const cookieStore = await cookies();
   const tenMinutes = 60 * 10;
+  // SP-initiated SAML with the HTTP-POST binding returns via a cross-site POST
+  // from the IdP to our ACS endpoint. A `SameSite=Lax` cookie is withheld on
+  // that request, so the ACS handler sees no state cookie and fails with
+  // `saml-state-missing`. The state must therefore ride `SameSite=None`, which
+  // browsers only honour together with `Secure`. Over HTTPS (every real SAML
+  // deployment, where APP_URL is https) that pairing is exact; on a plain-http
+  // dev origin `Secure` would be dropped, so fall back to Lax there — a same-
+  // site dev round-trip never needs the cross-site relaxation anyway.
+  const httpsOrigin = env.APP_URL.startsWith("https:");
   const cookieOpts = {
     httpOnly: true,
-    secure: isProduction,
-    sameSite: "lax" as const,
+    secure: httpsOrigin || isProduction,
+    sameSite: httpsOrigin ? ("none" as const) : ("lax" as const),
     path: "/",
     maxAge: tenMinutes,
   };


### PR DESCRIPTION
## Summary

Fixes #108 — SP-initiated SAML login always failing with `?error=saml-state-missing`.

The SAML request-state cookies (`pda_saml_state`, `pda_saml_slug`, `pda_saml_next`)
were set with `SameSite=Lax`. The HTTP-POST binding returns the assertion via a
**cross-site POST** from the IdP to `/api/auth/saml/<slug>/acs`, and browsers withhold
`Lax` cookies on that request — so the ACS handler sees no state cookie and rejects the
sign-in.

## Fix

Set the SAML state cookies `SameSite=None` (with the mandatory `Secure`) on HTTPS
origins — the standard requirement for SP-initiated POST-binding SAML. Plain-http dev
origins keep `Lax`, since `Secure` would be dropped there and a same-site dev round-trip
never needs the relaxation.

Scope is limited to the SAML login route. As noted in the issue, OIDC's `pda_oidc_*`
cookies stay `Lax` — its callback is a top-level `GET` redirect, so `Lax` is sent and
OIDC is unaffected.

## Testing
- `tsc --noEmit` clean
- `eslint` clean on the changed route
