### PR TITLE
feat(zones): add PowerDNS Lua record support

### DIFF
--- a/app/(app)/zones/[zoneId]/_components/editable-record-table.tsx
+++ b/app/(app)/zones/[zoneId]/_components/editable-record-table.tsx
@@ -73,6 +73,8 @@ interface EditableRecordTableProps {
   canCreate: boolean;
   canUpdate: boolean;
   canDelete: boolean;
+  /** Live ENABLE-LUA-RECORDS=1 state for this zone. */
+  luaRecordsEnabled: boolean;
 }
 
 interface EditorState {
@@ -364,6 +366,12 @@ export function EditableRecordTable(props: EditableRecordTableProps) {
       setEditorError("Edit SOA through the SOA panel above the records table.");
       return;
     }
+    if (editor.type === "LUA" && !props.luaRecordsEnabled) {
+      setEditorError(
+        "LUA records require ENABLE-LUA-RECORDS to be set to 1 in this zone's metadata.",
+      );
+      return;
+    }
 
     const validation = getRRTypeValidator(editor.type).validate(editor.value);
     if (hasErrors(validation) && !overrideErrors) {
@@ -611,7 +619,9 @@ export function EditableRecordTable(props: EditableRecordTableProps) {
                     });
                   }}
                   options={(() => {
-                    const allowed = typesForZone(props.zoneName);
+                    const allowed = typesForZone(props.zoneName).filter(
+                      (type) => type !== "LUA" || props.luaRecordsEnabled,
+                    );
                     const opts =
                       editor.mode === "edit" && !allowed.includes(editor.type)
                         ? [editor.type, ...allowed]
@@ -621,6 +631,12 @@ export function EditableRecordTable(props: EditableRecordTableProps) {
                   ariaLabel="Type"
                   className="mt-1 w-full"
                 />
+                {!props.luaRecordsEnabled ? (
+                  <p className="mt-1 text-[0.6875rem] text-[color:var(--color-fg-muted)]">
+                    To add LUA records through AuthAdmin, set <code>ENABLE-LUA-RECORDS</code> to{" "}
+                    <code>1</code> for this zone on the PowerDNS host.
+                  </p>
+                ) : null}
               </Field>
             </div>
 

--- a/app/(app)/zones/[zoneId]/metadata/_components/kind-specs.ts
+++ b/app/(app)/zones/[zoneId]/metadata/_components/kind-specs.ts
@@ -80,6 +80,12 @@ export const KIND_SPECS: Record<string, KindShape> = {
     type: "string",
     description: "Local IP used as the source for outgoing AXFR.",
   },
+  "ENABLE-LUA-RECORDS": {
+    type: "bool",
+    description:
+      "Allow trusted PowerDNS Lua records in this zone. Lua records execute code inside the authoritative server.",
+    apiWritable: false,
+  },
   "FORWARD-DNSUPDATE": {
     type: "bool",
     description: "Forward dynamic updates to the configured primary.",

--- a/app/(app)/zones/[zoneId]/page.tsx
+++ b/app/(app)/zones/[zoneId]/page.tsx
@@ -294,6 +294,29 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
   const canReadDnssec = zoneCan("dnssec.read");
   const canReadMetadata = zoneCan("metadata.read");
 
+  // LUA records are executable server-side code. AuthAdmin cannot discover
+  // whether the daemon-wide enable-lua-records setting is active, so editing
+  // requires the explicit per-zone metadata opt-in. Read it even for users
+  // without metadata.read: only the resulting capability bit reaches the
+  // record editor, not the metadata bag itself. A read failure fails closed.
+  let luaRecordsEnabled = false;
+  try {
+    const zoneMetadata = await client.listZoneMetadata(canonical);
+    luaRecordsEnabled = zoneMetadata.some(
+      (item) =>
+        item.kind === "ENABLE-LUA-RECORDS" && item.metadata.some((value) => value.trim() === "1"),
+    );
+  } catch (err) {
+    logger.warn(
+      {
+        server: selected.slug,
+        zone: canonical,
+        error: err instanceof Error ? redact(err.message) : "Unknown error",
+      },
+      "zone.lua-metadata.read.failed",
+    );
+  }
+
   // Direct ?tab=sync / ?tab=statistics on a polling-off install bounces
   // back to the default records view with an error flash toast - these
   // surfaces are powered by the background poller, which is opt-in
@@ -445,6 +468,7 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
               canCreate={canCreate}
               canUpdate={canUpdate}
               canDelete={canDelete}
+              luaRecordsEnabled={luaRecordsEnabled}
             />
           ) : (
             <RecordTable

--- a/app/api/admin/pdns/zones/[zoneId]/rrsets/route.ts
+++ b/app/api/admin/pdns/zones/[zoneId]/rrsets/route.ts
@@ -145,6 +145,34 @@ export async function PATCH(request: Request, context: RouteContext): Promise<Re
     // role (a primary box can still host mirror zones).
     assertEditableZoneKind(zoneBefore.kind);
 
+    // LUA records execute code inside the authoritative server. AuthAdmin
+    // cannot discover whether the daemon-wide enable-lua-records setting is
+    // active, so require the explicit per-zone metadata opt-in. Re-read it
+    // immediately so a crafted request or stale tab cannot bypass the guard.
+    const upsertsLua = input.changes.some(
+      (change) => change.kind === "upsert" && change.type === "LUA",
+    );
+    if (upsertsLua) {
+      let metadata;
+      try {
+        metadata = await client.listZoneMetadata(zoneName);
+      } catch (err) {
+        if (err instanceof PdnsError) {
+          throw new ValidationError(`Could not verify ENABLE-LUA-RECORDS: ${redact(err.message)}`);
+        }
+        throw err;
+      }
+      const enabled = metadata.some(
+        (item) =>
+          item.kind === "ENABLE-LUA-RECORDS" && item.metadata.some((value) => value.trim() === "1"),
+      );
+      if (!enabled) {
+        throw new ValidationError(
+          "LUA records require ENABLE-LUA-RECORDS to be set to 1 in this zone's metadata.",
+        );
+      }
+    }
+
     // NOTE: zone-level edited_serial concurrency check was removed - it had
     // the wrong granularity (every successful edit advances the zone's serial
     // so consecutive edits in the same session falsely 409'd against the

--- a/lib/validators/rr-types/index.ts
+++ b/lib/validators/rr-types/index.ts
@@ -19,6 +19,7 @@ import { cnameValidator } from "./cname";
 import { dnameValidator } from "./dname";
 import { dsValidator } from "./ds";
 import { makeGenericValidator } from "./generic";
+import { luaValidator } from "./lua";
 import { mxValidator } from "./mx";
 import { naptrValidator } from "./naptr";
 import { nsValidator } from "./ns";
@@ -54,6 +55,7 @@ const REGISTRY = new Map<string, RRTypeValidator>(
     openpgpkeyValidator,
     svcbValidator,
     httpsValidator,
+    luaValidator,
   ].map((v) => [v.type, v]),
 );
 
@@ -82,17 +84,19 @@ export const SUPPORTED_TYPES: readonly string[] = [
   "OPENPGPKEY",
   "SVCB",
   "HTTPS",
+  "LUA",
 ];
 
 /**
  * Record types that belong in a reverse zone. PTR is the primary
  * purpose; NS / DNAME / CNAME cover RFC 2317-style classless reverse
  * delegations; TXT is occasionally used for ownership / contact notes.
+ * LUA is included because PowerDNS supports scripted reverse answers.
  * Everything else (A, MX, SRV, …) is semantically nonsensical in an
  * `in-addr.arpa` / `ip6.arpa` zone and would only ever land there by
  * accident.
  */
-export const REVERSE_ZONE_TYPES: readonly string[] = ["PTR", "NS", "DNAME", "CNAME", "TXT"];
+export const REVERSE_ZONE_TYPES: readonly string[] = ["PTR", "NS", "DNAME", "CNAME", "TXT", "LUA"];
 
 /**
  * Forward zones get the full menu minus PTR - PTR in a forward zone

--- a/lib/validators/rr-types/lua.ts
+++ b/lib/validators/rr-types/lua.ts
@@ -1,0 +1,178 @@
+/**
+ * PowerDNS LUA content (PowerDNS-specific, not an IETF RR type):
+ *   `<query-type> "<Lua snippet>" ["<continued snippet>" ...]`
+ *
+ * PowerDNS evaluates an ordinary snippet as an expression (as though it were
+ * the argument to `return`). Full statements start with `;`; a `LUA` selector
+ * is also allowed for configuration records. We deliberately do not attempt
+ * to parse Lua here. Doing that incompletely would reject valid PowerDNS Lua,
+ * while successful parsing would still say nothing about runtime behaviour.
+ */
+
+import type { RRTypeValidator, RRValidationIssue } from "./types";
+
+interface QuotedSnippet {
+  chunks: string[];
+  error?: string;
+}
+
+export const luaValidator: RRTypeValidator = {
+  type: "LUA",
+  label: "PowerDNS Lua record",
+  description:
+    "PowerDNS query type followed by a quoted Lua expression, e.g. `A \"ifportup(443, {'192.0.2.1', '192.0.2.2'})\"`. Only use trusted code.",
+  placeholder: "A \"ifportup(443, {'192.0.2.1', '192.0.2.2'})\"",
+  rfc: "PowerDNS Lua Records (PowerDNS-specific)",
+  validate(content: string) {
+    const issues: RRValidationIssue[] = [];
+    const trimmed = content.trim();
+
+    if (trimmed === "") {
+      return {
+        issues: [{ level: "error", message: "LUA content is empty." }],
+        normalized: trimmed,
+      };
+    }
+
+    if (/\r|\n/.test(trimmed)) {
+      return {
+        issues: [
+          {
+            level: "error",
+            message:
+              "LUA content cannot contain literal newlines. Keep it on one line or encode the newline inside the quoted snippet.",
+          },
+        ],
+        normalized: trimmed,
+      };
+    }
+
+    const match = /^(\S+)\s+(.+)$/.exec(trimmed);
+    if (!match) {
+      return {
+        issues: [
+          {
+            level: "error",
+            message:
+              'LUA content needs a query type and quoted snippet: `<query-type> "<Lua expression>"`.',
+          },
+        ],
+        normalized: trimmed,
+      };
+    }
+
+    const [, rawQueryType, rawSnippet] = match as unknown as [string, string, string];
+    const queryType = rawQueryType.toUpperCase();
+
+    // The exact set of assigned mnemonics evolves, so validate the shape
+    // rather than maintaining a stale allow-list.
+    const numericType = /^TYPE(\d+)$/.exec(queryType);
+    if (!/^[A-Z][A-Z0-9-]*$/.test(queryType) || (queryType.startsWith("TYPE") && !numericType)) {
+      issues.push({
+        level: "error",
+        message: `Query type "${rawQueryType}" is not a valid DNS type mnemonic.`,
+      });
+    } else if (numericType) {
+      const typeCode = Number(numericType[1]);
+      if (typeCode > 65535) {
+        issues.push({
+          level: "error",
+          message: "Numeric query type must be TYPE0–TYPE65535.",
+        });
+      }
+    }
+
+    const parsed = parseQuotedSnippet(rawSnippet);
+    if (parsed.error) {
+      issues.push({ level: "error", message: parsed.error });
+    } else {
+      if (parsed.chunks.join("").length === 0) {
+        issues.push({
+          level: "error",
+          message: "The quoted Lua snippet cannot be empty.",
+        });
+      }
+
+      for (const chunk of parsed.chunks) {
+        const octets = new TextEncoder().encode(chunk).length;
+        if (octets > 255) {
+          issues.push({
+            level: "warning",
+            message: `One quoted snippet segment is ${octets} octets. Split long LUA content into adjacent quoted segments of at most 255 octets so AXFR does not split the code in an unsafe place.`,
+          });
+          break;
+        }
+      }
+    }
+
+    if (trimmed.length > 65535) {
+      issues.push({
+        level: "error",
+        message: `Content is ${trimmed.length} characters; the DNS message-size ceiling is 65535.`,
+      });
+    }
+
+    return { issues, normalized: `${queryType} ${rawSnippet}` };
+  },
+};
+
+/** Parse one or more adjacent DNS presentation-format quoted strings. */
+function parseQuotedSnippet(input: string): QuotedSnippet {
+  const chunks: string[] = [];
+  let i = 0;
+
+  while (i < input.length) {
+    while (i < input.length && /\s/.test(input[i]!)) i++;
+    if (i >= input.length) break;
+    if (input[i] !== '"') {
+      return {
+        chunks,
+        error:
+          'The Lua snippet must be one or more double-quoted strings; escape embedded `"` characters as `\\"`.',
+      };
+    }
+    i++;
+
+    let chunk = "";
+    let closed = false;
+    while (i < input.length) {
+      const char = input[i]!;
+      if (char === '"') {
+        i++;
+        closed = true;
+        break;
+      }
+      if (char === "\\") {
+        if (i + 1 >= input.length) {
+          return { chunks, error: "The quoted Lua snippet ends with an incomplete escape." };
+        }
+
+        // RFC 1035 presentation syntax permits \DDD decimal octet escapes.
+        const decimal = input.slice(i + 1, i + 4);
+        if (/^\d{3}$/.test(decimal)) {
+          const value = Number(decimal);
+          if (value > 255) {
+            return { chunks, error: `Decimal escape \\${decimal} is outside 0–255.` };
+          }
+          // A decimal escape represents exactly one wire octet.
+          // An ASCII placeholder preserves that length for the check above.
+          chunk += "x";
+          i += 4;
+        } else {
+          chunk += input[i + 1]!;
+          i += 2;
+        }
+        continue;
+      }
+      chunk += char;
+      i++;
+    }
+
+    if (!closed) {
+      return { chunks, error: "The Lua snippet has an unterminated double-quoted string." };
+    }
+    chunks.push(chunk);
+  }
+
+  return { chunks };
+}

--- a/lib/validators/rr-types/validators.test.ts
+++ b/lib/validators/rr-types/validators.test.ts
@@ -15,6 +15,7 @@ import { caaValidator } from "./caa";
 import { cnameValidator } from "./cname";
 import { dnameValidator } from "./dname";
 import { dsValidator } from "./ds";
+import { luaValidator } from "./lua";
 import { mxValidator } from "./mx";
 import { naptrValidator } from "./naptr";
 import { nsValidator } from "./ns";
@@ -878,6 +879,51 @@ describe("NAPTR validator", () => {
     // regexp rewrite step with no terminal classification.
     const r = naptrValidator.validate('100 10 "" "E2U+sip" "!^.*$!sip:x@y.example!" .');
     expect(r.issues.filter((i) => i.level === "error")).toEqual([]);
+  });
+});
+
+describe("LUA validator", () => {
+  it("accepts a typical PowerDNS ifportup expression", () => {
+    const r = luaValidator.validate(`A "ifportup(443, {'192.0.2.1', '192.0.2.2'})"`);
+    expect(hasErrors(r)).toBe(false);
+  });
+
+  it("accepts full scripts and LUA configuration selectors", () => {
+    expect(hasErrors(luaValidator.validate(`TXT ";return 'hello'"`))).toBe(false);
+    expect(hasErrors(luaValidator.validate(`LUA "settings={selector='pickclosest'}"`))).toBe(false);
+  });
+
+  it("normalizes the query type to uppercase", () => {
+    const r = luaValidator.validate(`a "'192.0.2.1'"`);
+    expect(hasErrors(r)).toBe(false);
+    expect(r.normalized).toBe(`A "'192.0.2.1'"`);
+  });
+
+  it("accepts adjacent quoted segments for AXFR-safe long snippets", () => {
+    const r = luaValidator.validate(`A "ifportup(443, " "{'192.0.2.1'})"`);
+    expect(hasErrors(r)).toBe(false);
+  });
+
+  it("rejects missing, unquoted, empty, and unterminated snippets", () => {
+    expect(hasErrors(luaValidator.validate("A"))).toBe(true);
+    expect(hasErrors(luaValidator.validate("A ifportup(443, {'192.0.2.1'})"))).toBe(true);
+    expect(hasErrors(luaValidator.validate('A ""'))).toBe(true);
+    expect(hasErrors(luaValidator.validate('A "ifportup(443)'))).toBe(true);
+  });
+
+  it("rejects malformed query types and literal newlines", () => {
+    expect(hasErrors(luaValidator.validate(`A! "'192.0.2.1'"`))).toBe(true);
+    expect(hasErrors(luaValidator.validate(`TYPE99999 "'192.0.2.1'"`))).toBe(true);
+    expect(hasErrors(luaValidator.validate(`TYPEABC "'192.0.2.1'"`))).toBe(true);
+    expect(hasErrors(luaValidator.validate('A "line one\nline two"'))).toBe(true);
+  });
+
+  it("warns when one quoted segment exceeds the AXFR 255-octet boundary", () => {
+    const long = luaValidator.validate(`TXT "${"a".repeat(256)}"`);
+    expect(long.issues.some((i) => i.level === "warning" && i.message.includes("255"))).toBe(true);
+
+    const split = luaValidator.validate(`TXT "${"a".repeat(200)}" "${"b".repeat(200)}"`);
+    expect(split.issues.some((i) => i.message.includes("255"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Expose LUA records in forward and reverse zone editors with type-aware validation for PowerDNS presentation syntax.

Require the per-zone ENABLE-LUA-RECORDS opt-in for writes and keep that metadata setting read-only because its API writability depends on the PowerDNS daemon configuration.

<!--
A good PR description is the difference between a 10-minute review and a 60-minute one.
Fill out each section honestly. If a section doesn't apply, write "n/a" - don't leave it blank.
-->

## What and why
Adds support for creating and editing PowerDNS `LUA` records in forward and reverse zones. Lua editing is available only when the zone explicitly has `ENABLE-LUA-RECORDS=1`.        

Closes #

## How
- Add `LUA` to the supported record types for forward and reverse zones.
- Add type-aware validation for the PowerDNS presentation format: query type followed by one or more quoted Lua chunks.
- Require `ENABLE-LUA-RECORDS=1` before allowing a Lua record to be created or replaced.                                            


## Tests

- Add validator coverage for expressions, statement-style scripts, selectors, query-type normalization, adjacent quoted chunks,
  malformed input, newlines, and oversized chunks.
- Verify every supported record type resolves to an appropriate validator.


## Threat-modeling

Lua records execute operator-provided code inside PowerDNS and may invoke network-aware or resource-intensive functions. Existing record-write RBAC remains required, and AuthAdmin additionally requires the explicit per-zone `ENABLE-LUA-RECORDS=1` opt-in. The RRset API re-reads live zone metadata for every Lua upsert, so a crafted request or stale browser cannot bypass the UI restriction; failure to verify metadata denies the write. AuthAdmin validates the record envelope but deliberately does not claim that Lua code is safe, so Lua records remain restricted to trusted operators. The enablement metadata itself is read-only in AuthAdmin.

## Documentation
- Add file-level documentation for the Lua validator and inline documentation for the security gate.
- Add user-facing guidance explaining that enablement must be configured on the PowerDNS host.


## Checklist

- [x] PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, …)
- [ ] Linked issue exists and is approved (no "I had a free afternoon" PRs)
- [x] `npm run validate` passes locally (lint + typecheck + format + test)
- [x] New code is documented (file-level + JSDoc on exports)
- [x] No secrets in code, config, logs, or fixture data
- [ ] If user-visible: strings go through i18n (or PR opens an i18n follow-up)
