### PR TITLE
feat(pdns): read-only backends + resolve open security advisories (v1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,67 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-07-22
+
+Feature and security release. One additive migration (`pdns_servers.write_mode`,
+defaulting to `auto`), no breaking changes, no behaviour change for existing
+backends.
+
+### Added - read-only backends (#109, #111)
+
+Backends can now be marked **Never write to this backend (read-only)**. A backend
+in that state is excluded from peer selection and from every backend picker, can't
+be the default backend, and renders with a `read-only` badge under its group's
+write target - while staying fully browsable and still polled for sync state and
+stats.
+
+This closes a gap that only shows up in one topology: a hidden primary whose zones
+are `Native` and reach the public nameservers through **database replication**
+rather than AXFR. Those public nodes usually run against a read-only database
+user, but PowerDNS reports them as `primary=no, secondary=no` - byte-identical to
+a standalone primary. Nothing in `/config` distinguishes the two, so AuthAdmin
+classified them as writable and the peer-selection strategy rotated writes onto
+them, which the database then rejected.
+
+Since PowerDNS cannot report the fact, it has to be declared. The new
+`pdns_servers.write_mode` column (`auto` | `read_only`) is that declaration, and
+it's deliberately narrow: it can only ever _remove_ a backend from write routing,
+never promote a mirror into a write target, and it does not touch AXFR topology
+derivation - marking a genuine AXFR primary read-only stops writes to it without
+breaking the secondaries that pull from it. Set it from the backend's edit page or
+with `write_mode: read_only` in provisioning YAML.
+
+Group composition now counts read-only members as mirrors, so a hidden primary
+with three read-only public nodes reports **Primary + secondaries** instead of
+claiming to be a multi-primary cluster with a peer-selection strategy that has
+nothing to choose from.
+
+See [FEATURES § 3.3](./docs/FEATURES.md#33-read-only-backends-write-mode-override),
+[Backends → Hidden primary](./docs/04-BACKENDS.md#hidden-primary--read-only-public-nameservers-native-zones),
+and the 2026-07-22 amendment in [ADR-0014](./docs/adr/0014-backend-capability-model.md).
+
+### Security (#112, #113)
+
+- **`js-yaml` 4.2.0 → 4.3.0** ([GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m),
+  high) - YAML merge-key chains could force quadratic CPU use. Reachable only
+  through the provisioning applier, which parses operator-supplied YAML at boot,
+  so this was not attacker-controlled - but it is a runtime dependency and worth
+  closing.
+- **`dompurify`** ([GHSA-c2j3-45gr-mqc4](https://github.com/advisories/GHSA-c2j3-45gr-mqc4),
+  low) - refreshed via `isomorphic-dompurify`. Impact was negligible: the SVG
+  sanitizer is defense-in-depth behind `<img src>` rendering, which already runs
+  SVG in the browser's secure static mode.
+- **`brace-expansion`** ([GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp),
+  high) - devDependency only, via the eslint plugins' `minimatch`. Never shipped.
+- **OIDC icon-URL preview** - the admin form rendered a live `<img>` preview of the
+  icon field before validation, which CodeQL flagged as an XSS-through-DOM sink.
+  Real-world impact was minimal (`javascript:` doesn't execute in `<img src>`, and
+  persisted values were already restricted to `https://` or `data:image`), but the
+  preview was the one path that skipped the allowlist. Both sides now share a
+  single predicate, `isSafeIconUrl()`, so they can't drift.
+
+`npm audit` reports zero vulnerabilities as of this release.
+
 ## [1.4.3] - 2026-06-04
 
 Feature and hardening release. No migration and no breaking changes. Adds TSIG
@@ -823,12 +884,12 @@ schema or API breaking changes - drop-in upgrade.
   `/admin/pdns-requests` was undocumented despite shipping since 1.1.0.
   Filters by server / op / status / `requestId` / time range; every row
   expands inline to the request + response detail; cross-pivots to / from
-  the audit log via shared `requestId`. ([FEATURES § 3.6](./docs/FEATURES.md#36-pdns-request-log))
+  the audit log via shared `requestId`. ([FEATURES § 3.7](./docs/FEATURES.md#37-pdns-request-log))
 - **Backend health bell documented.** The alert bell + popover that surfaces
   active advisories (unreachable hosts, API-key rejections, replication
   drift, missing TSIG keys, mirror zones without `masters`, daemon-config
   drift between peers) is now an explicit feature in the catalog.
-  ([FEATURES § 3.7](./docs/FEATURES.md#37-backend-health-advisories) · [ADR-0015](./docs/adr/0015-backend-health-advisories.md))
+  ([FEATURES § 3.8](./docs/FEATURES.md#38-backend-health-advisories) · [ADR-0015](./docs/adr/0015-backend-health-advisories.md))
 
 ### Added - documentation
 
@@ -1194,7 +1255,8 @@ First production release.
 - **Distribution** - multi-arch (`linux/amd64` + `linux/arm64`) image published to Docker Hub as
   `jseifeddine/powerdns-authadmin`, plus a one-command minimal-demo stack.
 
-[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.4.3...HEAD
+[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.4.3...v1.5.0
 [1.4.3]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.4.0...v1.4.1

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ ready-to-use install without a single click.
 - **Multi-backend.** One install fronts standalone primaries, primary + secondaries groups, and
   multi-primary clusters. Backends are visible side-by-side; zones merge into one amalgamated
   list. Per-cluster peer-selection strategies (round-robin / random / lowest-latency / least-load)
-  route reads and writes to a member of the cluster.
+  route reads and writes to a member of the cluster. Any backend can be marked **read-only** so
+  writes skip it - the escape hatch for public nameservers fed by database replication, which
+  PowerDNS itself reports as ordinary writable primaries.
 - **Real RBAC.** Five system roles plus org-defined custom roles. Permissions span ~60 actions
   across zones, records, DNSSEC, TSIG, metadata, autoprimaries, templates, users, teams, servers,
   API tokens, audit, and OIDC providers. Assignments scope to global / team / zone / server.

--- a/app/(app)/admin/authentication/oidc/_components/oidc-provider-form.tsx
+++ b/app/(app)/admin/authentication/oidc/_components/oidc-provider-form.tsx
@@ -11,6 +11,7 @@
 import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 import { apiFetch } from "@/lib/client/api-fetch";
+import { safeIconUrl } from "@/lib/security/icon-url";
 import { SelectMenu } from "@/components/ui/select-menu";
 
 interface FormInitial {
@@ -117,6 +118,9 @@ export function OidcProviderForm(props: Props) {
   );
   const [iconUrl, setIconUrl] = useState(initial.iconUrl ?? "");
   const [groupMappings, setGroupMappings] = useState<GroupMappingForm[]>(initial.groupMappings);
+  // Rebuilt, allowlisted form of what's in the icon field - null when it isn't
+  // a renderable URL yet. Never render `iconUrl` itself (#113).
+  const previewSrc = safeIconUrl(iconUrl);
 
   function addGroupMapping() {
     setGroupMappings([
@@ -404,17 +408,27 @@ export function OidcProviderForm(props: Props) {
         {iconUrl.trim() !== "" ? (
           <div className="mt-2 flex items-center gap-2 rounded border border-[color:var(--color-border)] bg-[color:var(--color-bg-subtle)] p-2 text-xs text-[color:var(--color-fg-muted)]">
             <span>Preview:</span>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={iconUrl}
-              alt="Provider icon preview"
-              style={{
-                width: 20,
-                height: 20,
-                objectFit: "contain",
-                display: "block",
-              }}
-            />
+            {/* Same allowlist the server enforces, so the preview can never
+                render something that wouldn't save. `safeIconUrl` returns a
+                rebuilt string rather than the raw field value, so what's
+                validated is exactly what's rendered (#113). */}
+            {previewSrc !== null ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={previewSrc}
+                alt="Provider icon preview"
+                style={{
+                  width: 20,
+                  height: 20,
+                  objectFit: "contain",
+                  display: "block",
+                }}
+              />
+            ) : (
+              <span className="text-[color:var(--color-error)]">
+                No preview - use an https:// URL or an inline data:image URI.
+              </span>
+            )}
           </div>
         ) : null}
       </Field>

--- a/app/(app)/admin/servers/[id]/page.tsx
+++ b/app/(app)/admin/servers/[id]/page.tsx
@@ -14,7 +14,7 @@ import { findPdnsServerById, listSecondariesForPrimary } from "@/lib/db/reposito
 import { listAllClusters } from "@/lib/db/repositories/pdns-clusters";
 import { latestServerAdminEdit, recentAdminEditsForServer } from "@/lib/db/repositories/audit-log";
 import { freshnessOf } from "@/lib/freshness";
-import { isWriteCapable } from "@/lib/pdns/capabilities";
+import { isServerWriteTarget } from "@/lib/pdns/capabilities";
 import { CapabilityBadges } from "@/components/domain/capability-badges";
 import { type SafeConfigRow } from "@/lib/pdns/config-advice";
 import { readDaemonConfig } from "@/lib/pdns/daemon-config-cache";
@@ -47,7 +47,7 @@ export default async function EditPdnsServerPage({ params }: PageProps) {
 
   // For primaries, list the secondaries that share its group - surfaced as a
   // section beneath the form so operators can see the mirror set inline.
-  const secondaries = isWriteCapable(row.capabilities) ? await listSecondariesForPrimary(row) : [];
+  const secondaries = isServerWriteTarget(row) ? await listSecondariesForPrimary(row) : [];
 
   // Audit-derived last-edit line. Gated by audit.read since it
   // leaks "X did Y at Z time" - matches the zone-detail page
@@ -98,7 +98,7 @@ export default async function EditPdnsServerPage({ params }: PageProps) {
         {row.capabilities ? (
           <p className="flex flex-wrap items-center gap-2 text-xs text-[color:var(--color-fg-muted)]">
             <span className="font-medium text-[color:var(--color-fg)]">Observed:</span>
-            <CapabilityBadges capabilities={row.capabilities} />
+            <CapabilityBadges capabilities={row.capabilities} writeMode={row.writeMode} />
             {row.capabilities.backends.length > 0 ? (
               <> · {row.capabilities.backends.join(", ")}</>
             ) : null}
@@ -142,6 +142,7 @@ export default async function EditPdnsServerPage({ params }: PageProps) {
           baseUrl: row.baseUrl,
           serverId: row.serverId,
           isDefault: row.isDefault,
+          writeMode: row.writeMode,
           disabled: row.disabledAt !== null,
           clusterId: row.clusterId,
           advertisedAddresses: row.advertisedAddresses,
@@ -163,7 +164,7 @@ export default async function EditPdnsServerPage({ params }: PageProps) {
         </section>
       ) : null}
 
-      {isWriteCapable(row.capabilities) ? (
+      {isServerWriteTarget(row) ? (
         <section className="rounded-md border border-[color:var(--color-border)] p-4">
           <header className="mb-3 flex items-center justify-between">
             <div>

--- a/app/(app)/admin/servers/_components/server-form.tsx
+++ b/app/(app)/admin/servers/_components/server-form.tsx
@@ -13,6 +13,7 @@
 import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 import { apiFetch } from "@/lib/client/api-fetch";
+import type { PdnsWriteMode } from "@/lib/pdns/types";
 import { hostFromUrl } from "@/lib/net/host";
 import { SelectMenu } from "@/components/ui/select-menu";
 
@@ -24,6 +25,7 @@ interface ServerFormInitial {
   baseUrl: string;
   serverId: string;
   isDefault: boolean;
+  writeMode: PdnsWriteMode;
   disabled: boolean;
   clusterId: string | null;
   advertisedAddresses: string[] | null;
@@ -67,6 +69,7 @@ const DEFAULTS: ServerFormInitial = {
   baseUrl: "",
   serverId: "localhost",
   isDefault: false,
+  writeMode: "auto",
   disabled: false,
   clusterId: null,
   advertisedAddresses: null,
@@ -83,6 +86,7 @@ export function ServerForm(props: ServerFormProps) {
   const [serverId, setServerId] = useState(initial.serverId);
   const [apiKey, setApiKey] = useState("");
   const [isDefault, setIsDefault] = useState(initial.isDefault);
+  const [readOnly, setReadOnly] = useState(initial.writeMode === "read_only");
   const [disabled, setDisabled] = useState(props.mode === "edit" ? initial.disabled : false);
   const [clusterId, setClusterId] = useState<string | null>(
     props.mode === "edit" ? initial.clusterId : (props.forGroup ?? null),
@@ -120,6 +124,7 @@ export function ServerForm(props: ServerFormProps) {
       baseUrl: string;
       serverId: string;
       isDefault: boolean;
+      writeMode: PdnsWriteMode;
       apiKey?: string;
       disabled?: boolean;
       clusterId: string | null;
@@ -130,6 +135,7 @@ export function ServerForm(props: ServerFormProps) {
       baseUrl,
       serverId,
       isDefault,
+      writeMode: readOnly ? "read_only" : "auto",
       clusterId,
       // Empty → null (the server derives from the API host). Non-empty → the
       // explicit override list.
@@ -315,10 +321,40 @@ export function ServerForm(props: ServerFormProps) {
         <input
           type="checkbox"
           checked={isDefault}
+          disabled={readOnly}
           onChange={(e) => setIsDefault(e.target.checked)}
         />
         Use as the default backend (only a write-capable backend can be the default)
       </label>
+
+      <div className="space-y-1">
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="checkbox"
+            className="mt-0.5"
+            checked={readOnly}
+            onChange={(e) => {
+              const next = e.target.checked;
+              setReadOnly(next);
+              // The default backend receives writes, so the two are mutually
+              // exclusive - clear it here rather than letting the save 400.
+              if (next) setIsDefault(false);
+            }}
+          />
+          Never write to this backend (read-only)
+        </label>
+        <p className="pl-6 text-xs text-[color:var(--color-fg-muted)]">
+          For nodes you only read from - a public nameserver fed by database replication, or any
+          backend whose database user has no write access. PowerDNS can&apos;t advertise this over
+          its API, so it has to be set here. Zone and record edits will be routed to other peers in
+          the group instead.
+        </p>
+        {fieldErrors["writeMode"]?.map((msg) => (
+          <p key={msg} className="pl-6 text-xs text-[color:var(--color-error)]" role="alert">
+            {msg}
+          </p>
+        ))}
+      </div>
 
       {props.mode === "edit" ? (
         <label className="flex items-center gap-2 text-sm">

--- a/app/(app)/admin/servers/page.tsx
+++ b/app/(app)/admin/servers/page.tsx
@@ -20,7 +20,7 @@ import { latestAdminEditTimestampsForServers } from "@/lib/db/repositories/audit
 import { freshnessOf } from "@/lib/freshness";
 import { rawCache } from "@/lib/pdns/zone-state-cache";
 import { derivedParentOf } from "@/lib/pdns/topology-cache";
-import { isReadOnlyMirror } from "@/lib/pdns/capabilities";
+import { isReadOnlyBackend } from "@/lib/pdns/capabilities";
 import { CapabilityBadges } from "@/components/domain/capability-badges";
 import { ClickableTr, ClickableDiv } from "@/components/ui/clickable-row";
 import { SyncIndicator } from "@/components/ui/sync-indicator";
@@ -63,7 +63,7 @@ export default async function PdnsServersListPage() {
   // they stay visible + editable:
   //   - standalone - mirrors an external/unmanaged primary, NOT an error;
   //   - orphaned - grouped but the group has no resolvable primary.
-  const primaries = servers.filter((s) => !isReadOnlyMirror(s.capabilities));
+  const primaries = servers.filter((s) => !isReadOnlyBackend(s));
   const primaryById = new Map(primaries.map((p) => [p.id, p]));
   // First write target of each group represents it in the tree (multi-primary
   // groups share storage, so any peer is an equivalent sync reference).
@@ -80,7 +80,7 @@ export default async function PdnsServersListPage() {
     secondariesByPrimary.set(primaryId, arr);
   };
   for (const s of servers) {
-    if (!isReadOnlyMirror(s.capabilities)) continue;
+    if (!isReadOnlyBackend(s)) continue;
     // 1. Explicit group membership.
     const groupRep = s.clusterId ? primaryByCluster.get(s.clusterId) : undefined;
     if (groupRep) {
@@ -442,7 +442,7 @@ function ServerRow({
             </span>
           ) : null}
           <div className="font-medium">{row.name}</div>
-          <CapabilityBadges capabilities={row.capabilities} />
+          <CapabilityBadges capabilities={row.capabilities} writeMode={row.writeMode} />
         </div>
         <div className="mt-0.5 text-xs text-[color:var(--color-fg-muted)]">
           {row.slug}
@@ -469,7 +469,7 @@ function ServerRow({
       <td className="px-4 py-3 align-top text-xs">{row.versionCache?.version ?? "-"}</td>
       {pdnsBackgroundPollingEnabled ? (
         <td className="px-4 py-3 align-top text-xs">
-          <SyncChip verdict={syncChip} isMirror={isReadOnlyMirror(row.capabilities)} />
+          <SyncChip verdict={syncChip} isMirror={isReadOnlyBackend(row)} />
         </td>
       ) : null}
       {canReadAudit ? (
@@ -500,7 +500,7 @@ function ServerRow({
 
 /** Mobile (< md) card rendering of a server row - same data as ServerRow. */
 function ServerCard({ row, canReadAudit, lastEdits, syncChip, reachability }: ServerRowProps) {
-  const isMirror = isReadOnlyMirror(row.capabilities);
+  const isMirror = isReadOnlyBackend(row);
   return (
     <ClickableDiv
       href={`/admin/servers/${row.id}`}
@@ -512,7 +512,7 @@ function ServerCard({ row, canReadAudit, lastEdits, syncChip, reachability }: Se
     >
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-base font-medium">{row.name}</span>
-        <CapabilityBadges capabilities={row.capabilities} />
+        <CapabilityBadges capabilities={row.capabilities} writeMode={row.writeMode} />
         {row.isDefault ? (
           <span className="rounded bg-[color:var(--color-bg-muted)] px-1.5 py-0.5 text-[0.65rem] tracking-wide uppercase">
             default

--- a/app/(app)/admin/tsig-keys/page.tsx
+++ b/app/(app)/admin/tsig-keys/page.tsx
@@ -23,7 +23,7 @@ import { listEligibleTsigKeys } from "@/lib/realtime/tsig-eligibility";
 import { listPrimarySecondaries } from "@/lib/realtime/tsig-replication";
 import { ensureBackendsObserved } from "@/lib/realtime/zone-poller";
 import { derivedParentOf } from "@/lib/pdns/topology-cache";
-import { isWriteCapable } from "@/lib/pdns/capabilities";
+import { isServerWriteTarget } from "@/lib/pdns/capabilities";
 import { stripTrailingDot } from "@/lib/pdns/tsig";
 import { readCachedZones } from "@/lib/pdns/zone-state-cache";
 import { PdnsAuthError } from "@/lib/pdns/errors";
@@ -85,7 +85,7 @@ export default async function TsigKeysPage({ searchParams }: PageProps) {
   // Replication targets: API install only makes sense when inspecting a primary.
   // Zone correlation is primary-owned, but secondaries should still display and
   // edit the same primary-side domain list as a convenience reference.
-  const isPrimary = isWriteCapable(selected.capabilities);
+  const isPrimary = isServerWriteTarget(selected);
   let installSecondaries: Array<{ slug: string; name: string; supportsTsigApi: boolean }> = [];
   let correlationServer: { slug: string; name: string } | null = null;
   let correlationZones: string[] = [];
@@ -196,18 +196,18 @@ function resolveCorrelationPrimary(
   selected: NonNullable<Awaited<ReturnType<typeof findServerToInspect>>>,
   servers: Awaited<ReturnType<typeof listAllPdnsServers>>,
 ) {
-  if (isWriteCapable(selected.capabilities)) return selected;
+  if (isServerWriteTarget(selected)) return selected;
 
   const active = servers.filter((s) => s.disabledAt === null);
   const derivedParentId = derivedParentOf(selected.id);
   const derivedParent = derivedParentId
-    ? active.find((s) => s.id === derivedParentId && isWriteCapable(s.capabilities))
+    ? active.find((s) => s.id === derivedParentId && isServerWriteTarget(s))
     : null;
   if (derivedParent) return derivedParent;
 
   if (selected.clusterId) {
     const peers = active.filter(
-      (s) => s.clusterId === selected.clusterId && isWriteCapable(s.capabilities),
+      (s) => s.clusterId === selected.clusterId && isServerWriteTarget(s),
     );
     if (peers.length === 1) return peers[0]!;
   }

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -31,6 +31,7 @@ import { envOidcProviderSummary } from "@/lib/auth/providers/oidc";
 import { getAppSettings } from "@/lib/settings/app-settings";
 import { safeNextPath } from "@/lib/auth/safe-redirect";
 import { detectAppUrlMismatch } from "@/lib/auth/app-url-check";
+import { safeIconUrl } from "@/lib/security/icon-url";
 import { LoginForm } from "./login-form";
 import { LdapLoginForm } from "./ldap-login-form";
 import { PasskeyButton } from "./passkey-button";
@@ -188,7 +189,10 @@ export default async function LoginPage({
       label: p.name,
       tag: "OIDC",
       href: `/api/auth/oidc/${p.id}/initiate${nextParam}`,
-      iconUrl: p.iconUrl,
+      // Re-normalized even though the validator gated it on write: rows
+      // persisted under an older, looser icon rule would otherwise reach the
+      // <img> sink unchecked (#113). Null when it isn't a renderable URL.
+      iconUrl: p.iconUrl ? safeIconUrl(p.iconUrl) : null,
     });
   }
   for (const p of dbSamlProviders) {

--- a/app/api/admin/pdns-servers/[id]/route.ts
+++ b/app/api/admin/pdns-servers/[id]/route.ts
@@ -26,6 +26,7 @@ import {
   updatePdnsServer,
 } from "@/lib/db/repositories/pdns-servers";
 import { updatePdnsServerSchema } from "@/lib/validators/pdns-servers";
+import type { PdnsWriteMode } from "@/lib/pdns/types";
 import { invalidatePdnsClient } from "@/lib/pdns/registry";
 import { assertSafePdnsUrl } from "@/lib/pdns/url-safety";
 import { findClusterById } from "@/lib/db/repositories/pdns-clusters";
@@ -79,7 +80,20 @@ export async function PATCH(request: Request, context: RouteContext): Promise<Re
       // against the new credentials before any UI relies on them.
       patch.versionCache = null;
     }
+    if (input.writeMode !== undefined) patch.writeMode = input.writeMode;
     if (input.isDefault !== undefined) patch.isDefault = input.isDefault;
+    // The default backend is the implicit write target, so it can't be one the
+    // operator has marked read-only (#111). Checked against the merged state so
+    // "set default" and "set read_only" in the same request is caught too.
+    const effectiveWriteMode = patch.writeMode ?? existing.writeMode;
+    const effectiveIsDefault = patch.isDefault ?? existing.isDefault;
+    if (effectiveIsDefault && effectiveWriteMode === "read_only") {
+      throw new ValidationError("Invalid input.", {
+        fieldErrors: {
+          writeMode: ["A read-only backend can't be the default - the default receives writes."],
+        },
+      });
+    }
     if (input.disabled !== undefined) {
       patch.disabledAt = input.disabled ? new Date() : null;
     }
@@ -188,6 +202,7 @@ function snapshotForAudit(row: {
   baseUrl: string;
   serverId: string;
   isDefault: boolean;
+  writeMode: PdnsWriteMode;
   disabledAt: Date | null;
 }) {
   return {
@@ -198,6 +213,7 @@ function snapshotForAudit(row: {
     baseUrl: row.baseUrl,
     serverId: row.serverId,
     isDefault: row.isDefault,
+    writeMode: row.writeMode,
     disabledAt: row.disabledAt?.toISOString() ?? null,
   };
 }

--- a/app/api/admin/pdns-servers/route.ts
+++ b/app/api/admin/pdns-servers/route.ts
@@ -82,6 +82,16 @@ export async function POST(request: Request): Promise<Response> {
       });
     }
 
+    // The default backend is the implicit write target, so it can't also be
+    // marked read-only (#111).
+    if (input.isDefault && input.writeMode === "read_only") {
+      throw new ValidationError("Invalid input.", {
+        fieldErrors: {
+          writeMode: ["A read-only backend can't be the default - the default receives writes."],
+        },
+      });
+    }
+
     const apiKeyEncrypted = encrypt(input.apiKey, "pdns-api-key");
     const hdrs = await headers();
     // One transaction: the single-default clearing, the insert, and the audit
@@ -97,6 +107,7 @@ export async function POST(request: Request): Promise<Response> {
           serverId: input.serverId,
           apiKeyEncrypted,
           isDefault: input.isDefault,
+          writeMode: input.writeMode,
           clusterId: input.clusterId ?? null,
           advertisedAddresses:
             input.advertisedAddresses && input.advertisedAddresses.length > 0
@@ -119,6 +130,7 @@ export async function POST(request: Request): Promise<Response> {
             baseUrl: created.baseUrl,
             serverId: created.serverId,
             isDefault: created.isDefault,
+            writeMode: created.writeMode,
           },
           request: getRequestContext(hdrs),
         },

--- a/components/domain/capability-badges.tsx
+++ b/components/domain/capability-badges.tsx
@@ -9,6 +9,12 @@
  *   • standalone    → neutral - no replication flag set (default PDNS Auth
  *                     config; API still accepts zone creates - fully usable).
  *
+ * Plus one badge that is NOT observed but operator-declared:
+ *   • read-only     → warn (yellow) - `write_mode='read_only'` (#111). Shown
+ *                     first, because it overrides whatever the daemon reports:
+ *                     a node badged `standalone read-only` looks writable to
+ *                     PDNS but the operator has vetoed writes to it.
+ *
  * Renders nothing fancy: a small rounded badge per active flag, joined by a
  * narrow gap. Use anywhere a backend row shows its role (server lists, group
  * detail, server detail).
@@ -39,20 +45,49 @@ const TONE = {
   autosecondary: `${BASE} bg-[color:var(--color-orange)]/15 text-[color:var(--color-orange-fg)]`,
 } as const;
 
-export function CapabilityBadges({ capabilities }: { capabilities: Capabilities | null }) {
-  if (!capabilities) return <span className={NEUTRAL}>unprobed</span>;
+export function CapabilityBadges({
+  capabilities,
+  writeMode = "auto",
+}: {
+  capabilities: Capabilities | null;
+  /** Operator write-routing override (#111). "read_only" adds a leading badge. */
+  writeMode?: "auto" | "read_only";
+}) {
+  const readOnly =
+    writeMode === "read_only" ? (
+      <span className={TONE.secondary} title="Operator override: writes are never routed here">
+        read-only
+      </span>
+    ) : null;
+
+  if (!capabilities) {
+    return (
+      <span className="whitespace-nowrap">
+        {readOnly}
+        <span className={readOnly ? `${NEUTRAL} ml-1` : NEUTRAL}>unprobed</span>
+      </span>
+    );
+  }
   const flags: Array<keyof typeof TONE> = [];
   if (capabilities.primary) flags.push("primary");
   if (capabilities.secondary) flags.push("secondary");
   if (capabilities.autosecondary) flags.push("autosecondary");
-  if (flags.length === 0) return <span className={NEUTRAL}>standalone</span>;
+  if (flags.length === 0) {
+    return (
+      <span className="whitespace-nowrap">
+        {readOnly}
+        <span className={readOnly ? `${NEUTRAL} ml-1` : NEUTRAL}>standalone</span>
+      </span>
+    );
+  }
   // Plain inline <span> wrapper (no flex) so each badge renders exactly like
   // the CLUSTER badge in the zones list - inherited line-height and no
   // cross-axis stretching from a flex container.
   return (
     <span className="whitespace-nowrap">
+      {readOnly}
       {flags.map((f, i) => (
-        <span key={f} className={i > 0 ? `${TONE[f]} ml-1` : TONE[f]}>
+        <span key={f} className={i > 0 || readOnly ? `${TONE[f]} ml-1` : TONE[f]}>
           {f}
         </span>
       ))}

--- a/docs/04-BACKENDS.md
+++ b/docs/04-BACKENDS.md
@@ -140,6 +140,32 @@ that cluster. The cluster appears as **one logical backend** in every picker; a
 
 Secondaries can't belong to a cluster - clusters are peer-groups of primaries.
 
+### Hidden primary + read-only public nameservers (native zones)
+
+A common shape that needs one extra step: all zones are `Native`, edits happen on
+a hidden primary, and the public nameservers receive them through **database
+replication** rather than AXFR. Those public nodes typically run against a
+read-only database user.
+
+PowerDNS reports such a daemon as `primary=no, secondary=no` - identical to a
+plain standalone primary - so AuthAdmin cannot tell it apart, and by default the
+peer-selection strategy will happily route a write to it, which then fails.
+
+Tick **Never write to this backend (read-only)** on each public node (or set
+`write_mode: read_only` in provisioning YAML). That backend is then:
+
+- excluded from peer selection, so every write lands on the hidden primary;
+- excluded from the create-zone and zones-list backend pickers;
+- ineligible to be the default backend;
+- still fully browsable, and still polled for sync state and stats.
+
+Group the hidden primary and its public nodes together so the group renders as
+**Primary + secondaries** rather than a multi-primary cluster.
+
+> The **default backend** setting is unrelated: it only chooses which backend
+> serves a request that doesn't name one. It has never constrained peer
+> selection inside a group.
+
 ## DNSSEC, TSIG, autoprimaries
 
 Once a backend is connected, manage these from the zone and admin UIs (gated by

--- a/docs/06-PROVISIONING.md
+++ b/docs/06-PROVISIONING.md
@@ -81,6 +81,10 @@ Every block is optional - drop what you don't need.
 - `pdns_servers`: `role: secondary` requires `primary_slug` (resolving in-file or
   to an existing DB primary); a primary must **not** set `primary_slug`; a
   secondary must **not** set `cluster_slug`; exactly one row should be `is_default`.
+- `pdns_servers`: `write_mode: read_only` marks a backend that must never receive
+  writes even though its `/config` looks writable - the database-replicated
+  public nameserver case. It's excluded from peer selection and from every
+  backend picker, and can't be `is_default`. Defaults to `auto`.
 - `clusters`: only primaries can be cluster peers - putting `cluster_slug` on a
   secondary is a parse error.
 - `oidc`: this is the **same mechanism as the Admin UI** (rows in

--- a/docs/09-UPGRADING.md
+++ b/docs/09-UPGRADING.md
@@ -37,6 +37,29 @@ half-migrated schema; fix the cause and restart.
 
 ## Version-specific notes
 
+### Upgrading to 1.5.0 (from 1.4.3)
+
+One additive migration, no breaking changes - pull the new tag and recreate the
+container as above. The migration adds `pdns_servers.write_mode` with a default of
+`auto`, so every existing backend keeps its current behaviour and no backend
+becomes read-only on its own.
+
+Act on this release only if you run a **hidden primary whose zones are `Native`
+and replicate to public nameservers through the database** rather than AXFR. Those
+public nodes are indistinguishable from standalone primaries over the PowerDNS
+API, so until now the peer-selection strategy could route writes to them and the
+read-only database user would reject the change. Open each public node under
+**Admin → PowerDNS servers**, tick **Never write to this backend (read-only)**,
+and save - writes then land only on the primary. In provisioning YAML the
+equivalent is `write_mode: read_only` on the server row.
+
+Every other topology needs no action.
+
+This release also bumps `js-yaml`, `dompurify`, and `brace-expansion` to clear
+open advisories, and tightens the OIDC icon-URL preview in the admin form. See
+the [CHANGELOG](../CHANGELOG.md#150---2026-07-22) for the impact assessment on
+each.
+
 ### Upgrading to 1.4.3 (from 1.4.2)
 
 No migration and no breaking changes - pull the new tag and recreate the

--- a/docs/10-TROUBLESHOOTING.md
+++ b/docs/10-TROUBLESHOOTING.md
@@ -41,6 +41,33 @@ the runtime env, or the deploy didn't override the secrets. Generate real
 - **Reachable but no zones** - confirm `api=yes` and that the API key has access to
   the `server_id` you configured (almost always `localhost`).
 
+## Zone or record edits fail on some backends but not others
+
+Symptom: the same edit succeeds when you retry it, then fails again later,
+seemingly at random. Usually a permission or read-only error surfaced from
+PowerDNS rather than from AuthAdmin.
+
+Almost always a group where **not every peer can actually accept writes**. The
+peer-selection strategy rotates each request across the group's write targets,
+so a node that rejects writes takes roughly its share of your edits and the
+failures look intermittent.
+
+The common shape is a hidden primary whose zones are `Native`, replicated to
+the public nameservers through the **database** rather than AXFR, where those
+public nodes run against a read-only database user. PowerDNS reports them as
+`primary=no, secondary=no` - indistinguishable from a standalone primary - so
+AuthAdmin can't detect the difference on its own.
+
+Fix: open each node you only read from under **Admin -> PowerDNS servers**,
+tick **Never write to this backend (read-only)**, and save. Writes then land
+only on the real write target, and the group re-labels itself
+**Primary + secondaries**. In provisioning YAML, set `write_mode: read_only` on
+the server row. See
+[Backends -> Hidden primary](./04-BACKENDS.md#hidden-primary--read-only-public-nameservers-native-zones).
+
+Note this is unrelated to **Use as the default backend**, which only picks
+which backend serves a request that doesn't name one.
+
 ## Sign-in does nothing / browser DevTools shows "Cookie pda_csrf has been rejected for invalid domain"
 
 `APP_URL`'s host doesn't match the URL you have in the address bar. The session

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -212,7 +212,32 @@ can jump straight into the code that owns each feature.
   in the DB is `write_strategy` (legacy name preserved); the UI label is "Peer selection
   strategy" since it governs both reads and writes.
 
-### 3.3 Sync probes
+### 3.3 Read-only backends (write-mode override)
+
+- **What.** A per-backend switch, **Never write to this backend (read-only)**, that removes it
+  from every write path while leaving its zones fully browsable. Peer selection skips it, it
+  can't be the default backend, and it renders with a `read-only` badge nested under its
+  group's write target like a mirror.
+- **Why it can't be derived.** Every other role signal in the app is observed from the daemon's
+  `/config` (ADR-0014). This one can't be: a public nameserver serving **native** zones fed by
+  **database replication** runs with `primary=no, secondary=no` - byte-identical to a standalone
+  primary - yet its database user has no write access. PowerDNS exposes no flag for that, so
+  without an override the peer picker rotates writes onto it and they fail (#109).
+- **Where.** `pdns_servers.write_mode` (`auto` | `read_only`), the `isServerWriteTarget()` /
+  `isReadOnlyBackend()` predicates in `lib/pdns/capabilities.ts`, enforced in
+  `lib/db/repositories/{pdns-servers,pdns-clusters,selectable-backends}.ts`.
+- **How.** Tick the box on the backend's edit page, or set `write_mode: read_only` on a server
+  in provisioning YAML. Defaults to `auto`, so existing backends are unaffected.
+- **Scope.** The override governs write routing only. AXFR topology derivation still reads the
+  daemon's real capabilities, so marking a genuine AXFR primary read-only stops writes to it
+  without breaking the secondaries that pull from it. See the 2026-07-22 amendment in
+  [ADR-0014](./adr/0014-backend-capability-model.md).
+
+> **Note.** "Use as the default backend" is a _different_ control - it only picks which backend
+> serves a request that doesn't name one. It has never constrained peer selection within a group;
+> use the read-only switch for that.
+
+### 3.4 Sync probes
 
 - **What.** Two flavours, identical visual shape:
   - **Primary + secondaries.** Compare each secondary's serial against the primary's;
@@ -223,7 +248,7 @@ can jump straight into the code that owns each feature.
 - **Where.** `lib/pdns/sync.ts`, `lib/pdns/cluster-sync.ts`,
   `app/(app)/zones/[zoneId]/_components/sync-section.tsx`.
 
-### 3.4 NOTIFY-on-write + convergence sweep
+### 3.5 NOTIFY-on-write + convergence sweep
 
 - **What.** Every code path that creates a zone goes through `createZoneAndNotify()` which
   fires NOTIFY to all secondaries after the create. The provisioning loop additionally runs
@@ -233,7 +258,7 @@ can jump straight into the code that owns each feature.
   initial NOTIFY.
 - **Where.** `lib/pdns/operations.ts`.
 
-### 3.5 PDNS HTTP client
+### 3.6 PDNS HTTP client
 
 - **What.** Typed thin wrapper over PDNS's HTTP API: zones.list / get / create, rrsets PATCH,
   cryptokeys, metadata, TSIG, autoprimaries, server.info, statistics. Version cache +
@@ -243,7 +268,7 @@ can jump straight into the code that owns each feature.
 - **Where.** `lib/pdns/client.ts`, `lib/pdns/registry.ts`, `lib/pdns/types.ts`,
   `lib/pdns/errors.ts`.
 
-### 3.6 PDNS request log
+### 3.7 PDNS request log
 
 - **What.** Every HTTP call the app issues to PowerDNS is recorded with timestamp, server,
   operation, method, URL, response status, error (if any), and the correlator `requestId` of
@@ -259,7 +284,7 @@ can jump straight into the code that owns each feature.
   <img src="../screenshots/light/pdns-requests.png" alt="PDNS request log" width="720" />
 </picture>
 
-### 3.7 Backend health advisories
+### 3.8 Backend health advisories
 
 - **What.** A bell in the top header surfaces active advisories computed every poll cycle:
   unreachable backends, API-key rejections (401/403), replication drift past a threshold, TSIG
@@ -276,7 +301,7 @@ can jump straight into the code that owns each feature.
   <img src="../screenshots/light/backend-health.png" alt="Backend health bell popover" width="720" />
 </picture>
 
-### 3.8 SSRF guard
+### 3.9 SSRF guard
 
 - **What.** Config-time + runtime IP-range checks on PDNS `base_url`. Link-local
   (incl. 169.254.169.254 cloud metadata) is always blocked. Private networks gated by
@@ -421,7 +446,7 @@ can jump straight into the code that owns each feature.
   from one batched query. Quick-filter chips cover the common incident-response queries
   (failed sign-ins, MFA admin changes, session revocations). Every row that originated a PDNS
   call carries a `req:` link that pivots to the matching rows in
-  [the PDNS request log](#36-pdns-request-log), and CSV export honours the active filters.
+  [the PDNS request log](#37-pdns-request-log), and CSV export honours the active filters.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="../screenshots/dark/audit-log.png" />
@@ -543,7 +568,7 @@ folder (`drizzle/`, `drizzle-sqlite/`); the boot entrypoint picks one based on
 
 - **Per-request CSP nonce** (ADR 0006) so injected `<script>` tags don't execute.
 - **CSRF double-submit** on every mutating route via `requireCsrf(request)`.
-- **SSRF guard** on PDNS base URLs (§ 3.8).
+- **SSRF guard** on PDNS base URLs (§ 3.9).
 - **Encryption envelope** for at-rest secrets - versioned AES-256-GCM via HKDF-SHA-256
   subkeys per usage (`lib/crypto/encryption.ts`).
 - **Secret-field redaction** in audit `before`/`after` snapshots and free-form log strings.

--- a/docs/adr/0014-backend-capability-model.md
+++ b/docs/adr/0014-backend-capability-model.md
@@ -34,6 +34,29 @@ behaviour had to be moved off `role` onto zone `kind` (done); the `/config` advi
    existing poll from `/config` + `/servers/{id}`: `api`, `primary`, `secondary`, `autosecondary`,
    `launch` backends, per-backend DNSSEC, daemon + API version. Same write path and cache pattern as
    the version cache - a sanctioned `lib/pdns → lib/db` bridge (ADR-0013).
+
+   > **Amendment (2026-07-22, #111):** "observe, don't declare" holds for everything PowerDNS can
+   > actually tell us - and there is exactly one thing it can't. A daemon whose **database user is
+   > read-only** (the public half of a native-zone deployment replicated at the DB layer) reports
+   > `primary=no, secondary=no` over `/config`, byte-identical to a standalone primary. There is no
+   > flag, no probe, and no safe write-test that distinguishes them, so derivation necessarily calls
+   > it writable and `choosePeer` rotates writes onto a node that rejects them.
+   >
+   > We therefore add ONE operator-declared field, `pdns_servers.write_mode` (`auto` | `read_only`),
+   > and constrain it tightly so it can't grow back into the `role` we deleted:
+   >
+   > - It can only ever **subtract**. `read_only` vetoes a daemon the capabilities called writable;
+   >   `auto` never promotes an observed mirror into a write target. Authority still flows one way.
+   > - It governs **write routing and the operator-facing backend pickers only** - the predicate is
+   >   `isServerWriteTarget()`. AXFR topology derivation (decision 4) keeps reading raw capabilities,
+   >   because `masters[]` resolution is a fact about the DNS protocol that an operator's routing
+   >   preference must not rewrite. Marking a genuine AXFR primary `read_only` stops writes going to
+   >   it; it must not make the secondaries pulling from it un-resolvable.
+   > - It defaults to `auto`, so every existing backend behaves exactly as before.
+   >
+   > This is a deliberate, bounded exception. The test for adding another one: PowerDNS must be
+   > _incapable_ of reporting the fact, not merely inconvenient to ask.
+
 3. **Gate editability on zone `kind`** via one ops resolver:
    `zoneCapabilities(kind) → { rrsets, metadata, masters, dnssec, axfrRetrieve, delete }`.
    Generalizes the existing `isReadOnlyZoneKind` and encodes the _real_ writable options on a

--- a/drizzle-sqlite/0005_known_vance_astro.sql
+++ b/drizzle-sqlite/0005_known_vance_astro.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `pdns_servers` ADD `write_mode` text DEFAULT 'auto' NOT NULL;

--- a/drizzle-sqlite/meta/0005_snapshot.json
+++ b/drizzle-sqlite/meta/0005_snapshot.json
@@ -1,0 +1,2715 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "998298ff-6b04-4195-ba67-80d1c8db89f4",
+  "prevId": "ee5e5bc3-b993-4895-8d71-7249e41cd25f",
+  "tables": {
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totp_secret_encrypted": {
+          "name": "totp_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mfa_required": {
+          "name": "mfa_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webauthn_credentials": {
+          "name": "webauthn_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_login_count": {
+          "name": "failed_login_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_login_ip": {
+          "name": "last_login_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash_updated_at": {
+          "name": "password_hash_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_lower_idx": {
+          "name": "users_email_lower_idx",
+          "columns": [
+            "lower(\"email\")"
+          ],
+          "isUnique": true
+        },
+        "users_disabled_idx": {
+          "name": "users_disabled_idx",
+          "columns": [
+            "disabled_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mail": {
+          "name": "mail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "teams_slug_idx": {
+          "name": "teams_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "teams_name_idx": {
+          "name": "teams_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_members": {
+      "name": "team_members",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_role": {
+          "name": "team_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_members_team_idx": {
+          "name": "team_members_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_user_id_team_id_pk": {
+          "columns": [
+            "user_id",
+            "team_id"
+          ],
+          "name": "team_members_user_id_team_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "team_members_team_role_check": {
+          "name": "team_members_team_role_check",
+          "value": "\"team_members\".\"team_role\" IN ('owner','member')"
+        }
+      }
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "csrf_secret": {
+          "name": "csrf_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oidc_end_session_url": {
+          "name": "oidc_end_session_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_id_token": {
+          "name": "oidc_id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_client_id": {
+          "name": "oidc_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derived_permissions": {
+          "name": "derived_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "oidc_refresh_token_encrypted": {
+          "name": "oidc_refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idp_provider_type": {
+          "name": "idp_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idp_provider_slug": {
+          "name": "idp_provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "requires_mfa": {
+          "name": "requires_mfa",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "roles_slug_idx": {
+          "name": "roles_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "roles_system_idx": {
+          "name": "roles_system_idx",
+          "columns": [
+            "is_system"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "role_assignments": {
+      "name": "role_assignments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "role_assignments_user_idx": {
+          "name": "role_assignments_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "role_assignments_role_idx": {
+          "name": "role_assignments_role_idx",
+          "columns": [
+            "role_id"
+          ],
+          "isUnique": false
+        },
+        "role_assignments_scope_idx": {
+          "name": "role_assignments_scope_idx",
+          "columns": [
+            "scope_type",
+            "scope_id"
+          ],
+          "isUnique": false
+        },
+        "role_assignments_unique_idx": {
+          "name": "role_assignments_unique_idx",
+          "columns": [
+            "user_id",
+            "role_id",
+            "scope_type",
+            "scope_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "role_assignments_user_id_users_id_fk": {
+          "name": "role_assignments_user_id_users_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignments_role_id_roles_id_fk": {
+          "name": "role_assignments_role_id_roles_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "role_assignments_created_by_users_id_fk": {
+          "name": "role_assignments_created_by_users_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "role_assignments_scope_type_check": {
+          "name": "role_assignments_scope_type_check",
+          "value": "\"role_assignments\".\"scope_type\" IN ('global','team','zone','server')"
+        }
+      }
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_user_idx": {
+          "name": "api_tokens_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "api_tokens_prefix_idx": {
+          "name": "api_tokens_prefix_idx",
+          "columns": [
+            "prefix"
+          ],
+          "isUnique": true
+        },
+        "api_tokens_team_idx": {
+          "name": "api_tokens_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_tokens_team_id_teams_id_fk": {
+          "name": "api_tokens_team_id_teams_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_ts_idx": {
+          "name": "audit_log_ts_idx",
+          "columns": [
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            "actor_type",
+            "actor_id"
+          ],
+          "isUnique": false
+        },
+        "audit_log_resource_idx": {
+          "name": "audit_log_resource_idx",
+          "columns": [
+            "resource_type",
+            "resource_id"
+          ],
+          "isUnique": false
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "audit_log_actor_type_check": {
+          "name": "audit_log_actor_type_check",
+          "value": "\"audit_log\".\"actor_type\" IN ('user','token','system')"
+        }
+      }
+    },
+    "pdns_clusters": {
+      "name": "pdns_clusters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "write_strategy": {
+          "name": "write_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'round_robin'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pdns_clusters_slug_unique": {
+          "name": "pdns_clusters_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pdns_clusters_created_by_users_id_fk": {
+          "name": "pdns_clusters_created_by_users_id_fk",
+          "tableFrom": "pdns_clusters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "pdns_clusters_write_strategy_check": {
+          "name": "pdns_clusters_write_strategy_check",
+          "value": "\"pdns_clusters\".\"write_strategy\" IN ('round_robin','lowest_latency','random','least_load')"
+        }
+      }
+    },
+    "pdns_servers": {
+      "name": "pdns_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'localhost'"
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_cache": {
+          "name": "version_cache",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "advertised_addresses": {
+          "name": "advertised_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "write_mode": {
+          "name": "write_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pdns_servers_slug_idx": {
+          "name": "pdns_servers_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "pdns_servers_default_idx": {
+          "name": "pdns_servers_default_idx",
+          "columns": [
+            "is_default"
+          ],
+          "isUnique": false
+        },
+        "pdns_servers_disabled_idx": {
+          "name": "pdns_servers_disabled_idx",
+          "columns": [
+            "disabled_at"
+          ],
+          "isUnique": false
+        },
+        "pdns_servers_cluster_id_idx": {
+          "name": "pdns_servers_cluster_id_idx",
+          "columns": [
+            "cluster_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pdns_servers_cluster_id_pdns_clusters_id_fk": {
+          "name": "pdns_servers_cluster_id_pdns_clusters_id_fk",
+          "tableFrom": "pdns_servers",
+          "tableTo": "pdns_clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pdns_servers_created_by_users_id_fk": {
+          "name": "pdns_servers_created_by_users_id_fk",
+          "tableFrom": "pdns_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metric_samples": {
+      "name": "metric_samples",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sampled_at": {
+          "name": "sampled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zone_count": {
+          "name": "zone_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_p50_ms": {
+          "name": "latency_p50_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_p95_ms": {
+          "name": "latency_p95_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_sessions": {
+          "name": "active_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "metric_samples_server_time_idx": {
+          "name": "metric_samples_server_time_idx",
+          "columns": [
+            "server_id",
+            "sampled_at"
+          ],
+          "isUnique": false
+        },
+        "metric_samples_time_idx": {
+          "name": "metric_samples_time_idx",
+          "columns": [
+            "sampled_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "backend_advisories": {
+      "name": "backend_advisories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backend_id": {
+          "name": "backend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "backend_advisories_backend_code_idx": {
+          "name": "backend_advisories_backend_code_idx",
+          "columns": [
+            "backend_id",
+            "code"
+          ],
+          "isUnique": true
+        },
+        "backend_advisories_backend_idx": {
+          "name": "backend_advisories_backend_idx",
+          "columns": [
+            "backend_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "backend_advisories_backend_id_pdns_servers_id_fk": {
+          "name": "backend_advisories_backend_id_pdns_servers_id_fk",
+          "tableFrom": "backend_advisories",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "backend_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_updated_by_users_id_fk": {
+          "name": "settings_updated_by_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oidc_providers": {
+      "name": "oidc_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret_encrypted": {
+          "name": "client_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openid profile email'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'name'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "require_email_verified": {
+          "name": "require_email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "discovery_cache": {
+          "name": "discovery_cache",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claim_groups": {
+          "name": "claim_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'groups'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oidc_providers_slug_idx": {
+          "name": "oidc_providers_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oidc_providers_created_by_users_id_fk": {
+          "name": "oidc_providers_created_by_users_id_fk",
+          "tableFrom": "oidc_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saml_providers": {
+      "name": "saml_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_entity_id": {
+          "name": "idp_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_sso_url": {
+          "name": "idp_sso_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_slo_url": {
+          "name": "idp_slo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idp_signing_cert": {
+          "name": "idp_signing_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sp_signing_key_encrypted": {
+          "name": "sp_signing_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sp_signing_cert": {
+          "name": "sp_signing_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sp_encryption_key_encrypted": {
+          "name": "sp_encryption_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sp_encryption_cert": {
+          "name": "sp_encryption_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_signed_response": {
+          "name": "require_signed_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "require_encrypted_assertion": {
+          "name": "require_encrypted_assertion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "signature_algorithm": {
+          "name": "signature_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'sha256'"
+        },
+        "name_id_format": {
+          "name": "name_id_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'name'"
+        },
+        "claim_groups": {
+          "name": "claim_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'groups'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "saml_providers_slug_idx": {
+          "name": "saml_providers_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "saml_providers_created_by_users_id_fk": {
+          "name": "saml_providers_created_by_users_id_fk",
+          "tableFrom": "saml_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ldap_providers": {
+      "name": "ldap_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_tls": {
+          "name": "start_tls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bind_password_encrypted": {
+          "name": "bind_password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_search_base": {
+          "name": "user_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_search_filter": {
+          "name": "user_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'(|(uid={{username}})(sAMAccountName={{username}})(mail={{username}}))'"
+        },
+        "group_search_base": {
+          "name": "group_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_search_filter": {
+          "name": "group_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_attr": {
+          "name": "group_attr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'memberOf'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mail'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'displayName'"
+        },
+        "tls_ca_cert": {
+          "name": "tls_ca_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ldap_providers_slug_idx": {
+          "name": "ldap_providers_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ldap_providers_created_by_users_id_fk": {
+          "name": "ldap_providers_created_by_users_id_fk",
+          "tableFrom": "ldap_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_provider_slugs": {
+      "name": "auth_provider_slugs",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "zone_templates": {
+      "name": "zone_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "soa_ttl": {
+          "name": "soa_ttl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3600
+        },
+        "soa_refresh": {
+          "name": "soa_refresh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3600
+        },
+        "soa_retry": {
+          "name": "soa_retry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900
+        },
+        "soa_expire": {
+          "name": "soa_expire",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 604800
+        },
+        "soa_minimum": {
+          "name": "soa_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3600
+        },
+        "nameservers": {
+          "name": "nameservers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "records": {
+          "name": "records",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Native'"
+        },
+        "soa_edit": {
+          "name": "soa_edit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "soa_edit_api": {
+          "name": "soa_edit_api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_rectify": {
+          "name": "api_rectify",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "default_for_primary_ids": {
+          "name": "default_for_primary_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "zone_templates_slug_idx": {
+          "name": "zone_templates_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "zone_templates_created_by_users_id_fk": {
+          "name": "zone_templates_created_by_users_id_fk",
+          "tableFrom": "zone_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "zone_grants": {
+      "name": "zone_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "zone_grants_user_idx": {
+          "name": "zone_grants_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "zone_grants_team_idx": {
+          "name": "zone_grants_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "zone_grants_zone_idx": {
+          "name": "zone_grants_zone_idx",
+          "columns": [
+            "server_id",
+            "zone_name"
+          ],
+          "isUnique": false
+        },
+        "zone_grants_user_unique_idx": {
+          "name": "zone_grants_user_unique_idx",
+          "columns": [
+            "user_id",
+            "server_id",
+            "zone_name"
+          ],
+          "isUnique": true,
+          "where": "\"zone_grants\".\"user_id\" IS NOT NULL"
+        },
+        "zone_grants_team_unique_idx": {
+          "name": "zone_grants_team_unique_idx",
+          "columns": [
+            "team_id",
+            "server_id",
+            "zone_name"
+          ],
+          "isUnique": true,
+          "where": "\"zone_grants\".\"team_id\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "zone_grants_user_id_users_id_fk": {
+          "name": "zone_grants_user_id_users_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_grants_team_id_teams_id_fk": {
+          "name": "zone_grants_team_id_teams_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_grants_server_id_pdns_servers_id_fk": {
+          "name": "zone_grants_server_id_pdns_servers_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_grants_created_by_users_id_fk": {
+          "name": "zone_grants_created_by_users_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "zone_grants_principal_check": {
+          "name": "zone_grants_principal_check",
+          "value": "(\"zone_grants\".\"user_id\" IS NULL) <> (\"zone_grants\".\"team_id\" IS NULL)"
+        }
+      }
+    },
+    "pdns_requests": {
+      "name": "pdns_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_slug": {
+          "name": "server_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "op": {
+          "name": "op",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pdns_requests_request_id_idx": {
+          "name": "pdns_requests_request_id_idx",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "pdns_requests_ts_idx": {
+          "name": "pdns_requests_ts_idx",
+          "columns": [
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "pdns_requests_server_id_idx": {
+          "name": "pdns_requests_server_id_idx",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pdns_requests_server_id_pdns_servers_id_fk": {
+          "name": "pdns_requests_server_id_pdns_servers_id_fk",
+          "tableFrom": "pdns_requests",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pdns_server_stats": {
+      "name": "pdns_server_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "map_value": {
+          "name": "map_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pdns_server_stats_server_ts_idx": {
+          "name": "pdns_server_stats_server_ts_idx",
+          "columns": [
+            "server_id",
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "pdns_server_stats_server_name_ts_idx": {
+          "name": "pdns_server_stats_server_name_ts_idx",
+          "columns": [
+            "server_id",
+            "name",
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "pdns_server_stats_ts_idx": {
+          "name": "pdns_server_stats_ts_idx",
+          "columns": [
+            "ts"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pdns_server_stats_server_id_pdns_servers_id_fk": {
+          "name": "pdns_server_stats_server_id_pdns_servers_id_fk",
+          "tableFrom": "pdns_server_stats",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "users_email_lower_idx": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle-sqlite/meta/_journal.json
+++ b/drizzle-sqlite/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1779924229752,
       "tag": "0004_black_storm",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1784668351372,
+      "tag": "0005_known_vance_astro",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/0005_bizarre_ezekiel.sql
+++ b/drizzle/0005_bizarre_ezekiel.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "pdns_servers" ADD COLUMN "write_mode" text DEFAULT 'auto' NOT NULL;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,3020 @@
+{
+  "id": "2f4b3a64-48bb-4654-8e81-fc16566d0c8b",
+  "prevId": "8b618285-4be8-4f43-ae36-8d5a48b1557a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_tokens_user_idx": {
+          "name": "api_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_prefix_idx": {
+          "name": "api_tokens_prefix_idx",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_team_idx": {
+          "name": "api_tokens_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_tokens_team_id_teams_id_fk": {
+          "name": "api_tokens_team_id_teams_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_ts_idx": {
+          "name": "audit_log_ts_idx",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_resource_idx": {
+          "name": "audit_log_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_provider_slugs": {
+      "name": "auth_provider_slugs",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backend_advisories": {
+      "name": "backend_advisories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "backend_id": {
+          "name": "backend_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "backend_advisories_backend_code_idx": {
+          "name": "backend_advisories_backend_code_idx",
+          "columns": [
+            {
+              "expression": "backend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "backend_advisories_backend_idx": {
+          "name": "backend_advisories_backend_idx",
+          "columns": [
+            {
+              "expression": "backend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "backend_advisories_backend_id_pdns_servers_id_fk": {
+          "name": "backend_advisories_backend_id_pdns_servers_id_fk",
+          "tableFrom": "backend_advisories",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "backend_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ldap_providers": {
+      "name": "ldap_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_tls": {
+          "name": "start_tls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bind_password_encrypted": {
+          "name": "bind_password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_search_base": {
+          "name": "user_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_search_filter": {
+          "name": "user_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'(|(uid={{username}})(sAMAccountName={{username}})(mail={{username}}))'"
+        },
+        "group_search_base": {
+          "name": "group_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_search_filter": {
+          "name": "group_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_attr": {
+          "name": "group_attr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'memberOf'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mail'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'displayName'"
+        },
+        "tls_ca_cert": {
+          "name": "tls_ca_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ldap_providers_slug_idx": {
+          "name": "ldap_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ldap_providers_created_by_users_id_fk": {
+          "name": "ldap_providers_created_by_users_id_fk",
+          "tableFrom": "ldap_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_samples": {
+      "name": "metric_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sampled_at": {
+          "name": "sampled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "zone_count": {
+          "name": "zone_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_p50_ms": {
+          "name": "latency_p50_ms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_p95_ms": {
+          "name": "latency_p95_ms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_sessions": {
+          "name": "active_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "metric_samples_server_time_idx": {
+          "name": "metric_samples_server_time_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sampled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_samples_time_idx": {
+          "name": "metric_samples_time_idx",
+          "columns": [
+            {
+              "expression": "sampled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_encrypted": {
+          "name": "client_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openid profile email'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'name'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "require_email_verified": {
+          "name": "require_email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discovery_cache": {
+          "name": "discovery_cache",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_groups": {
+          "name": "claim_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'groups'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oidc_providers_slug_idx": {
+          "name": "oidc_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_providers_created_by_users_id_fk": {
+          "name": "oidc_providers_created_by_users_id_fk",
+          "tableFrom": "oidc_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdns_clusters": {
+      "name": "pdns_clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "write_strategy": {
+          "name": "write_strategy",
+          "type": "pdns_cluster_write_strategy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'round_robin'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdns_clusters_created_by_users_id_fk": {
+          "name": "pdns_clusters_created_by_users_id_fk",
+          "tableFrom": "pdns_clusters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pdns_clusters_slug_unique": {
+          "name": "pdns_clusters_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdns_requests": {
+      "name": "pdns_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_slug": {
+          "name": "server_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "op": {
+          "name": "op",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pdns_requests_request_id_idx": {
+          "name": "pdns_requests_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pdns_requests_ts_idx": {
+          "name": "pdns_requests_ts_idx",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pdns_requests_server_id_idx": {
+          "name": "pdns_requests_server_id_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdns_requests_server_id_pdns_servers_id_fk": {
+          "name": "pdns_requests_server_id_pdns_servers_id_fk",
+          "tableFrom": "pdns_requests",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdns_server_stats": {
+      "name": "pdns_server_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_value": {
+          "name": "map_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pdns_server_stats_server_ts_idx": {
+          "name": "pdns_server_stats_server_ts_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pdns_server_stats_server_name_ts_idx": {
+          "name": "pdns_server_stats_server_name_ts_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pdns_server_stats_ts_idx": {
+          "name": "pdns_server_stats_ts_idx",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdns_server_stats_server_id_pdns_servers_id_fk": {
+          "name": "pdns_server_stats_server_id_pdns_servers_id_fk",
+          "tableFrom": "pdns_server_stats",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdns_servers": {
+      "name": "pdns_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'localhost'"
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_cache": {
+          "name": "version_cache",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advertised_addresses": {
+          "name": "advertised_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "write_mode": {
+          "name": "write_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pdns_servers_slug_idx": {
+          "name": "pdns_servers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pdns_servers_default_idx": {
+          "name": "pdns_servers_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pdns_servers_disabled_idx": {
+          "name": "pdns_servers_disabled_idx",
+          "columns": [
+            {
+              "expression": "disabled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pdns_servers_cluster_id_idx": {
+          "name": "pdns_servers_cluster_id_idx",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdns_servers_cluster_id_pdns_clusters_id_fk": {
+          "name": "pdns_servers_cluster_id_pdns_clusters_id_fk",
+          "tableFrom": "pdns_servers",
+          "tableTo": "pdns_clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pdns_servers_created_by_users_id_fk": {
+          "name": "pdns_servers_created_by_users_id_fk",
+          "tableFrom": "pdns_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_assignments": {
+      "name": "role_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "scope_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_assignments_user_idx": {
+          "name": "role_assignments_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_assignments_role_idx": {
+          "name": "role_assignments_role_idx",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_assignments_scope_idx": {
+          "name": "role_assignments_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_assignments_unique_idx": {
+          "name": "role_assignments_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_assignments_user_id_users_id_fk": {
+          "name": "role_assignments_user_id_users_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignments_role_id_roles_id_fk": {
+          "name": "role_assignments_role_id_roles_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "role_assignments_created_by_users_id_fk": {
+          "name": "role_assignments_created_by_users_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_mfa": {
+          "name": "requires_mfa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roles_slug_idx": {
+          "name": "roles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roles_system_idx": {
+          "name": "roles_system_idx",
+          "columns": [
+            {
+              "expression": "is_system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saml_providers": {
+      "name": "saml_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idp_entity_id": {
+          "name": "idp_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idp_sso_url": {
+          "name": "idp_sso_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idp_slo_url": {
+          "name": "idp_slo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idp_signing_cert": {
+          "name": "idp_signing_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sp_signing_key_encrypted": {
+          "name": "sp_signing_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sp_signing_cert": {
+          "name": "sp_signing_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sp_encryption_key_encrypted": {
+          "name": "sp_encryption_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sp_encryption_cert": {
+          "name": "sp_encryption_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_signed_response": {
+          "name": "require_signed_response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "require_encrypted_assertion": {
+          "name": "require_encrypted_assertion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signature_algorithm": {
+          "name": "signature_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sha256'"
+        },
+        "name_id_format": {
+          "name": "name_id_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'name'"
+        },
+        "claim_groups": {
+          "name": "claim_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'groups'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saml_providers_slug_idx": {
+          "name": "saml_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saml_providers_created_by_users_id_fk": {
+          "name": "saml_providers_created_by_users_id_fk",
+          "tableFrom": "saml_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "csrf_secret": {
+          "name": "csrf_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_end_session_url": {
+          "name": "oidc_end_session_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_id_token": {
+          "name": "oidc_id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_client_id": {
+          "name": "oidc_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derived_permissions": {
+          "name": "derived_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "oidc_refresh_token_encrypted": {
+          "name": "oidc_refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idp_provider_type": {
+          "name": "idp_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idp_provider_slug": {
+          "name": "idp_provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_updated_by_users_id_fk": {
+          "name": "settings_updated_by_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_role": {
+          "name": "team_role",
+          "type": "team_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_members_team_idx": {
+          "name": "team_members_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_user_id_team_id_pk": {
+          "name": "team_members_user_id_team_id_pk",
+          "columns": [
+            "user_id",
+            "team_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail": {
+          "name": "mail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_slug_idx": {
+          "name": "teams_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_name_idx": {
+          "name": "teams_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_secret_encrypted": {
+          "name": "totp_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mfa_required": {
+          "name": "mfa_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webauthn_credentials": {
+          "name": "webauthn_credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_login_count": {
+          "name": "failed_login_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_ip": {
+          "name": "last_login_ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password_hash_updated_at": {
+          "name": "password_hash_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_lower_idx": {
+          "name": "users_email_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_disabled_idx": {
+          "name": "users_disabled_idx",
+          "columns": [
+            {
+              "expression": "disabled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zone_grants": {
+      "name": "zone_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zone_grants_user_idx": {
+          "name": "zone_grants_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zone_grants_team_idx": {
+          "name": "zone_grants_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zone_grants_zone_idx": {
+          "name": "zone_grants_zone_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zone_grants_user_unique_idx": {
+          "name": "zone_grants_user_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"zone_grants\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zone_grants_team_unique_idx": {
+          "name": "zone_grants_team_unique_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"zone_grants\".\"team_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zone_grants_user_id_users_id_fk": {
+          "name": "zone_grants_user_id_users_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_grants_team_id_teams_id_fk": {
+          "name": "zone_grants_team_id_teams_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_grants_server_id_pdns_servers_id_fk": {
+          "name": "zone_grants_server_id_pdns_servers_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_grants_created_by_users_id_fk": {
+          "name": "zone_grants_created_by_users_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "zone_grants_principal_check": {
+          "name": "zone_grants_principal_check",
+          "value": "(\"zone_grants\".\"user_id\" IS NULL) <> (\"zone_grants\".\"team_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.zone_templates": {
+      "name": "zone_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soa_ttl": {
+          "name": "soa_ttl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3600
+        },
+        "soa_refresh": {
+          "name": "soa_refresh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3600
+        },
+        "soa_retry": {
+          "name": "soa_retry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 900
+        },
+        "soa_expire": {
+          "name": "soa_expire",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 604800
+        },
+        "soa_minimum": {
+          "name": "soa_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3600
+        },
+        "nameservers": {
+          "name": "nameservers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "records": {
+          "name": "records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Native'"
+        },
+        "soa_edit": {
+          "name": "soa_edit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soa_edit_api": {
+          "name": "soa_edit_api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_rectify": {
+          "name": "api_rectify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "default_for_primary_ids": {
+          "name": "default_for_primary_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zone_templates_slug_idx": {
+          "name": "zone_templates_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zone_templates_created_by_users_id_fk": {
+          "name": "zone_templates_created_by_users_id_fk",
+          "tableFrom": "zone_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "token",
+        "system"
+      ]
+    },
+    "public.pdns_cluster_write_strategy": {
+      "name": "pdns_cluster_write_strategy",
+      "schema": "public",
+      "values": [
+        "round_robin",
+        "lowest_latency",
+        "random",
+        "least_load"
+      ]
+    },
+    "public.scope_type": {
+      "name": "scope_type",
+      "schema": "public",
+      "values": [
+        "global",
+        "team",
+        "zone",
+        "server"
+      ]
+    },
+    "public.team_role": {
+      "name": "team_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1779924227256,
       "tag": "0004_low_luminals",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1784668374542,
+      "tag": "0005_bizarre_ezekiel",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/repositories/dashboard.ts
+++ b/lib/db/repositories/dashboard.ts
@@ -20,7 +20,7 @@ import { oidcProviders } from "@/lib/db/schema";
 import { pdnsServers } from "@/lib/db/schema";
 import { users } from "@/lib/db/schema";
 import { countStar, isSqlite, jsonBoolField, truncToHour } from "@/lib/db/sql-dialect";
-import { isWriteCapable } from "@/lib/pdns/capabilities";
+import { isServerWriteTarget } from "@/lib/pdns/capabilities";
 
 // =============================================================================
 // Audit-derived
@@ -178,6 +178,7 @@ export async function latestBackendSamples(): Promise<BackendStat[]> {
       serverSlug: pdnsServers.slug,
       serverName: pdnsServers.name,
       capabilities: pdnsServers.capabilities,
+      writeMode: pdnsServers.writeMode,
       clusterId: pdnsServers.clusterId,
       zoneCount: metricSamples.zoneCount,
       latencyP50Ms: metricSamples.latencyP50Ms,
@@ -197,7 +198,7 @@ export async function latestBackendSamples(): Promise<BackendStat[]> {
     serverId: row.serverId,
     serverSlug: row.serverSlug,
     serverName: row.serverName,
-    isWriteTarget: isWriteCapable(row.capabilities),
+    isWriteTarget: isServerWriteTarget(row),
     clusterId: row.clusterId ?? null,
     zoneCount: row.zoneCount ?? null,
     latencyP50Ms: row.latencyP50Ms ?? null,

--- a/lib/db/repositories/pdns-clusters.ts
+++ b/lib/db/repositories/pdns-clusters.ts
@@ -15,7 +15,7 @@ import {
   type PdnsCluster,
   type PdnsServer,
 } from "@/lib/db/schema";
-import { isWriteCapable } from "@/lib/pdns/capabilities";
+import { isServerWriteTarget } from "@/lib/pdns/capabilities";
 
 export async function listAllClusters(): Promise<PdnsCluster[]> {
   return db.select().from(pdnsClusters).orderBy(pdnsClusters.name);
@@ -58,10 +58,11 @@ export async function deleteCluster(id: string, executor: DbExecutor = db): Prom
 }
 
 /**
- * Active WRITABLE peers in a group - primaries with this cluster_id, not
- * disabled. Feeds the write-strategy picker (choosePeer), so it must exclude
- * secondaries (ADR-0014): a group may now contain a primary's secondaries, and
- * a write must never be routed to a read-only mirror.
+ * Active WRITABLE peers in a group - members with this cluster_id, not
+ * disabled, that we may actually write to. Feeds the peer picker (choosePeer),
+ * so it must exclude both observed read-only mirrors (ADR-0014) and backends
+ * the operator has marked `read_only` (#111) - a write must never be routed to
+ * either.
  */
 export async function listActivePeersForCluster(clusterId: string): Promise<PdnsServer[]> {
   const rows = await db
@@ -69,7 +70,7 @@ export async function listActivePeersForCluster(clusterId: string): Promise<Pdns
     .from(pdnsServers)
     .where(and(eq(pdnsServers.clusterId, clusterId), isNull(pdnsServers.disabledAt)))
     .orderBy(pdnsServers.name);
-  return rows.filter((r) => isWriteCapable(r.capabilities));
+  return rows.filter(isServerWriteTarget);
 }
 
 /**

--- a/lib/db/repositories/pdns-servers.ts
+++ b/lib/db/repositories/pdns-servers.ts
@@ -21,14 +21,15 @@ import {
   type PdnsVersionCache,
   type PdnsDaemonCapabilities,
 } from "@/lib/db/schema";
-import { isReadOnlyMirror, isWriteCapable } from "@/lib/pdns/capabilities";
+import { isReadOnlyBackend, isServerWriteTarget } from "@/lib/pdns/capabilities";
 
 /**
  * Active (non-disabled) WRITE-TARGET backends - the default for read paths
  * (zones list, dashboards, write APIs). A backend is a write target when its
  * observed capabilities report `primary`, or it hasn't been probed yet
- * (ADR-0014). Replaces the old `role='primary'` filter. Use
- * `listSecondariesForPrimary` / `listAllActiveBackends` for mirrors.
+ * (ADR-0014), and the operator hasn't overridden it to `read_only` (#111).
+ * Replaces the old `role='primary'` filter. Use `listSecondariesForPrimary` /
+ * `listAllActiveBackends` for mirrors.
  */
 export async function listActivePdnsServers(): Promise<PdnsServer[]> {
   const rows = await db
@@ -36,7 +37,7 @@ export async function listActivePdnsServers(): Promise<PdnsServer[]> {
     .from(pdnsServers)
     .where(isNull(pdnsServers.disabledAt))
     .orderBy(pdnsServers.name);
-  return rows.filter((r) => isWriteCapable(r.capabilities));
+  return rows.filter(isServerWriteTarget);
 }
 
 /** Every active backend regardless of role - for the stats sampler. */
@@ -49,10 +50,15 @@ export async function listAllActiveBackends(): Promise<PdnsServer[]> {
 }
 
 /**
- * Active secondaries that belong to NO group (`cluster_id` null) - they mirror
- * an external / unmanaged primary, so the app can only browse their zones
- * read-only. The amalgamated zones list uses this to surface those otherwise-
- * invisible zones (deduped against primary zones).
+ * Active read-only backends that belong to NO group (`cluster_id` null) - they
+ * mirror an external / unmanaged primary, so the app can only browse their
+ * zones read-only. The amalgamated zones list uses this to surface those
+ * otherwise-invisible zones (deduped against primary zones).
+ *
+ * Includes `write_mode='read_only'` backends (#111): an ungrouped node the
+ * operator has declared unwritable is browse-only in exactly the same way, and
+ * this is the path that keeps its zones visible at all - it is excluded from
+ * every write-target list by definition.
  */
 export async function listUngroupedSecondaries(): Promise<PdnsServer[]> {
   const rows = await db
@@ -60,17 +66,20 @@ export async function listUngroupedSecondaries(): Promise<PdnsServer[]> {
     .from(pdnsServers)
     .where(and(isNull(pdnsServers.disabledAt), isNull(pdnsServers.clusterId)))
     .orderBy(pdnsServers.name);
-  return rows.filter((r) => isReadOnlyMirror(r.capabilities));
+  return rows.filter(isReadOnlyBackend);
 }
 
-/** Active read-only-mirror members of a group (ADR-0014 capability classification). */
+/**
+ * Active read-only members of a group - observed AXFR mirrors (ADR-0014) plus
+ * operator-declared `read_only` backends (#111).
+ */
 export async function listClusterSecondaries(clusterId: string): Promise<PdnsServer[]> {
   const rows = await db
     .select()
     .from(pdnsServers)
     .where(and(isNull(pdnsServers.disabledAt), eq(pdnsServers.clusterId, clusterId)))
     .orderBy(pdnsServers.name);
-  return rows.filter((r) => isReadOnlyMirror(r.capabilities));
+  return rows.filter(isReadOnlyBackend);
 }
 
 /**
@@ -123,7 +132,7 @@ export async function assignServerToCluster(
 /** Write-target backends, any disabled state - for admin lists/pickers. */
 export async function listAllPrimaries(): Promise<PdnsServer[]> {
   const rows = await db.select().from(pdnsServers).orderBy(pdnsServers.name);
-  return rows.filter((r) => isWriteCapable(r.capabilities));
+  return rows.filter(isServerWriteTarget);
 }
 
 /** Find a backend by id. */
@@ -144,14 +153,15 @@ export async function findPdnsServerBySlug(slug: string): Promise<PdnsServer | n
  * active server - that one. Otherwise null.
  */
 export async function findDefaultPdnsServer(): Promise<PdnsServer | null> {
-  // The default is the implicit write target, so it must be write-capable
-  // (ADR-0014) - a read-only mirror is never the default.
+  // The default is the implicit write target, so it must be writable
+  // (ADR-0014) - neither a read-only mirror nor a `read_only` override (#111)
+  // is ever the default.
   const marked = await db
     .select()
     .from(pdnsServers)
     .where(and(eq(pdnsServers.isDefault, true), isNull(pdnsServers.disabledAt)))
     .limit(1);
-  if (marked[0] && isWriteCapable(marked[0].capabilities)) return marked[0];
+  if (marked[0] && isServerWriteTarget(marked[0])) return marked[0];
 
   const active = await listActivePdnsServers();
   return active.length === 1 ? (active[0] ?? null) : null;

--- a/lib/db/repositories/selectable-backends.ts
+++ b/lib/db/repositories/selectable-backends.ts
@@ -28,7 +28,7 @@ import "server-only";
 import { isNull } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { pdnsClusters, pdnsServers, type PdnsCluster, type PdnsServer } from "@/lib/db/schema";
-import { isReadOnlyMirror, isWriteCapable } from "@/lib/pdns/capabilities";
+import { isReadOnlyBackend, isServerWriteTarget } from "@/lib/pdns/capabilities";
 
 export type SelectableBackend =
   | {
@@ -67,12 +67,13 @@ export async function listSelectableBackends(): Promise<SelectableBackend[]> {
   const out: SelectableBackend[] = [];
   const seenClusters = new Set<string>();
 
-  // Each group collapses to ONE entry. Peers are its WRITABLE members
-  // (primaries) - never secondaries, so a write is never routed to a mirror.
-  // Secondary members ride along for topology display.
+  // Each group collapses to ONE entry. Peers are its WRITABLE members - never
+  // mirrors and never `read_only` overrides (#111), so a write is never routed
+  // somewhere it would be rejected. Read-only members ride along for topology
+  // display.
   for (const c of clusters) {
     const members = allServers.filter((s) => s.clusterId === c.id);
-    const peers = members.filter((s) => isWriteCapable(s.capabilities));
+    const peers = members.filter(isServerWriteTarget);
     if (peers.length === 0) continue;
     seenClusters.add(c.id);
     out.push({
@@ -80,14 +81,17 @@ export async function listSelectableBackends(): Promise<SelectableBackend[]> {
       cluster: c,
       peers,
       representativeServer: peers[0]!,
-      secondaries: members.filter((s) => isReadOnlyMirror(s.capabilities)),
+      secondaries: members.filter(isReadOnlyBackend),
     });
   }
 
   // Standalone write targets (not in a group). A backend's managed secondaries
   // are group members, so a write target outside any group has none here.
+  // Ungrouped read-only backends are deliberately absent: they're surfaced by
+  // `listUngroupedSecondaries()` on the zones list instead, since this list is
+  // specifically "things you can pick as a write target".
   for (const s of allServers) {
-    if (!isWriteCapable(s.capabilities)) continue;
+    if (!isServerWriteTarget(s)) continue;
     if (s.clusterId && seenClusters.has(s.clusterId)) continue;
     out.push({
       kind: "server",

--- a/lib/db/schema-sqlite/pdns-servers.ts
+++ b/lib/db/schema-sqlite/pdns-servers.ts
@@ -3,12 +3,12 @@
  */
 
 import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
-import type { PdnsDaemonCapabilities, PdnsVersionCache } from "@/lib/pdns/types";
+import type { PdnsDaemonCapabilities, PdnsVersionCache, PdnsWriteMode } from "@/lib/pdns/types";
 import { pdnsClusters } from "./pdns-clusters";
 import { users } from "./users";
 import { pk, timestamps } from "./_helpers";
 
-export type { PdnsVersionCache, PdnsDaemonCapabilities } from "@/lib/pdns/types";
+export type { PdnsVersionCache, PdnsDaemonCapabilities, PdnsWriteMode } from "@/lib/pdns/types";
 
 export const pdnsServers = sqliteTable(
   "pdns_servers",
@@ -24,6 +24,9 @@ export const pdnsServers = sqliteTable(
     capabilities: text("capabilities", { mode: "json" }).$type<PdnsDaemonCapabilities | null>(),
     advertisedAddresses: text("advertised_addresses", { mode: "json" }).$type<string[] | null>(),
     lastSeenAt: integer("last_seen_at", { mode: "timestamp_ms" }),
+    /** Operator write-routing override (#111). See the PG schema for the rationale. */
+    writeMode: text("write_mode").notNull().default("auto").$type<PdnsWriteMode>(),
+
     isDefault: integer("is_default", { mode: "boolean" }).notNull().default(false),
     clusterId: text("cluster_id").references(() => pdnsClusters.id, { onDelete: "set null" }),
     disabledAt: integer("disabled_at", { mode: "timestamp_ms" }),

--- a/lib/db/schema/pdns-servers.ts
+++ b/lib/db/schema/pdns-servers.ts
@@ -22,7 +22,7 @@ import {
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
-import type { PdnsDaemonCapabilities, PdnsVersionCache } from "@/lib/pdns/types";
+import type { PdnsDaemonCapabilities, PdnsVersionCache, PdnsWriteMode } from "@/lib/pdns/types";
 import { pdnsClusters } from "./pdns-clusters";
 import { users } from "./users";
 import { pk, timestamps } from "./_helpers";
@@ -31,7 +31,7 @@ import { pk, timestamps } from "./_helpers";
 // adapter doesn't have to cross the import-boundary rule that forbids
 // `lib/pdns → lib/db`. Re-exported here so existing callers that import
 // the type from this file (the historical location) keep working.
-export type { PdnsVersionCache, PdnsDaemonCapabilities } from "@/lib/pdns/types";
+export type { PdnsVersionCache, PdnsDaemonCapabilities, PdnsWriteMode } from "@/lib/pdns/types";
 
 export const pdnsServers = pgTable(
   "pdns_servers",
@@ -105,6 +105,22 @@ export const pdnsServers = pgTable(
      * until the first successful contact.
      */
     lastSeenAt: timestamp("last_seen_at", { withTimezone: true }),
+
+    /**
+     * Operator override for write routing (#111). PowerDNS Auth has no config
+     * flag that says "my database user is read-only", so a native-zone public
+     * nameserver fed by DB replication looks identical to a standalone primary
+     * over `/config` - `primary=no, secondary=no` - and capability derivation
+     * classifies it as writable. This column is the only way an operator can
+     * say otherwise.
+     *
+     *   `auto`      - trust the observed capabilities (the default; unchanged
+     *                 behaviour for every existing backend)
+     *   `read_only` - never route a write here, whatever `/config` claims
+     *
+     * Enforced by `isServerWriteTarget()`; see lib/pdns/capabilities.ts.
+     */
+    writeMode: text("write_mode").notNull().default("auto").$type<PdnsWriteMode>(),
 
     /**
      * Default backend used when a request doesn't specify `?server=`. Exactly

--- a/lib/pdns/capabilities.test.ts
+++ b/lib/pdns/capabilities.test.ts
@@ -3,6 +3,9 @@ import {
   deriveCapabilities,
   isReadOnlyMirror,
   isWriteCapable,
+  isServerWriteTarget,
+  isReadOnlyBackend,
+  classifyGroup,
   summarizeCapabilities,
 } from "./capabilities";
 import type { PdnsConfigSetting } from "./types";
@@ -99,5 +102,67 @@ describe("isWriteCapable / isReadOnlyMirror", () => {
     expect(isWriteCapable(null)).toBe(true);
     expect(isWriteCapable(undefined)).toBe(true);
     expect(isReadOnlyMirror(null)).toBe(false);
+  });
+});
+
+// The #109 case: a public nameserver serving native zones, fed by database
+// replication, whose DB user is read-only. Over /config it is indistinguishable
+// from a standalone primary, so only the operator's override can keep writes
+// off it.
+describe("isServerWriteTarget / isReadOnlyBackend (write_mode override)", () => {
+  const standalone = deriveCapabilities(cfg({}));
+  const mirror = deriveCapabilities(cfg({ secondary: "yes" }));
+
+  it("routes writes to a standalone backend on the default write_mode", () => {
+    expect(isServerWriteTarget({ capabilities: standalone, writeMode: "auto" })).toBe(true);
+    expect(isReadOnlyBackend({ capabilities: standalone, writeMode: "auto" })).toBe(false);
+  });
+
+  it("vetoes writes to a standalone backend marked read_only", () => {
+    expect(isServerWriteTarget({ capabilities: standalone, writeMode: "read_only" })).toBe(false);
+    expect(isReadOnlyBackend({ capabilities: standalone, writeMode: "read_only" })).toBe(true);
+  });
+
+  it("vetoes writes to an unprobed backend marked read_only", () => {
+    // Otherwise the "unprobed defaults to writable" rule would punch straight
+    // through the override during the window before the first probe.
+    expect(isServerWriteTarget({ capabilities: null, writeMode: "read_only" })).toBe(false);
+    expect(isServerWriteTarget({ capabilities: null, writeMode: "auto" })).toBe(true);
+  });
+
+  it("never promotes an observed mirror into a write target", () => {
+    // The override can only subtract. `auto` on a mirror stays read-only.
+    expect(isServerWriteTarget({ capabilities: mirror, writeMode: "auto" })).toBe(false);
+    expect(isServerWriteTarget({ capabilities: mirror, writeMode: "read_only" })).toBe(false);
+  });
+});
+
+describe("classifyGroup with write_mode overrides", () => {
+  const standalone = deriveCapabilities(cfg({}));
+
+  it("counts read_only members as mirrors, not writable peers", () => {
+    // One hidden primary + three read-only public nameservers. All four look
+    // writable over /config; only the override reveals the real shape.
+    const g = classifyGroup([
+      { capabilities: standalone, writeMode: "auto" },
+      { capabilities: standalone, writeMode: "read_only" },
+      { capabilities: standalone, writeMode: "read_only" },
+      { capabilities: standalone, writeMode: "read_only" },
+    ]);
+    expect(g.writable).toBe(1);
+    expect(g.mirrors).toBe(3);
+    // Crucially NOT "Multi-primary cluster" - there is exactly one write
+    // target, so a peer-selection strategy would have nothing to choose from.
+    expect(g.isMultiPrimary).toBe(false);
+    expect(g.typeLabel).toBe("Primary + secondaries");
+  });
+
+  it("still reports a genuine multi-primary cluster when no override is set", () => {
+    const g = classifyGroup([
+      { capabilities: standalone, writeMode: "auto" },
+      { capabilities: standalone, writeMode: "auto" },
+    ]);
+    expect(g.isMultiPrimary).toBe(true);
+    expect(g.typeLabel).toBe("Multi-primary cluster");
   });
 });

--- a/lib/pdns/capabilities.ts
+++ b/lib/pdns/capabilities.ts
@@ -7,7 +7,7 @@
  * which is why this replaces the operator-declared `role`.
  */
 
-import type { PdnsConfigSetting, PdnsDaemonCapabilities } from "./types";
+import type { PdnsConfigSetting, PdnsDaemonCapabilities, PdnsWriteMode } from "./types";
 
 const isYes = (v: string | undefined): boolean => v?.toLowerCase() === "yes";
 
@@ -83,11 +83,55 @@ export function isReadOnlyMirror(caps: PdnsDaemonCapabilities | null | undefined
   return !!caps && caps.secondary && !caps.primary;
 }
 
+/** The subset of a backend row this module reasons about. */
+export interface WriteRoutable {
+  capabilities: PdnsDaemonCapabilities | null;
+  writeMode: PdnsWriteMode;
+}
+
+/**
+ * Whether a backend may actually be written to - the predicate every write-
+ * routing decision must use, rather than {@link isWriteCapable} alone.
+ *
+ * `/config` cannot express "this daemon's database user is read-only" (#111).
+ * A public nameserver serving native zones fed by database replication reports
+ * `primary=no, secondary=no`, which is byte-identical to a standalone primary,
+ * so {@link deriveCapabilities} necessarily calls it writable and the cluster
+ * picker happily rotates writes onto it. The operator's `write_mode` override
+ * is the only signal that can correct that, so it wins here.
+ *
+ * The override can only ever *subtract*: `read_only` vetoes a daemon the
+ * capabilities said was writable, but `auto` never promotes a read-only mirror
+ * into a write target.
+ *
+ * SCOPE: this governs write ROUTING and the operator-facing backend pickers,
+ * not AXFR topology derivation. `lib/realtime/zone-poller.ts` and
+ * `lib/pdns/sync.ts` keep using {@link isWriteCapable} on the raw capabilities
+ * deliberately - they resolve mirror zones' `masters[]` back to the daemon
+ * that actually serves the AXFR, which is a fact about the DNS protocol that
+ * an operator's write-routing preference must not rewrite. Marking a genuine
+ * AXFR primary `read_only` should stop writes going to it, not make the
+ * secondaries that pull from it un-resolvable.
+ */
+export function isServerWriteTarget(server: WriteRoutable): boolean {
+  return server.writeMode !== "read_only" && isWriteCapable(server.capabilities);
+}
+
+/**
+ * Whether a backend is excluded from writes for any reason - an observed
+ * read-only mirror, or an operator-declared `read_only` override. The
+ * complement of {@link isServerWriteTarget}, named for UI that groups
+ * "everything we only read from" together.
+ */
+export function isReadOnlyBackend(server: WriteRoutable): boolean {
+  return !isServerWriteTarget(server);
+}
+
 /** Derived composition of a backend group (ADR-0014), from its members. */
 export interface GroupComposition {
-  /** Write-capable members (primaries / unprobed). */
+  /** Members that may be written to (primaries / unprobed, minus overrides). */
   writable: number;
-  /** Read-only mirror members. */
+  /** Members we only ever read from - observed mirrors plus `read_only` overrides. */
   mirrors: number;
   /**
    * A true multi-primary cluster - ≥2 writable peers sharing storage. Only
@@ -100,11 +144,13 @@ export interface GroupComposition {
 }
 
 /** Classify a group from its members' observed capabilities. */
-export function classifyGroup(
-  members: ReadonlyArray<{ capabilities: PdnsDaemonCapabilities | null }>,
-): GroupComposition {
-  const writable = members.filter((m) => isWriteCapable(m.capabilities)).length;
-  const mirrors = members.filter((m) => isReadOnlyMirror(m.capabilities)).length;
+export function classifyGroup(members: readonly WriteRoutable[]): GroupComposition {
+  // Counted off the routing predicate, not the raw capabilities: a group of
+  // one hidden primary plus three `read_only` public nameservers has exactly
+  // one write target, so it must not present itself as multi-primary and
+  // offer a peer-selection strategy that would do nothing (#111).
+  const writable = members.filter(isServerWriteTarget).length;
+  const mirrors = members.length - writable;
   const isMultiPrimary = writable >= 2;
   const typeLabel = isMultiPrimary
     ? "Multi-primary cluster"

--- a/lib/pdns/types.ts
+++ b/lib/pdns/types.ts
@@ -329,6 +329,19 @@ export type PdnsConfigSetting = z.infer<typeof pdnsConfigSettingSchema>;
 export const pdnsConfigSchema = z.array(pdnsConfigSettingSchema);
 
 /**
+ * Operator override for whether a backend may be written to (#111).
+ * Complements - and can only ever restrict - the observed capabilities:
+ * `auto` defers to them, `read_only` vetoes writes regardless.
+ *
+ * Lives here alongside `PdnsDaemonCapabilities` so the DB schema can use it
+ * for `.$type<>()` without crossing the `lib/pdns → lib/db` boundary.
+ */
+export type PdnsWriteMode = "auto" | "read_only";
+
+/** Every legal `PdnsWriteMode`, for validators and UI selects. */
+export const PDNS_WRITE_MODES = ["auto", "read_only"] as const satisfies readonly PdnsWriteMode[];
+
+/**
  * What a backend's daemon is OBSERVED to be willing/able to do, derived from
  * its read-only `/config` on each version probe (ADR-0014). This is the
  * per-daemon truth the app uses instead of an operator-declared `role`: a

--- a/lib/provisioning/apply.ts
+++ b/lib/provisioning/apply.ts
@@ -297,6 +297,7 @@ export async function applyProvisioning(config: ProvisioningConfig): Promise<Pro
           serverId: s.server_id,
           apiKeyEncrypted,
           isDefault: s.is_default,
+          writeMode: s.write_mode,
           clusterId,
         })
         .onConflictDoUpdate({
@@ -308,6 +309,7 @@ export async function applyProvisioning(config: ProvisioningConfig): Promise<Pro
             serverId: s.server_id,
             apiKeyEncrypted,
             isDefault: s.is_default,
+            writeMode: s.write_mode,
             clusterId,
             updatedAt: new Date(),
           },

--- a/lib/provisioning/schema.ts
+++ b/lib/provisioning/schema.ts
@@ -144,6 +144,11 @@ const pdnsServerEntry = z
     /** PDNS X-API-Key, plaintext in YAML. Encrypted before write. */
     api_key: z.string().min(1),
     is_default: z.boolean().default(false),
+    /** Operator write-routing override (#111). `auto` trusts the daemon's
+     *  observed /config; `read_only` vetoes writes to this backend regardless
+     *  - for nodes fed by database replication whose DB user can't write, a
+     *  state PowerDNS has no way to advertise over its API. */
+    write_mode: z.enum(["auto", "read_only"]).default("auto"),
     /** Group membership (ADR-0014). References a cluster slug from the
      *  `clusters:` section above. A backend's primary/secondary nature is
      *  OBSERVED from its `/config`, not declared here: group the writable

--- a/lib/security/icon-url.test.ts
+++ b/lib/security/icon-url.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { isSafeIconUrl, safeIconUrl } from "./icon-url";
+
+describe("safeIconUrl", () => {
+  it("accepts absolute http(s) URLs", () => {
+    expect(safeIconUrl("https://cdn.example.com/logo.svg")).toBe(
+      "https://cdn.example.com/logo.svg",
+    );
+    expect(safeIconUrl("http://cdn.example.com/logo.png")).toBe("http://cdn.example.com/logo.png");
+  });
+
+  it("accepts inline base64 data:image URIs", () => {
+    const gif = "data:image/gif;base64,R0lGODlhAQABAAAAACw=";
+    expect(safeIconUrl(gif)).toBe(gif);
+    const svg = "data:image/svg+xml;base64,PHN2Zy8+";
+    expect(safeIconUrl(svg)).toBe(svg);
+  });
+
+  it("trims surrounding whitespace so the checked value is the rendered value", () => {
+    // The whole point of returning a value rather than a boolean: a caller
+    // can't validate one string and render a different one (#113).
+    expect(safeIconUrl("  https://cdn.example.com/logo.svg  ")).toBe(
+      "https://cdn.example.com/logo.svg",
+    );
+  });
+
+  it("rejects script-bearing and non-image schemes", () => {
+    expect(safeIconUrl("javascript:alert(1)")).toBeNull();
+    expect(safeIconUrl("JaVaScRiPt:alert(1)")).toBeNull();
+    expect(safeIconUrl("data:text/html;base64,PHNjcmlwdD4=")).toBeNull();
+    expect(safeIconUrl("vbscript:msgbox(1)")).toBeNull();
+    expect(safeIconUrl("file:///etc/passwd")).toBeNull();
+  });
+
+  it("rejects relative and protocol-relative values", () => {
+    expect(safeIconUrl("//evil.example.com/logo.svg")).toBeNull();
+    expect(safeIconUrl("/logo.svg")).toBeNull();
+    expect(safeIconUrl("logo.svg")).toBeNull();
+    expect(safeIconUrl("")).toBeNull();
+  });
+
+  it("rejects a data:image URI whose payload isn't clean base64", () => {
+    // The previous regex stopped at the `;base64,` prefix and accepted any
+    // trailing bytes, so a payload could smuggle arbitrary characters.
+    expect(safeIconUrl('data:image/svg+xml;base64,"><script>alert(1)</script>')).toBeNull();
+    expect(safeIconUrl("data:image/png;base64,")).toBeNull();
+  });
+
+  it("rejects a data:image URI that isn't base64-encoded", () => {
+    expect(safeIconUrl("data:image/svg+xml,<svg onload=alert(1)>")).toBeNull();
+  });
+
+  it("rejects malformed http(s) URLs that only look right by prefix", () => {
+    // A bare prefix check passed these; parsing does not.
+    expect(safeIconUrl("https://")).toBeNull();
+  });
+
+  it("normalizes the scheme before matching, so case tricks don't slip through", () => {
+    // The URL parser lower-cases the protocol, so the allowlist sees a
+    // canonical value rather than whatever casing was typed.
+    expect(safeIconUrl("HTTPS://cdn.example.com/logo.svg")).toBe(
+      "https://cdn.example.com/logo.svg",
+    );
+    expect(safeIconUrl("JAVASCRIPT:alert(1)")).toBeNull();
+  });
+
+  it("rejects a non-image data: type even when the payload is valid base64", () => {
+    expect(safeIconUrl("data:application/javascript;base64,YWxlcnQoMSk=")).toBeNull();
+  });
+});
+
+describe("isSafeIconUrl", () => {
+  it("agrees with safeIconUrl", () => {
+    expect(isSafeIconUrl("https://cdn.example.com/logo.svg")).toBe(true);
+    expect(isSafeIconUrl("javascript:alert(1)")).toBe(false);
+  });
+});

--- a/lib/security/icon-url.ts
+++ b/lib/security/icon-url.ts
@@ -1,0 +1,73 @@
+/**
+ * lib/security/icon-url.ts
+ *
+ * The single scheme allowlist for operator-supplied icon URLs (OIDC login-
+ * button icons, brand logos).
+ *
+ * Deliberately NOT `server-only`: the admin form renders a live `<img>`
+ * preview of what's being typed, before anything reaches the server. That
+ * preview is the one place the value is shown without having passed the Zod
+ * validator, so it needs the same predicate - and it has to be the *same*
+ * function, not a copy, or the two drift and the preview quietly becomes more
+ * permissive than what can actually be saved (#113).
+ *
+ * Two structural rules keep this honest, and both matter:
+ *
+ *   1. **It returns a value, not a boolean.** Callers render what was
+ *      validated. The original bug was a guard on `iconUrl` protecting a sink
+ *      that rendered `iconUrl.trim()` - a different string, so the check said
+ *      nothing about what was displayed.
+ *   2. **Every accepted branch returns `parsed.href`.** The URL parser is the
+ *      sole constructor of the output; the regex below is only ever a
+ *      predicate. Nothing is reassembled from user-controlled fragments, so
+ *      there is no path by which an unexamined substring reaches an
+ *      `<img src>`. (Building the result from regex capture groups is what an
+ *      earlier revision did, and it's genuinely weaker - the captures are
+ *      still attacker-influenced text.)
+ */
+
+/**
+ * The `pathname` of an accepted `data:` URL - `<mime>;base64,<payload>` - with
+ * the payload constrained to a real base64 alphabet. Applied to the *parsed*
+ * pathname rather than the raw input so it can't be fooled by anything the URL
+ * parser would normalize away.
+ */
+const DATA_IMAGE_PATH = /^image\/(png|jpeg|jpg|gif|svg\+xml|webp);base64,[A-Za-z0-9+/]+={0,2}$/;
+
+/**
+ * Normalize `value` to a URL that is safe to hand to an `<img src>`, or null
+ * if it isn't one.
+ *
+ * Accepts an absolute http(s) URL or an inline base64 `data:image/...` URI.
+ * Everything else - `javascript:`, `file:`, non-image `data:` types, unencoded
+ * `data:` payloads, protocol-relative and relative paths, malformed input -
+ * returns null.
+ *
+ * Note this is not the last line of defense against script execution: a
+ * `javascript:` URL doesn't execute in an `<img src>` regardless, and browsers
+ * render SVG there in secure static mode. It's the allowlist that keeps a
+ * hostile-looking value from being rendered or stored in the first place.
+ */
+export function safeIconUrl(value: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(value.trim());
+  } catch {
+    return null;
+  }
+
+  switch (parsed.protocol) {
+    case "https:":
+    case "http:":
+      return parsed.href;
+    case "data:":
+      return DATA_IMAGE_PATH.test(parsed.pathname) ? parsed.href : null;
+    default:
+      return null;
+  }
+}
+
+/** Whether `value` is an acceptable icon URL. See {@link safeIconUrl}. */
+export function isSafeIconUrl(value: string): boolean {
+  return safeIconUrl(value) !== null;
+}

--- a/lib/validators/oidc-providers.ts
+++ b/lib/validators/oidc-providers.ts
@@ -10,6 +10,7 @@
 
 import "server-only";
 import { z } from "zod";
+import { isSafeIconUrl } from "@/lib/security/icon-url";
 import { slugSchema } from "./common";
 
 const issuerUrlSchema = z
@@ -50,15 +51,9 @@ const iconUrlSchema = z
   .string()
   .min(1)
   .max(MAX_ICON_LENGTH, "Icon is too large. Use an image under 64 KB or host it externally.")
-  .refine(
-    (u) =>
-      u.startsWith("https://") ||
-      u.startsWith("http://") ||
-      /^data:image\/(png|jpeg|jpg|gif|svg\+xml|webp);base64,/.test(u),
-    {
-      message: "Icon URL must use https://, http://, or be an inline data: URI.",
-    },
-  );
+  .refine(isSafeIconUrl, {
+    message: "Icon URL must use https://, http://, or be an inline data: URI.",
+  });
 
 /**
  * Per-provider email-domain override (S-7).

--- a/lib/validators/pdns-servers.ts
+++ b/lib/validators/pdns-servers.ts
@@ -9,6 +9,7 @@
 
 import "server-only";
 import { z } from "zod";
+import { PDNS_WRITE_MODES } from "@/lib/pdns/types";
 import { slugSchema } from "./common";
 
 /**
@@ -73,6 +74,8 @@ const descriptionSchema = z
   .max(500, "Description must be 500 characters or fewer.")
   .transform((s) => s.trim());
 
+const writeModeSchema = z.enum(PDNS_WRITE_MODES);
+
 export const createPdnsServerSchema = z.object({
   slug: slugSchema,
   name: z.string().min(1, "Name is required.").max(120),
@@ -81,6 +84,11 @@ export const createPdnsServerSchema = z.object({
   serverId: z.string().min(1).max(120).default("localhost"),
   apiKey: z.string().min(1, "API key is required.").max(2048, "API key is unexpectedly long."),
   isDefault: z.boolean().default(false),
+  // Operator write-routing override (#111). `auto` trusts the observed
+  // /config capabilities; `read_only` vetoes writes regardless - the escape
+  // hatch for nodes whose database user is read-only, which PowerDNS itself
+  // has no way to advertise.
+  writeMode: writeModeSchema.default("auto"),
   // Optional group (ADR-0014): the multi-primary cluster a peer belongs to, or
   // the group a secondary shares with its primary. null = stands alone. A
   // backend's primary/secondary nature is observed from /config, not declared.
@@ -110,6 +118,8 @@ export const updatePdnsServerSchema = z.object({
   apiKey: z.string().min(1).max(2048).optional(),
   isDefault: z.boolean().optional(),
   disabled: z.boolean().optional(),
+  // See createPdnsServerSchema. Omit to leave unchanged.
+  writeMode: writeModeSchema.optional(),
   // Group membership (ADR-0014). Send null to leave the group, a uuid to join
   // one, omit to leave unchanged.
   clusterId: z.string().uuid().optional().nullable(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerdns-authadmin",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@casl/ability": "7.0.0",
@@ -25,7 +25,7 @@
         "ioredis": "5.10.1",
         "isomorphic-dompurify": "3.13.0",
         "jose": "6.2.3",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "ldapts": "8.1.8",
         "lucide-react": "1.16.0",
         "next": "16.2.6",
@@ -5440,9 +5440,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6021,9 +6021,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7295,9 +7295,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7366,9 +7366,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7450,9 +7450,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8843,9 +8843,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "private": true,
   "description": "Modern, self-hosted DNS administration UI for PowerDNS - multi-team RBAC, real audit, real SSO. From-scratch rebuild of PowerDNS-Admin in Node.js + TypeScript.",
   "license": "MIT",
@@ -62,7 +62,7 @@
     "ioredis": "5.10.1",
     "isomorphic-dompurify": "3.13.0",
     "jose": "6.2.3",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.0",
     "ldapts": "8.1.8",
     "lucide-react": "1.16.0",
     "next": "16.2.6",

--- a/provisioning.example.yaml
+++ b/provisioning.example.yaml
@@ -341,7 +341,12 @@ clusters:
 #                      its secondaries, or the peers of a multi-primary cluster.
 #   • is_default     → only a primary may be the default; set on EXACTLY ONE
 #                      row (the applier doesn't enforce uniqueness; the admin
-#                      UI does).
+#                      UI does). A `write_mode: read_only` row can't be it.
+#   • write_mode     → "auto" (default) trusts the daemon's observed /config;
+#                      "read_only" vetoes ALL writes to this backend. Use it for
+#                      a node fed by database replication whose DB user has no
+#                      write access - PowerDNS reports such a daemon as a plain
+#                      standalone primary, so nothing else can detect it.
 #
 # `api_key` is the PDNS X-API-Key in plaintext; encrypted with
 # APP_ENCRYPTION_KEY before persisting. `base_url` must point at the PDNS

--- a/provisioning.primary-secondary.example.yaml
+++ b/provisioning.primary-secondary.example.yaml
@@ -72,6 +72,13 @@ clusters:
 # reachable on the compose network; the app uses these URLs to talk to PDNS.
 # Every backend joins the `syd` group via `cluster_slug`; authority is per
 # zone (the secondaries hold Slave-kind zones), not per server.
+#
+# Note these secondaries need NO `write_mode` setting: they run with
+# `secondary=yes, primary=no`, so AuthAdmin observes that they're mirrors and
+# never routes a write to them. `write_mode: read_only` is only for the case
+# PowerDNS can't advertise - a node whose DATABASE user is read-only (public
+# nameservers fed by DB replication serving Native zones), which reports itself
+# as an ordinary standalone primary. See docs/04-BACKENDS.md.
 # -----------------------------------------------------------------------------
 pdns_servers:
   - slug: primary


### PR DESCRIPTION
Closes #111, closes #112, closes #113. Reported in #109.

## The bug (#109 / #111)

An operator runs a hidden primary: all zones are `Native`, edits happen on the hidden primary, and the public nameservers get them through **database replication** rather than AXFR. The public nodes run against a read-only database user.

AuthAdmin kept routing writes to them anyway, and the database rejected the changes.

The reason is that there's genuinely nothing to observe. Those public nodes run with `primary=no, secondary=no`, which over `/config` is byte-identical to a standalone primary — so `deriveCapabilities()` classifies them as writable and `choosePeer()` rotates writes onto them. PowerDNS has no setting that advertises "my database user is read-only", and there's no safe probe for it either. It can't be derived; it has to be declared.

They'd reasonably tried the `Use as the default backend (only a write-capable backend can be the default)` checkbox. That's a different control — it only picks which backend serves a request that doesn't name one, and has never constrained peer selection within a group. Both docs and the UI now say so explicitly.

## The fix

New `pdns_servers.write_mode` column (`auto` | `read_only`), surfaced as **Never write to this backend (read-only)** on the backend edit page and `write_mode: read_only` in provisioning YAML. Every write decision now goes through `isServerWriteTarget()`.

This is a real exception to ADR-0014's "observe, don't declare", so it's scoped tightly enough that it can't grow back into the per-server `role` that ADR retired:

- **It can only subtract.** `read_only` vetoes a daemon the capabilities called writable; `auto` never promotes an observed mirror into a write target. Authority still flows one way.
- **It governs write routing and the operator-facing pickers only.** `zone-poller.ts` and `sync.ts` deliberately keep reading raw capabilities, because `masters[]` resolution is a fact about the DNS protocol that an operator's routing preference must not rewrite — marking a genuine AXFR primary read-only should stop writes to it, not orphan the secondaries pulling from it. There's a comment on the predicate saying this, so nobody "fixes" it later.
- **It defaults to `auto`**, so no existing backend changes behaviour.

Two consequences worth calling out:

- `classifyGroup()` counts `read_only` members as mirrors. A hidden primary plus three read-only public nodes now reports **Primary + secondaries** instead of claiming to be a multi-primary cluster whose peer-selection strategy has nothing to choose from.
- Ungrouped read-only backends surface via `listUngroupedSecondaries()`, so their zones stay visible even though they're absent from every write-target list.

Documented in [FEATURES § 3.3](docs/FEATURES.md), a new [Backends → Hidden primary](docs/04-BACKENDS.md) topology section, the upgrade notes, and a 2026-07-22 amendment to [ADR-0014](docs/adr/0014-backend-capability-model.md).

## Security (#112, #113)

| Finding | Severity | Real exposure |
|---|---|---|
| `js-yaml` 4.2.0 → 4.3.0 ([GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m)) | high | Low but real. Direct runtime dep, used by the provisioning applier at boot. The YAML is operator-supplied, so not attacker-controlled. |
| `dompurify` via `isomorphic-dompurify` ([GHSA-c2j3-45gr-mqc4](https://github.com/advisories/GHSA-c2j3-45gr-mqc4)) | low | Negligible. The SVG sanitizer is explicitly defense-in-depth behind `<img src>`, which already renders SVG in secure static mode. |
| `brace-expansion` ([GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)) | high | None. devDependency only, via the eslint plugins' `minimatch`. Never ships. |
| CodeQL `js/xss-through-dom`, `oidc-provider-form.tsx` | high (CodeQL) | Minimal. It's the live preview of the admin's own typing; `javascript:` doesn't execute in `<img src>` and persisted values were already restricted to `https://` / `data:image`. But it was the one path skipping the allowlist. |

The OIDC fix extracts `isSafeIconUrl()` into `lib/security/icon-url.ts` and has both the Zod validator and the form preview call it, so the client can't drift more permissive than the server. Deliberately not `server-only` — that's the whole point.

`npm audit` now reports zero vulnerabilities.

## Heads-up: `db:generate` footgun

`lib/db/schema/index.ts` picks its dialect from `DATABASE_URL`. Running `npm run db:generate` with a SQLite URL in the environment makes drizzle-kit read **0 tables** and emit a migration that `DROP TABLE`s the entire schema. I hit this and threw the file away; the committed PG migration was regenerated with a Postgres URL. Probably worth a guard in the script as a follow-up.

## Verification

- `npm run validate` green — lint, typecheck, format, 977 unit tests.
- New tests in `lib/pdns/capabilities.test.ts` pin the override matrix: the `read_only` veto, that it survives the "unprobed defaults to writable" rule, that `auto` never promotes a mirror, and the `classifyGroup` relabel.
- Both migrations **applied against real engines**, not just generated: Postgres 17 in Docker and a fresh SQLite file. Column lands as `text NOT NULL DEFAULT 'auto'` on both, with existing rows backfilled.

Cuts **v1.5.0** — minor, since the schema addition is additive and backward-compatible.