### PR TITLE
fix(pdns): surface enable-lua-records as an observed capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed - `enable-lua-records` now shows up in backend capabilities
+
+A daemon with Lua records armed said so nowhere in the UI: the record editor
+offered the `LUA` type (correctly), but no capability badge, no daemon-settings
+row, and nothing in the stored capability snapshot reflected it - the only way
+to find out was to open a zone and look for the type in a dropdown. The observed
+capability set now carries `enable-lua-records` (`no` / `yes` / `shared`), it
+renders as a `lua records` badge wherever backends are listed, and the setting
+appears verbatim in the backend's **Daemon settings** table.
+
+The zone page now reads the cached capability instead of issuing a live
+`/config` call on every render for editors, so enabling Lua in `pdns.conf` needs
+a backend refresh (**Admin → PowerDNS servers → Refresh**) to show up - the same
+contract as every other capability. Per-zone `ENABLE-LUA-RECORDS` metadata still
+overrides a daemon-level `no`.
+
+See [FEATURES § 3.10](./docs/FEATURES.md#310-observed-daemon-capabilities) ·
+[ADR-0014](./docs/adr/0014-backend-capability-model.md) · (#122)
+
+### Security
+
+- `undici` 8.5.0 → 8.10.0 (and the transitive 7.28.0 → 7.29.0), clearing the
+  open advisories for degenerate private cache directives, retry-interceptor
+  response desynchronization, cookie attribute injection, Cache-Control
+  whitespace disclosure, and blob-type CRLF injection.
+
 ## [1.5.3] - 2026-07-26
 
 Feature + dependency-security release. No migration, no schema change.

--- a/app/(app)/zones/[zoneId]/page.tsx
+++ b/app/(app)/zones/[zoneId]/page.tsx
@@ -303,17 +303,30 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
   // LUA type when PowerDNS actually has Lua enabled for this zone - the global
   // enable-lua-records setting or the per-zone ENABLE-LUA-RECORDS metadata.
   // Only editors need the bit, so read-only viewers skip the extra PDNS reads;
-  // the metadata read short-circuits the config read; only the derived boolean
+  // the metadata read short-circuits the global check; only the derived boolean
   // (never the metadata bag) reaches the client; a read failure fails closed.
+  //
+  // The global half comes from the backend's observed capability snapshot
+  // (#122), not a live `/config` per render - the daemon-meta probe already
+  // reads it every poll, and the operator refreshing a backend is the same
+  // gesture that refreshes every other capability. Only a snapshot predating
+  // that field (or a never-probed backend) falls back to the live read.
   let luaRecordsEnabled = false;
   if (canEdit) {
     try {
       const zoneMetadata = await client.listZoneMetadata(canonical);
       luaRecordsEnabled = isLuaEnabledByZoneMetadata(zoneMetadata);
       if (!luaRecordsEnabled) {
-        const config = await client.getConfig();
-        const globalSetting = config.find((row) => row.name === ENABLE_LUA_RECORDS_SETTING)?.value;
-        luaRecordsEnabled = isLuaEnabledGlobally(globalSetting);
+        const observed = selected.capabilities?.luaRecords;
+        if (observed !== undefined) {
+          luaRecordsEnabled = observed !== "no";
+        } else {
+          const config = await client.getConfig();
+          const globalSetting = config.find(
+            (row) => row.name === ENABLE_LUA_RECORDS_SETTING,
+          )?.value;
+          luaRecordsEnabled = isLuaEnabledGlobally(globalSetting);
+        }
       }
     } catch (err) {
       logger.warn(

--- a/components/domain/capability-badges.tsx
+++ b/components/domain/capability-badges.tsx
@@ -9,6 +9,15 @@
  *   • standalone    → neutral - no replication flag set (default PDNS Auth
  *                     config; API still accepts zone creates - fully usable).
  *
+ * Plus one observed capability that isn't a replication role:
+ *   • lua records   → orange - `enable-lua-records` is `yes` or `shared` (#122).
+ *                     Shares autosecondary's tone because both mark a daemon
+ *                     doing something beyond plain authoritative serving; the
+ *                     label carries the distinction. Rendered last so the
+ *                     replication roles keep their leading position, and never
+ *                     suppressed by `standalone` - a standalone daemon with Lua
+ *                     armed is exactly the case the operator must see.
+ *
  * Plus one badge that is NOT observed but operator-declared:
  *   • read-only     → warn (yellow) - `write_mode='read_only'` (#111). Shown
  *                     first, because it overrides whatever the daemon reports:
@@ -27,6 +36,9 @@ interface Capabilities {
   primary: boolean;
   secondary: boolean;
   autosecondary: boolean;
+  /** `enable-lua-records` mode. Absent on snapshots taken before #122 - that's
+   *  "not observed", so no badge either way, rather than a claim of "off". */
+  luaRecords?: "no" | "yes" | "shared";
 }
 
 // Same recipe as the CLUSTER badge in the zones list and the DEFAULT badge in
@@ -43,7 +55,15 @@ const TONE = {
   primary: `${BASE} bg-[color:var(--color-accent)]/15 text-[color:var(--color-accent)]`,
   secondary: `${BASE} bg-[color:var(--color-warn)]/15 text-[color:var(--color-warn-fg)]`,
   autosecondary: `${BASE} bg-[color:var(--color-orange)]/15 text-[color:var(--color-orange-fg)]`,
+  lua: `${BASE} bg-[color:var(--color-orange)]/15 text-[color:var(--color-orange-fg)]`,
 } as const;
+
+interface Badge {
+  key: string;
+  className: string;
+  label: string;
+  title?: string;
+}
 
 export function CapabilityBadges({
   capabilities,
@@ -53,42 +73,50 @@ export function CapabilityBadges({
   /** Operator write-routing override (#111). "read_only" adds a leading badge. */
   writeMode?: "auto" | "read_only";
 }) {
-  const readOnly =
-    writeMode === "read_only" ? (
-      <span className={TONE.secondary} title="Operator override: writes are never routed here">
-        read-only
-      </span>
-    ) : null;
+  const badges: Badge[] = [];
+
+  // First, because it overrides whatever the daemon reports.
+  if (writeMode === "read_only") {
+    badges.push({
+      key: "read-only",
+      className: TONE.secondary,
+      label: "read-only",
+      title: "Operator override: writes are never routed here",
+    });
+  }
 
   if (!capabilities) {
-    return (
-      <span className="whitespace-nowrap">
-        {readOnly}
-        <span className={readOnly ? `${NEUTRAL} ml-1` : NEUTRAL}>unprobed</span>
-      </span>
+    badges.push({ key: "unprobed", className: NEUTRAL, label: "unprobed" });
+  } else {
+    const roles = (["primary", "secondary", "autosecondary"] as const).filter(
+      (role) => capabilities[role],
     );
+    if (roles.length === 0) {
+      badges.push({ key: "standalone", className: NEUTRAL, label: "standalone" });
+    } else {
+      for (const role of roles) badges.push({ key: role, className: TONE[role], label: role });
+    }
+    // Not a replication role, so it rides alongside `standalone` rather than
+    // being displaced by it.
+    const lua = capabilities.luaRecords;
+    if (lua === "yes" || lua === "shared") {
+      badges.push({
+        key: "lua",
+        className: TONE.lua,
+        label: lua === "shared" ? "lua records (shared)" : "lua records",
+        title: `enable-lua-records=${lua} - this daemon arms LUA records (executable server-side code) for every zone it serves`,
+      });
+    }
   }
-  const flags: Array<keyof typeof TONE> = [];
-  if (capabilities.primary) flags.push("primary");
-  if (capabilities.secondary) flags.push("secondary");
-  if (capabilities.autosecondary) flags.push("autosecondary");
-  if (flags.length === 0) {
-    return (
-      <span className="whitespace-nowrap">
-        {readOnly}
-        <span className={readOnly ? `${NEUTRAL} ml-1` : NEUTRAL}>standalone</span>
-      </span>
-    );
-  }
+
   // Plain inline <span> wrapper (no flex) so each badge renders exactly like
   // the CLUSTER badge in the zones list - inherited line-height and no
   // cross-axis stretching from a flex container.
   return (
     <span className="whitespace-nowrap">
-      {readOnly}
-      {flags.map((f, i) => (
-        <span key={f} className={i > 0 || readOnly ? `${TONE[f]} ml-1` : TONE[f]}>
-          {f}
+      {badges.map((b, i) => (
+        <span key={b.key} className={i > 0 ? `${b.className} ml-1` : b.className} title={b.title}>
+          {b.label}
         </span>
       ))}
     </span>

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -312,6 +312,25 @@ can jump straight into the code that owns each feature.
 - **Where.** `lib/pdns/url-safety.ts` (the guard); `lib/pdns/http.ts` (request-time
   re-check + pinned dispatcher).
 
+### 3.10 Observed daemon capabilities
+
+- **What.** Each backend carries a capability snapshot derived from its read-only `/config` on
+  every daemon-meta probe: `api`, `primary`, `secondary`, `autosecondary`, the `launch` backends,
+  DNSSEC, the configured autoprimary count, and `enable-lua-records`. The active ones render as
+  tinted badges wherever a backend is listed; the allowlisted raw settings show verbatim under
+  **Daemon settings** on the backend's detail page.
+- **Lua records.** `enable-lua-records` (`no` | `yes` | `shared`) is in the snapshot because it
+  decides whether the record editor offers the `LUA` type at all. LUA records are executable
+  server-side code, so which daemons have it armed has to be visible from the backend list, not
+  discoverable only by opening a zone and looking for the type in a dropdown. A daemon-level `no`
+  is not a veto: per-zone `ENABLE-LUA-RECORDS` metadata still enables Lua for that one zone.
+- **Freshness.** Badges reflect the last probe. After editing `pdns.conf`, re-probe the backend
+  (**Admin → PowerDNS servers → Refresh**) - the same gesture that refreshes every other
+  capability.
+- **Where.** `lib/pdns/capabilities.ts`, `lib/pdns/config-advice.ts`,
+  `components/domain/capability-badges.tsx`, `lib/realtime/backend-health.ts`.
+  See [ADR-0014](./adr/0014-backend-capability-model.md).
+
 ---
 
 ## 4. Zones

--- a/docs/adr/0014-backend-capability-model.md
+++ b/docs/adr/0014-backend-capability-model.md
@@ -57,6 +57,16 @@ behaviour had to be moved off `role` onto zone `kind` (done); the `/config` advi
    > This is a deliberate, bounded exception. The test for adding another one: PowerDNS must be
    > _incapable_ of reporting the fact, not merely inconvenient to ask.
 
+   > **Amendment (2026-08-08, #122):** the snapshot also carries `enable-lua-records`
+   > (`luaRecords: "no" | "yes" | "shared"`). It is an observed `/config` flag like the rest, and it
+   > belongs here for the same reason DNSSEC does: it changes what the app will let an operator
+   > create. LUA records are executable server-side code, so "is Lua armed on this daemon?" is a
+   > capability question, and computing it live on every zone render (which is what the record
+   > editor did before) both hid it from every capability surface and put two PDNS calls on the zone
+   > page's critical path. The field is **optional** - absent means "snapshot predates this field",
+   > which readers must treat as _not observed_ (fall back to a live read) rather than as `no`.
+   > Zone-level `ENABLE-LUA-RECORDS` metadata still ORs on top; a daemon-level `no` is not a veto.
+
 3. **Gate editability on zone `kind`** via one ops resolver:
    `zoneCapabilities(kind) → { rrsets, metadata, masters, dnssec, axfrRetrieve, delete }`.
    Generalizes the existing `isReadOnlyZoneKind` and encodes the _real_ writable options on a

--- a/lib/pdns/capabilities.test.ts
+++ b/lib/pdns/capabilities.test.ts
@@ -57,6 +57,21 @@ describe("deriveCapabilities", () => {
     expect(deriveCapabilities(cfg({ primary: "yes" })).api).toBe(true);
     expect(deriveCapabilities(cfg({ api: "no" })).api).toBe(false);
   });
+
+  // #122 - `enable-lua-records` arms executable server-side code, so the
+  // snapshot has to carry it: the record editor gates the LUA type on this and
+  // the capability badges have to say so.
+  it.each<[string, Record<string, string>, "no" | "yes" | "shared"]>([
+    ["absent → the documented default", {}, "no"],
+    ["explicit no", { "enable-lua-records": "no" }, "no"],
+    ["yes", { "enable-lua-records": "yes" }, "yes"],
+    ["empty is documented as equivalent to yes", { "enable-lua-records": "" }, "yes"],
+    ["shared keeps its own mode", { "enable-lua-records": "shared" }, "shared"],
+    ["legacy `shard` spelling", { "enable-lua-records": "shard" }, "shared"],
+    ["case + whitespace insensitive", { "enable-lua-records": "  YES " }, "yes"],
+  ])("derives enable-lua-records: %s", (_label, flags, expected) => {
+    expect(deriveCapabilities(cfg(flags)).luaRecords).toBe(expected);
+  });
 });
 
 describe("summarizeCapabilities", () => {

--- a/lib/pdns/capabilities.ts
+++ b/lib/pdns/capabilities.ts
@@ -7,9 +7,30 @@
  * which is why this replaces the operator-declared `role`.
  */
 
-import type { PdnsConfigSetting, PdnsDaemonCapabilities, PdnsWriteMode } from "./types";
+import { ENABLE_LUA_RECORDS_SETTING, isLuaEnabledGlobally } from "./metadata-policy";
+import type {
+  PdnsConfigSetting,
+  PdnsDaemonCapabilities,
+  PdnsLuaRecordsMode,
+  PdnsWriteMode,
+} from "./types";
 
 const isYes = (v: string | undefined): boolean => v?.toLowerCase() === "yes";
+
+/**
+ * Normalize `enable-lua-records` into the three modes PowerDNS documents.
+ * Truthiness is delegated to `isLuaEnabledGlobally` so the record editor and
+ * this snapshot can never disagree about what "armed" means; only the
+ * `shared`-vs-`yes` distinction is resolved here, because the badge shows the
+ * mode verbatim. A setting the daemon doesn't echo at all reads as the
+ * documented default, `no`.
+ */
+function luaRecordsMode(value: string | undefined): PdnsLuaRecordsMode {
+  if (value === undefined) return "no";
+  const v = value.trim().toLowerCase();
+  if (v === "shared" || v === "shard") return "shared";
+  return isLuaEnabledGlobally(value) ? "yes" : "no";
+}
 
 /** Parse `launch` (comma/space separated, entries may be `backend:instance`). */
 function parseLaunch(value: string | undefined): string[] {
@@ -44,6 +65,7 @@ export function deriveCapabilities(
     // We only ever call this on a successful /config read, so the API is on
     // even if the daemon doesn't echo the `api` flag back.
     api: map.has("api") ? isYes(map.get("api")) : true,
+    luaRecords: luaRecordsMode(map.get(ENABLE_LUA_RECORDS_SETTING)),
     primary: isYes(map.get("primary")) || isYes(map.get("master")),
     secondary: isYes(map.get("secondary")) || isYes(map.get("slave")),
     autosecondary: isYes(map.get("autosecondary")) || isYes(map.get("superslave")),
@@ -172,6 +194,10 @@ export function classifyGroup(members: readonly WriteRoutable[]): GroupCompositi
  * set it falls back to "standalone" (the daemon hosts zones over the API but does
  * no DNS-protocol replication - the default PDNS Auth shape); "unknown" when the
  * daemon has never been observed, "unreachable" when the API itself is down.
+ *
+ * Replication roles ONLY. `luaRecords` is deliberately absent: this string is
+ * the peer "role" label in the cluster pickers, where a feature flag would read
+ * as a topology claim ("primary + lua"). The Lua capability has its own badge.
  */
 export function summarizeCapabilities(caps: PdnsDaemonCapabilities | null): string {
   if (!caps) return "unknown";

--- a/lib/pdns/config-advice.ts
+++ b/lib/pdns/config-advice.ts
@@ -39,6 +39,10 @@ const DISPLAY_SETTINGS: readonly string[] = [
   "gsqlite3-dnssec",
   "gmysql-dnssec",
   "gpgsql-dnssec",
+  // Arms LUA records fleet-wide (#122). Carries no secret material, and an
+  // operator reading this table needs to see that server-side code execution
+  // is enabled just as much as they need to see the replication flags.
+  "enable-lua-records",
 ];
 
 /** Settings whose name smells secret - shown as `<redacted>`, never plaintext. */

--- a/lib/pdns/types.ts
+++ b/lib/pdns/types.ts
@@ -342,6 +342,14 @@ export type PdnsWriteMode = "auto" | "read_only";
 export const PDNS_WRITE_MODES = ["auto", "read_only"] as const satisfies readonly PdnsWriteMode[];
 
 /**
+ * The three values PowerDNS documents for `enable-lua-records`: `no` (the
+ * default), `yes`, and `shared` (Lua state shared between threads - still
+ * armed). The older `shard` spelling and the documented empty-string alias for
+ * `yes` are normalized away before they reach this type.
+ */
+export type PdnsLuaRecordsMode = "no" | "yes" | "shared";
+
+/**
  * What a backend's daemon is OBSERVED to be willing/able to do, derived from
  * its read-only `/config` on each version probe (ADR-0014). This is the
  * per-daemon truth the app uses instead of an operator-declared `role`: a
@@ -355,6 +363,18 @@ export const PDNS_WRITE_MODES = ["auto", "read_only"] as const satisfies readonl
 export interface PdnsDaemonCapabilities {
   /** `api=yes` - the HTTP API is enabled (definitionally true if we read this). */
   api: boolean;
+  /**
+   * `enable-lua-records` - whether the daemon arms LUA records for every zone
+   * it serves, and in which mode. LUA records are executable server-side code,
+   * so this is an operator-relevant capability, not a cosmetic one: it decides
+   * whether the record editor offers the type at all.
+   *
+   * Optional: absent on snapshots taken before this field existed (#122), which
+   * readers must treat as "not observed" rather than "off" - the zone editor
+   * falls back to a live `/config` read in that case. Once observed, `"no"` is
+   * a real negative.
+   */
+  luaRecords?: PdnsLuaRecordsMode;
   /** `primary`/`master`=yes - sends NOTIFY + serves AXFR for its master zones. */
   primary: boolean;
   /** `secondary`/`slave`=yes - initiates AXFR for its slave zones. */


### PR DESCRIPTION
## What and why

`enable-lua-records=yes` on a backend arms Lua records and the app honours it — the record editor
offers the `LUA` type and writes succeed — but nothing in the UI ever said the backend had Lua
enabled. No badge, no row in the daemon-settings table, no field in the stored capability snapshot.
The only way to find out was to open a zone and look for the type in a dropdown.

LUA records are executable server-side code, which is exactly why the editor gates them. That makes
"is Lua armed on this daemon?" an operator-relevant signal, not a cosmetic one.

Closes #122

## How

Three independent gaps, all from Lua enablement being wired into the zone editor (#115 / #117) but
never into the capability model:

- **Never derived.** `PdnsDaemonCapabilities.luaRecords` (`"no" | "yes" | "shared"`), derived in
  `deriveCapabilities()` from `enable-lua-records`. Truthiness is delegated to the existing
  `isLuaEnabledGlobally()` so the badge and the record editor can't drift apart on what "armed"
  means; only the `shared`-vs-`yes` distinction is resolved locally, because the badge shows the
  mode verbatim. The field is **optional** — absent means "snapshot predates this field", which is
  *not observed*, not `no`. Same back-compat shape `autoprimaryCount` already uses.
- **Never badged.** A `lua records` badge in `CapabilityBadges`, appended after the replication
  roles and — deliberately — *not* displaced by `standalone`. A standalone daemon with Lua armed is
  precisely the case the operator has to see. It shares autosecondary's orange because both mark a
  daemon doing something beyond plain authoritative serving; the label carries the distinction.
  The component body was restructured from nested early-returns into a badge-descriptor list so
  "standalone plus lua" is representable at all; the rendered markup is unchanged.
- **Not in the raw settings view.** `enable-lua-records` added to `DISPLAY_SETTINGS` in
  `config-advice.ts`. That list is a security allowlist; this setting carries no secret material,
  so its absence was oversight rather than policy.

Plus one thing that isn't cosmetic: enablement was computed **live, per zone-page render**. Every
editor loading any zone issued a `listZoneMetadata` call and, when that returned false, a full
`getConfig`. The zone page now reads `selected.capabilities.luaRecords` and only falls back to the
live read when the snapshot predates the field (or the backend was never probed). Per-zone
`ENABLE-LUA-RECORDS` metadata still ORs on top, unchanged — a daemon-level `no` is not a veto.

Two deliberate non-changes:

- `summarizeCapabilities()` stays replication-roles-only. It's the peer "role" label in the cluster
  pickers, where `primary + lua` would read as a topology claim.
- The trade-off in reading the snapshot instead of `/config`: the badge and the editor now reflect
  the last probe, so enabling Lua in `pdns.conf` needs a backend refresh to show up. That's the same
  contract as every other capability in the app, and it's documented in FEATURES § 3.10.

## Tests

- `lib/pdns/capabilities.test.ts` — a table over the derivation: absent (documented default `no`),
  explicit `no`, `yes`, the documented empty-string alias for `yes`, `shared`, the legacy `shard`
  spelling, and case/whitespace insensitivity.
- Full unit suite green (`npm run validate`): 1007 passed, 15 skipped.

## Threat-modeling

Touches the PDNS client's capability derivation, so: the badge is display-only and cannot *grant*
anything — the RRset write path still gates LUA server-side on its own read, so a stale or
fabricated capability snapshot can't turn into an unauthorised Lua write. The direction of the
zone-page change is fail-closed in the risky direction: a snapshot that says `no` while the daemon
says `yes` hides the LUA type (annoying, safe); a snapshot saying `yes` while the daemon says `no`
offers the type and PowerDNS rejects the write. `enable-lua-records` is not secret-shaped, and it
passes through the same `safeConfigSettings` allowlist + `SECRET_NAME` denylist as every other
displayed setting, so nothing new is exposed by adding it.

## Documentation

- `docs/FEATURES.md` § 3.10 "Observed daemon capabilities" — new subsection covering the snapshot,
  the Lua flag, and the badge-freshness contract. Appended as 3.10 rather than renumbering, so the
  existing (already partly stale) anchors elsewhere don't shift further.
- `docs/adr/0014-backend-capability-model.md` — amendment recording why an observed feature flag
  belongs in the capability snapshot, and that `undefined` means "not observed".

## Checklist

- [x] PR title uses Conventional Commits
- [x] Linked issue exists and is approved
- [x] `npm run validate` passes locally
- [x] New code is documented (file-level + JSDoc on exports)
- [x] No secrets in code, config, logs, or fixture data
- [x] If user-visible: n/a — the app has no i18n layer yet; strings follow the existing inline pattern
