### PR TITLE
feat(zones): split-horizon zones - classify a zone as internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added - split-horizon zones ("This is an internal zone")
+
+Zones carry a **horizon** - public (the default) or internal - set with a toggle
+when you add a zone, or later on the zone's **Zone settings** tab. An internal
+zone is listed as its own row alongside a public zone of the same name instead of
+disappearing into the "duplicate zones hidden" notice, carries an `INTERNAL`
+badge next to the `CLUSTER` badge in the zones list, and shows that badge on its
+detail page so it's unambiguous which copy you have open. A Public / Internal
+filter appears above the list once at least one internal zone exists.
+
+The classification is AuthAdmin-side - PowerDNS has no way to tell two same-named
+zones apart - and is stored only when it differs from the default, so nothing
+changes for installs that don't use it. Cluster zones classify against the
+cluster (not the peer that happened to serve the write), a mirror inherits its
+managed primary's classification, and changes are audited as
+`zone.horizon.update`. Adds one table, `zone_horizons`; no data migration.
+
+See [FEATURES § 4.1.1](./docs/FEATURES.md#411-split-horizon-zones-public--internal)
+· [ADR-0022](./docs/adr/0022-zone-horizons.md) · (#121)
+
 ## [1.5.3] - 2026-07-26
 
 Feature + dependency-security release. No migration, no schema change.

--- a/app/(app)/zones/[zoneId]/_components/zone-header.tsx
+++ b/app/(app)/zones/[zoneId]/_components/zone-header.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { freshnessOf } from "@/lib/freshness";
 import { displayZoneName } from "@/lib/dns/zone-name";
+import { type ZoneHorizon } from "@/lib/dns/zone-horizon";
+import { ZoneHorizonBadge } from "@/components/domain/zone-horizon-badge";
 import type { PdnsZoneDetail } from "@/lib/pdns/types";
 import type { ZoneAuditEntry } from "@/lib/db/repositories/audit-log";
 import { CloneZoneButton } from "./clone-zone-button";
@@ -8,6 +10,12 @@ import { ZoneRealtimeSubscriber } from "./zone-realtime-subscriber";
 import { PollingDisabledHint } from "@/components/domain/polling-disabled-hint";
 
 interface ZoneHeaderProps {
+  /**
+   * Which audience this copy serves (#121). `internal` renders the INTERNAL
+   * badge next to the name, so it's unambiguous which of two same-named zones
+   * is open before anyone edits a record.
+   */
+  horizon: ZoneHorizon;
   /**
    * Cached sync verdict (primary vs secondaries). Drives the realtime
    * indicator into fast-poll mode while replication is in flight. `null`
@@ -37,6 +45,7 @@ interface ZoneHeaderProps {
 
 export function ZoneHeader({
   zone,
+  horizon,
   zoneIdEncoded,
   server,
   cluster,
@@ -64,6 +73,7 @@ export function ZoneHeader({
         <div className="flex flex-wrap items-baseline justify-between gap-3">
           <h1 className="font-mono text-2xl font-semibold tracking-tight">
             {displayZoneName(zone.name)}
+            <ZoneHorizonBadge horizon={horizon} className="ml-2 align-middle" />
           </h1>
           <ZoneRealtimeSubscriber zoneName={zone.name} inSync={inSync} />
           {inSync === null ? <PollingDisabledHint /> : null}

--- a/app/(app)/zones/[zoneId]/_components/zone-settings-panel.tsx
+++ b/app/(app)/zones/[zoneId]/_components/zone-settings-panel.tsx
@@ -7,6 +7,13 @@
  * PDNS' `PUT /zones/{id}` - PDNS' metadata-endpoint allowlist doesn't
  * accept these kinds in 4.9, so the zone-object endpoint is the right
  * door.
+ *
+ * The panel also carries the one setting that ISN'T a PDNS zone-object field:
+ * the zone's horizon (#121). PowerDNS has no notion of it - it's app-side
+ * classification that decides whether this zone lists separately from a
+ * same-named public zone - but from the operator's seat it's a zone setting
+ * like any other, so it shares the panel and the Save button. The route sorts
+ * the two halves out.
  */
 
 import { useEffect, useRef, useState } from "react";
@@ -14,6 +21,7 @@ import { useRouter } from "next/navigation";
 import { useDialog } from "@/components/ui/dialog";
 import { mutate } from "@/lib/client/api-fetch";
 import { Switch } from "@/components/ui/switch";
+import { type ZoneHorizon } from "@/lib/dns/zone-horizon";
 
 interface Props {
   zoneIdEncoded: string;
@@ -24,6 +32,8 @@ interface Props {
     soa_edit?: string;
     soa_edit_api?: string;
     api_rectify?: boolean;
+    /** App-side, not from PDNS. `public` unless the operator classified it. */
+    horizon: ZoneHorizon;
   };
   canEdit: boolean;
 }
@@ -79,14 +89,17 @@ export function ZoneSettingsPanel({ zoneIdEncoded, serverSlug, initial, canEdit 
   const [soaEdit, setSoaEdit] = useState(initial.soa_edit ?? "");
   const [soaEditApi, setSoaEditApi] = useState(initial.soa_edit_api ?? "");
   const [apiRectify, setApiRectify] = useState(initial.api_rectify ?? false);
+  const [internal, setInternal] = useState(initial.horizon === "internal");
   const [saving, setSaving] = useState(false);
 
+  const initialInternal = initial.horizon === "internal";
   const dirty =
     kind !== initialKind ||
     mastersText !== (initial.masters ?? []).join("\n") ||
     soaEdit !== (initial.soa_edit ?? "") ||
     soaEditApi !== (initial.soa_edit_api ?? "") ||
-    apiRectify !== (initial.api_rectify ?? false);
+    apiRectify !== (initial.api_rectify ?? false) ||
+    internal !== initialInternal;
 
   async function handleSave() {
     setSaving(true);
@@ -98,6 +111,7 @@ export function ZoneSettingsPanel({ zoneIdEncoded, serverSlug, initial, canEdit 
         soa_edit?: string;
         soa_edit_api?: string;
         api_rectify?: boolean;
+        horizon?: ZoneHorizon;
       }
       const patch: Patch = { serverSlug };
       if (kind !== initialKind) patch.kind = kind;
@@ -113,6 +127,7 @@ export function ZoneSettingsPanel({ zoneIdEncoded, serverSlug, initial, canEdit 
       if (soaEdit !== (initial.soa_edit ?? "")) patch.soa_edit = soaEdit;
       if (soaEditApi !== (initial.soa_edit_api ?? "")) patch.soa_edit_api = soaEditApi;
       if (apiRectify !== (initial.api_rectify ?? false)) patch.api_rectify = apiRectify;
+      if (internal !== initialInternal) patch.horizon = internal ? "internal" : "public";
 
       const result = await mutate(`/api/admin/pdns/zones/${zoneIdEncoded}/settings`, {
         method: "PUT",
@@ -197,6 +212,21 @@ export function ZoneSettingsPanel({ zoneIdEncoded, serverSlug, initial, canEdit 
               ariaLabel="API-RECTIFY"
             />
             <span className="font-mono text-xs">{apiRectify ? "enabled" : "disabled"}</span>
+          </div>
+        </Field>
+
+        <Field
+          label="This is an internal zone"
+          help="Split-horizon: an internal zone lists separately from a public zone of the same name, and carries an INTERNAL badge. AuthAdmin-side only - nothing is sent to PowerDNS."
+        >
+          <div className="flex items-center gap-2">
+            <Switch
+              checked={internal}
+              onChange={setInternal}
+              disabled={!canEdit}
+              ariaLabel="This is an internal zone"
+            />
+            <span className="font-mono text-xs">{internal ? "internal" : "public"}</span>
           </div>
         </Field>
       </div>

--- a/app/(app)/zones/[zoneId]/page.tsx
+++ b/app/(app)/zones/[zoneId]/page.tsx
@@ -29,6 +29,7 @@ import type { PdnsCluster, PdnsServer } from "@/lib/db/schema";
 import { latestZoneEdit, zoneAuditLog } from "@/lib/db/repositories/audit-log";
 import { findPdnsRequestsByRequestIds } from "@/lib/db/repositories/pdns-requests";
 import { listAllPdnsServers } from "@/lib/db/repositories/pdns-servers";
+import { getZoneHorizon, horizonScopeFor } from "@/lib/db/repositories/zone-horizons";
 import { normalizeZoneId } from "@/lib/pdns/client";
 import { zoneCapabilities } from "@/lib/pdns/writable-kind";
 import {
@@ -299,6 +300,10 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
   const canReadDnssec = zoneCan("dnssec.read");
   const canReadMetadata = zoneCan("metadata.read");
 
+  // Which audience this copy of the zone serves (#121). Cluster zones classify
+  // against the cluster, so the answer doesn't change as `choosePeer` rotates.
+  const zoneHorizon = await getZoneHorizon(horizonScopeFor(selected), canonical);
+
   // LUA records are executable server-side code, so the editor only offers the
   // LUA type when PowerDNS actually has Lua enabled for this zone - the global
   // enable-lua-records setting or the per-zone ENABLE-LUA-RECORDS metadata.
@@ -400,6 +405,7 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
     <div className="space-y-6">
       <ZoneHeader
         zone={zone}
+        horizon={zoneHorizon}
         zoneIdEncoded={encodeURIComponent(zoneId)}
         server={{ name: selected.name, slug: selected.slug }}
         cluster={clusterContext ? { name: clusterContext.name, slug: clusterContext.slug } : null}
@@ -517,6 +523,7 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
                 ...(zone.soa_edit !== undefined ? { soa_edit: zone.soa_edit } : {}),
                 ...(zone.soa_edit_api !== undefined ? { soa_edit_api: zone.soa_edit_api } : {}),
                 ...(zone.api_rectify !== undefined ? { api_rectify: zone.api_rectify } : {}),
+                horizon: zoneHorizon,
               }}
               canEdit={canEditSettings}
             />

--- a/app/(app)/zones/_components/create-zone-form.tsx
+++ b/app/(app)/zones/_components/create-zone-form.tsx
@@ -28,6 +28,7 @@ import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { apiFetch } from "@/lib/client/api-fetch";
 import { TsigKeySelector } from "@/components/domain/tsig-key-selector";
 import { SelectMenu } from "@/components/ui/select-menu";
+import { Switch } from "@/components/ui/switch";
 
 /**
  * Operator-facing backend option. A logical backend is either a
@@ -154,6 +155,7 @@ export function CreateZoneForm(props: Props) {
   const backendSelection = backendKey ? parseKey(backendKey) : null;
   const [name, setName] = useState("");
   const [kind, setKind] = useState<(typeof KINDS)[number]["value"]>("Native");
+  const [internal, setInternal] = useState(false);
   const selectedBackend = backendSelection
     ? (props.backends.find(
         (b) => b.kind === backendSelection.kind && b.slug === backendSelection.slug,
@@ -344,6 +346,9 @@ export function CreateZoneForm(props: Props) {
         ? { clusterSlug: backendSelection.slug }
         : { serverSlug: backendSelection.slug }),
     };
+    // Only send a non-default horizon - the server treats "absent" as public,
+    // and this keeps the payload honest about what the operator actually chose.
+    if (internal) body["horizon"] = "internal";
     if (templateId) body["templateId"] = templateId;
     if (responsibleEmail) body["responsibleEmail"] = responsibleEmail;
     if (kind === "Primary" && selectedTsigKey) body["tsigKeyName"] = selectedTsigKey;
@@ -452,6 +457,23 @@ export function CreateZoneForm(props: Props) {
           />
           <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">
             {KINDS.find((k) => k.value === kind)?.hint}
+          </p>
+        </Field>
+
+        <Field label="Horizon">
+          <div className="mt-1 flex items-center gap-2">
+            <Switch
+              checked={internal}
+              onChange={setInternal}
+              ariaLabel="This is an internal zone"
+            />
+            <span className="text-sm">This is an internal zone.</span>
+          </div>
+          <p className="mt-1 text-xs text-[color:var(--color-fg-muted)]">
+            Tick this for the internal half of a split-horizon setup. An internal zone is listed
+            separately from a public zone of the same name and carries an{" "}
+            <span className="font-mono">INTERNAL</span> badge. AuthAdmin-side only - nothing is sent
+            to PowerDNS. Changeable later from the zone&apos;s Zone settings tab.
           </p>
         </Field>
       </Section>

--- a/app/(app)/zones/_components/zones-table.tsx
+++ b/app/(app)/zones/_components/zones-table.tsx
@@ -19,12 +19,21 @@ import { SyncIndicator } from "@/components/ui/sync-indicator";
 import { freshnessOf, freshnessOfDay } from "@/lib/freshness";
 import { isReverseZone } from "@/lib/dns/zone-kind";
 import { displayZoneName } from "@/lib/dns/zone-name";
+import { type ZoneHorizon } from "@/lib/dns/zone-horizon";
+import { ZoneHorizonBadge } from "@/components/domain/zone-horizon-badge";
 
 type ScopeFilter = "all" | "forward" | "reverse";
 const SCOPE_STORAGE_KEY = "pda.zones.scope";
 
 function isValidScope(s: unknown): s is ScopeFilter {
   return s === "all" || s === "forward" || s === "reverse";
+}
+
+type HorizonFilter = "all" | ZoneHorizon;
+const HORIZON_STORAGE_KEY = "pda.zones.horizon";
+
+function isValidHorizonFilter(s: unknown): s is HorizonFilter {
+  return s === "all" || s === "public" || s === "internal";
 }
 
 /**
@@ -58,6 +67,11 @@ export interface ZoneRow {
   kind: string;
   serial: number | null;
   dnssec: boolean;
+  /**
+   * Which audience this copy serves (#121). `internal` rows carry the INTERNAL
+   * badge and de-duplicate separately from a public zone of the same name.
+   */
+  horizon: ZoneHorizon;
   /** The backend this row was read from. The view + edit link resolves
    *  to a concrete server slug regardless of whether the source was a
    *  cluster (any peer suffices). */
@@ -168,6 +182,7 @@ export function ZonesTable({ zones, showLastEdit, showSync }: ZonesTableProps) {
                   cluster
                 </span>
               ) : null}
+              <ZoneHorizonBadge horizon={row.horizon} className="ml-2" />
               {row.readOnly ? (
                 <span
                   className="ml-2 rounded bg-[color:var(--color-bg-muted)] px-1 py-0.5 font-mono text-[0.625rem] tracking-wide text-[color:var(--color-fg-muted)] uppercase"
@@ -268,25 +283,62 @@ export function ZonesTable({ zones, showLastEdit, showSync }: ZonesTableProps) {
     }
   }, [scope]);
 
+  // Public / Internal filter. Same persistence as the scope tabs, but the
+  // control only appears once the fleet actually has an internal zone -
+  // otherwise it's a filter with nothing to filter.
+  const [horizon, setHorizon] = useState<HorizonFilter>("all");
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const raw = window.localStorage.getItem(HORIZON_STORAGE_KEY);
+      if (raw && isValidHorizonFilter(raw)) setHorizon(raw);
+    } catch {
+      // Corrupt / blocked localStorage - keep the default.
+    }
+  }, []);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(HORIZON_STORAGE_KEY, horizon);
+    } catch {
+      // Quota / blocked - non-fatal.
+    }
+  }, [horizon]);
+
   const counts = useMemo(() => {
     let forward = 0;
     let reverse = 0;
+    let internal = 0;
     for (const z of zones) {
       if (isReverseZone(z.name)) reverse++;
       else forward++;
+      if (z.horizon === "internal") internal++;
     }
-    return { all: zones.length, forward, reverse };
+    return {
+      all: zones.length,
+      forward,
+      reverse,
+      internal,
+      public: zones.length - internal,
+    };
   }, [zones]);
 
   const filtered = useMemo(() => {
-    if (scope === "all") return zones;
-    const wantReverse = scope === "reverse";
-    return zones.filter((z) => isReverseZone(z.name) === wantReverse);
-  }, [zones, scope]);
+    return zones.filter((z) => {
+      if (scope !== "all" && isReverseZone(z.name) !== (scope === "reverse")) return false;
+      if (horizon !== "all" && z.horizon !== horizon) return false;
+      return true;
+    });
+  }, [zones, scope, horizon]);
 
   return (
     <div className="space-y-3">
-      <ScopeTabs scope={scope} counts={counts} onChange={setScope} />
+      <div className="flex flex-wrap items-center gap-2">
+        <ScopeTabs scope={scope} counts={counts} onChange={setScope} />
+        {counts.internal > 0 ? (
+          <HorizonTabs horizon={horizon} counts={counts} onChange={setHorizon} />
+        ) : null}
+      </div>
       <DataTable
         columns={columns}
         data={filtered}
@@ -309,16 +361,17 @@ export function ZonesTable({ zones, showLastEdit, showSync }: ZonesTableProps) {
         pageSizeParam="pageSize"
         stateKey="zones"
         rowHref={zoneHref}
-        noDataMessage={
-          scope === "forward"
-            ? "No forward zones across any backend yet."
-            : scope === "reverse"
-              ? "No reverse zones across any backend yet."
-              : "No zones across any backend yet."
-        }
+        noDataMessage={emptyMessage(scope, horizon)}
       />
     </div>
   );
+}
+
+/** Empty-state copy that names whichever filters are actually narrowing the list. */
+function emptyMessage(scope: ScopeFilter, horizon: HorizonFilter): string {
+  const kind = scope === "forward" ? "forward " : scope === "reverse" ? "reverse " : "";
+  const audience = horizon === "internal" ? "internal " : horizon === "public" ? "public " : "";
+  return `No ${audience}${kind}zones across any backend yet.`;
 }
 
 function ScopeTabs({
@@ -330,28 +383,73 @@ function ScopeTabs({
   counts: { all: number; forward: number; reverse: number };
   onChange: (next: ScopeFilter) => void;
 }) {
-  const tabs: Array<{ id: ScopeFilter; label: string; count: number }> = [
-    { id: "all", label: "All", count: counts.all },
-    { id: "forward", label: "Forward", count: counts.forward },
-    { id: "reverse", label: "Reverse", count: counts.reverse },
-  ];
+  return (
+    <SegmentedTabs
+      ariaLabel="Zone scope filter"
+      active={scope}
+      onChange={onChange}
+      tabs={[
+        { id: "all", label: "All", count: counts.all },
+        { id: "forward", label: "Forward", count: counts.forward },
+        { id: "reverse", label: "Reverse", count: counts.reverse },
+      ]}
+    />
+  );
+}
+
+/** Public / Internal split-horizon filter (#121). Rendered only when the fleet
+ *  has at least one internal zone - see the call site. */
+function HorizonTabs({
+  horizon,
+  counts,
+  onChange,
+}: {
+  horizon: HorizonFilter;
+  counts: { all: number; public: number; internal: number };
+  onChange: (next: HorizonFilter) => void;
+}) {
+  return (
+    <SegmentedTabs
+      ariaLabel="Zone horizon filter"
+      active={horizon}
+      onChange={onChange}
+      tabs={[
+        { id: "all", label: "Any horizon", count: counts.all },
+        { id: "public", label: "Public", count: counts.public },
+        { id: "internal", label: "Internal", count: counts.internal },
+      ]}
+    />
+  );
+}
+
+function SegmentedTabs<T extends string>({
+  ariaLabel,
+  active,
+  tabs,
+  onChange,
+}: {
+  ariaLabel: string;
+  active: T;
+  tabs: Array<{ id: T; label: string; count: number }>;
+  onChange: (next: T) => void;
+}) {
   return (
     <div
       role="tablist"
-      aria-label="Zone scope filter"
+      aria-label={ariaLabel}
       className="inline-flex rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-0.5 text-sm"
     >
       {tabs.map((t) => {
-        const active = t.id === scope;
+        const isActive = t.id === active;
         return (
           <button
             key={t.id}
             role="tab"
             type="button"
-            aria-selected={active}
+            aria-selected={isActive}
             onClick={() => onChange(t.id)}
             className={
-              active
+              isActive
                 ? "rounded bg-[color:var(--color-accent)] px-3 py-1 font-medium text-[color:var(--color-accent-fg)]"
                 : "rounded px-3 py-1 text-[color:var(--color-fg-muted)] hover:text-[color:var(--color-fg)]"
             }
@@ -359,7 +457,7 @@ function ScopeTabs({
             {t.label}
             <span
               className={
-                active
+                isActive
                   ? "ml-1.5 text-[color:var(--color-accent-fg)]/80"
                   : "ml-1.5 text-[color:var(--color-fg-subtle)]"
               }

--- a/app/(app)/zones/page.tsx
+++ b/app/(app)/zones/page.tsx
@@ -34,6 +34,14 @@ import {
   type SelectableBackend,
 } from "@/lib/db/repositories/selectable-backends";
 import { listUngroupedSecondaries } from "@/lib/db/repositories/pdns-servers";
+import {
+  horizonFrom,
+  horizonScopeFor,
+  loadZoneHorizonIndex,
+  type ZoneHorizonIndex,
+} from "@/lib/db/repositories/zone-horizons";
+import { DEFAULT_ZONE_HORIZON } from "@/lib/dns/zone-horizon";
+import { dedupeZonesByIdentity } from "@/lib/dns/zone-dedupe";
 import { isReadOnlyZoneKind } from "@/lib/pdns/writable-kind";
 import { latestEditTimestampsByZone } from "@/lib/db/repositories/audit-log";
 import { checkZonesSyncBatch, type SecondarySyncStatus } from "@/lib/pdns/sync";
@@ -80,8 +88,21 @@ export default async function ZonesPage() {
     return <NoServersState canCreateServer={canCreateServer} />;
   }
 
+  // Horizon classifications for the whole fleet, in one query (#121). Every row
+  // needs one, and the table only holds deliberately-classified zones, so a
+  // single indexed read beats a lookup per row.
+  const horizonIndex = await loadZoneHorizonIndex();
+
+  // Backend rows by id, so a derived secondary can inherit its primary's
+  // classification below.
+  const backendServersById = new Map<string, PdnsServer>();
+  for (const b of backends) {
+    if (b.kind === "server") backendServersById.set(b.server.id, b.server);
+    else for (const p of b.peers) backendServersById.set(p.id, p);
+  }
+
   // Build the amalgamated list from the broker store - no PDNS calls here.
-  const fetched = await Promise.all(backends.map((b) => rowsFromBackend(b)));
+  const fetched = await Promise.all(backends.map((b) => rowsFromBackend(b, horizonIndex)));
 
   const errors: Array<{ backendName: string; message: string }> = [];
   const allRows: ZoneRow[] = [];
@@ -120,7 +141,7 @@ export default async function ZonesPage() {
   // everything else below. Display-only; writes to a secondary are blocked
   // server-side.
   for (const s of readOnlySecondaries) {
-    const r = readOnlySecondaryRows(s);
+    const r = readOnlySecondaryRows(s, horizonIndex, backendServersById);
     if (r.error) {
       errors.push({ backendName: r.label, message: r.error });
       continue;
@@ -128,13 +149,13 @@ export default async function ZonesPage() {
     for (const row of r.rows) allRows.push(row);
   }
 
-  // De-dup by zone name. The SAME zone surfaces from multiple backends - a
-  // primary plus its mirrors, two primaries seeded with the same name, or two
-  // secondaries of one external primary. Keep ONE row per name: an authoritative
-  // (writable) row always wins over a read-only mirror; within the same tier the
-  // first wins (backends arrive name-ordered). So a zone always resolves to its
-  // primary, or - if none is managed - to the first secondary that serves it.
-  const { kept: dedupedRows, hidden: hiddenRows } = dedupeZonesByName(allRows);
+  // De-dup by zone IDENTITY - (horizon, name), not name alone. The SAME zone
+  // surfaces from multiple backends (a primary plus its mirrors, two primaries
+  // seeded with the same name, two secondaries of one external primary) and
+  // collapses to one row. A zone the operator marked internal is a DIFFERENT
+  // zone from the public one sharing its name, so it keeps its own row (#121).
+  // See lib/dns/zone-dedupe.ts for the precedence rule.
+  const { kept: dedupedRows, hidden: hiddenRows } = dedupeZonesByIdentity(allRows);
 
   // Restrict the amalgamated list to zones the viewer may actually read.
   // Global zone.read sees all; otherwise only granted zone names. (The
@@ -252,9 +273,11 @@ export default async function ZonesPage() {
           <strong>
             {hiddenSummary.count} duplicate zone{hiddenSummary.count === 1 ? "" : "s"} hidden.
           </strong>{" "}
-          Each zone is listed once (resolved to its primary, or the first secondary when no primary
-          is managed). These copies are on backends with no managed primary - standalone secondaries
-          mirroring an unmanaged primary, or the same name on another primary. Also served by:{" "}
+          Each zone is listed once per horizon (resolved to its primary, or the first secondary when
+          no primary is managed). These copies are on backends with no managed primary - standalone
+          secondaries mirroring an unmanaged primary, or the same name on another primary serving
+          the same audience. A zone marked <strong>internal</strong> is a separate zone, not a
+          duplicate, and gets its own row instead of appearing here. Also served by:{" "}
           {hiddenSummary.backends.map((b, i) => (
             <span key={`${b.name} ${b.type}`}>
               {i > 0 ? ", " : ""}
@@ -294,7 +317,10 @@ function unreachableMessage(kind: "down" | "auth"): string {
  * (peers share data); a backend the broker can't reach yields an error envelope
  * so it surfaces consistently with the servers list + bell.
  */
-async function rowsFromBackend(backend: SelectableBackend): Promise<FetchResult> {
+async function rowsFromBackend(
+  backend: SelectableBackend,
+  horizonIndex: ZoneHorizonIndex,
+): Promise<FetchResult> {
   const label = backend.kind === "cluster" ? backend.cluster.name : backend.server.name;
 
   // The peer whose cached zone set we read. Any reachable peer is equivalent for
@@ -346,37 +372,22 @@ async function rowsFromBackend(backend: SelectableBackend): Promise<FetchResult>
     serverSlug: readPeer.slug,
   };
 
-  const rows = zones.map((z) => toZoneRow(z, rowsBackend, syncByZone.get(z.name) ?? []));
-  return { label, lastEditServerSlug, rows, error: null };
-}
+  // Cluster zones are classified against the cluster, not the peer we happened
+  // to read from - `readPeer` rotates, the classification must not.
+  const horizonScope =
+    backend.kind === "cluster"
+      ? { clusterId: backend.cluster.id }
+      : horizonScopeFor(backend.server);
 
-/**
- * One row per zone name across the whole fleet. An authoritative (writable) row
- * beats a read-only mirror of the same name; among rows of the same tier the
- * first wins (rows arrive in a stable, name-ordered backend sequence). Net: a
- * zone resolves to its primary, or to the first secondary when no primary serves
- * it. Map preserves first-insertion order, so an in-place replacement keeps the
- * row's original position.
- */
-function dedupeZonesByName(rows: readonly ZoneRow[]): { kept: ZoneRow[]; hidden: ZoneRow[] } {
-  const byName = new Map<string, ZoneRow>();
-  const hidden: ZoneRow[] = [];
-  for (const row of rows) {
-    const existing = byName.get(row.name);
-    if (!existing) {
-      byName.set(row.name, row);
-      continue;
-    }
-    // Prefer an authoritative row over a read-only mirror; the displaced one is
-    // hidden. Otherwise this duplicate is the one hidden.
-    if (existing.readOnly && !row.readOnly) {
-      byName.set(row.name, row);
-      hidden.push(existing);
-    } else {
-      hidden.push(row);
-    }
-  }
-  return { kept: [...byName.values()], hidden };
+  const rows = zones.map((z) =>
+    toZoneRow(
+      z,
+      rowsBackend,
+      syncByZone.get(z.name) ?? [],
+      horizonFrom(horizonIndex, horizonScope, z.name),
+    ),
+  );
+  return { label, lastEditServerSlug, rows, error: null };
 }
 
 /**
@@ -387,7 +398,11 @@ function dedupeZonesByName(rows: readonly ZoneRow[]): { kept: ZoneRow[]; hidden:
  * column (no app-side primary to compare); "last edit" falls back to the
  * SOA-serial date.
  */
-function readOnlySecondaryRows(secondary: PdnsServer): {
+function readOnlySecondaryRows(
+  secondary: PdnsServer,
+  horizonIndex: ZoneHorizonIndex,
+  backendServersById: ReadonlyMap<string, PdnsServer>,
+): {
   label: string;
   rows: ZoneRow[];
   error: string | null;
@@ -398,10 +413,26 @@ function readOnlySecondaryRows(secondary: PdnsServer): {
   if (unreach || !cached) {
     return { label, rows: [], error: unreachableMessage(unreach ?? "down") };
   }
+  // A mirror of a managed primary INHERITS that primary's classification when
+  // it has none of its own. Otherwise marking a zone internal on the primary
+  // would split its own mirror off into a second row - the mirror would sit on
+  // the public horizon and stop de-duplicating against the zone it mirrors.
+  // Same derived-parent signal the hidden-zones notice and the servers page use.
+  const parentId = derivedParentOf(secondary.id);
+  const parent = parentId ? (backendServersById.get(parentId) ?? null) : null;
+
   const rows: ZoneRow[] = [];
   for (const z of cached.zones.values()) {
     const fold = foldLastEdit(z.serial, null);
+    const own = horizonFrom(horizonIndex, { serverId: secondary.id }, z.name);
+    const horizon =
+      own !== DEFAULT_ZONE_HORIZON
+        ? own
+        : parent
+          ? horizonFrom(horizonIndex, horizonScopeFor(parent), z.name)
+          : DEFAULT_ZONE_HORIZON;
     rows.push({
+      horizon,
       id: z.id,
       name: z.name,
       kind: z.kind,
@@ -476,6 +507,7 @@ function toZoneRow(
   zone: CachedZoneSnapshot,
   backend: ZoneRow["backend"],
   sync: SecondarySyncStatus[],
+  horizon: ZoneRow["horizon"],
 ): ZoneRow {
   // Worst-case sync verdict across peers/secondaries: error > missing
   // > lagging > ahead > in-sync. Drives the column's color.
@@ -497,6 +529,7 @@ function toZoneRow(
     kind: zone.kind,
     serial: zone.serial,
     dnssec: zone.dnssec,
+    horizon,
     // Read-only by zone kind - a Slave/Secondary/Consumer zone is an AXFR
     // mirror even when it lives on an otherwise-writable (primary) backend.
     readOnly: isReadOnlyZoneKind(zone.kind),

--- a/app/api/admin/pdns/zones/[zoneId]/route.ts
+++ b/app/api/admin/pdns/zones/[zoneId]/route.ts
@@ -19,7 +19,9 @@ import { getRequestContext } from "@/lib/client-ip";
 import { requireUser } from "@/lib/auth/require-user";
 import { requireCsrf } from "@/lib/auth/csrf";
 import { findDefaultPdnsServer, findPdnsServerBySlug } from "@/lib/db/repositories/pdns-servers";
+import { deleteZoneHorizon, horizonScopeFor } from "@/lib/db/repositories/zone-horizons";
 import { getBackendGateway } from "@/lib/realtime/backend-gateway";
+import { normalizeZoneId } from "@/lib/pdns/client";
 import { PdnsError, PdnsNotFoundError } from "@/lib/pdns/errors";
 import { canActOnZone } from "@/lib/rbac/zone-permissions";
 import { redact } from "@/lib/errors/redact";
@@ -92,6 +94,23 @@ export async function DELETE(request: Request, context: RouteContext): Promise<R
         return Response.json({ error: `PDNS rejected the request: ${message}` }, { status: 502 });
       }
       throw err;
+    }
+
+    // Drop the horizon classification with the zone. Left behind, it would
+    // silently re-apply to a zone of the same name recreated later on this
+    // backend. Best-effort: the zone is already gone on PDNS, and a stale row
+    // classifies nothing until such a recreate.
+    try {
+      await deleteZoneHorizon(horizonScopeFor(selected), normalizeZoneId(zoneName));
+    } catch (err) {
+      logger.warn(
+        {
+          server: selected.slug,
+          zone: zoneName,
+          error: err instanceof Error ? redact(err.message) : "unknown",
+        },
+        "zone.delete.horizon-cleanup.failed",
+      );
     }
 
     const hdrs = await headers();

--- a/app/api/admin/pdns/zones/[zoneId]/settings/route.ts
+++ b/app/api/admin/pdns/zones/[zoneId]/settings/route.ts
@@ -21,7 +21,14 @@ import { getRequestContext } from "@/lib/client-ip";
 import { requireUser } from "@/lib/auth/require-user";
 import { requireCsrf } from "@/lib/auth/csrf";
 import { findDefaultPdnsServer, findPdnsServerBySlug } from "@/lib/db/repositories/pdns-servers";
+import {
+  getZoneHorizon,
+  horizonScopeFor,
+  setZoneHorizon,
+} from "@/lib/db/repositories/zone-horizons";
+import { ZONE_HORIZONS } from "@/lib/dns/zone-horizon";
 import { getBackendGateway } from "@/lib/realtime/backend-gateway";
+import { normalizeZoneId } from "@/lib/pdns/client";
 import { PdnsError } from "@/lib/pdns/errors";
 import { canActOnZone } from "@/lib/rbac/zone-permissions";
 import { redact } from "@/lib/errors/redact";
@@ -45,6 +52,13 @@ const putBodySchema = z.object({
   soa_edit: z.string().max(64).optional(),
   soa_edit_api: z.string().max(64).optional(),
   api_rectify: z.boolean().optional(),
+  /**
+   * Horizon classification (#121). The odd one out in this payload: every other
+   * field is forwarded to PowerDNS, this one is app-side state. It rides along
+   * anyway because it's the same Save button on the same panel, and splitting
+   * it into its own request would let the two halves land independently.
+   */
+  horizon: z.enum(ZONE_HORIZONS).optional(),
 });
 
 interface RouteContext {
@@ -92,6 +106,13 @@ export async function PUT(request: Request, context: RouteContext): Promise<Resp
       throw new ForbiddenError("Missing zone.update for this zone.");
     }
 
+    // Horizon lives in our DB, keyed on the canonical zone name (the same form
+    // the zones list and the create path store), so normalize rather than trust
+    // whatever casing the URL carried.
+    const horizonScope = horizonScopeFor(selected);
+    const canonicalZoneName = normalizeZoneId(zoneName);
+    const horizonBefore = await getZoneHorizon(horizonScope, canonicalZoneName);
+
     // Read current state for the audit `before` snapshot.
     const before = await client.getZone(zoneName).catch(() => null);
 
@@ -108,34 +129,59 @@ export async function PUT(request: Request, context: RouteContext): Promise<Resp
     if (body.soa_edit_api !== undefined) patch.soa_edit_api = body.soa_edit_api;
     if (body.api_rectify !== undefined) patch.api_rectify = body.api_rectify;
 
-    await client.updateZoneSettings(zoneName, patch);
-    const after = await client.getZone(zoneName).catch(() => null);
-
+    // A horizon-only save carries no PowerDNS-side change; don't spend a PUT
+    // (and don't log a settings-update that updated nothing) on it.
+    const touchesPdns = Object.keys(patch).length > 0;
     const hdrs = await headers();
-    await appendAudit({
-      actor: { type: "user", id: actor.id },
-      action: "zone.settings.update",
-      resource: { type: "zone", id: `${selected.slug}:${zoneName}` },
-      before: before
-        ? {
-            kind: before.kind,
-            masters: before.masters,
-            soa_edit: before.soa_edit,
-            soa_edit_api: before.soa_edit_api,
-            api_rectify: before.api_rectify,
-          }
-        : null,
-      after: after
-        ? {
-            kind: after.kind,
-            masters: after.masters,
-            soa_edit: after.soa_edit,
-            soa_edit_api: after.soa_edit_api,
-            api_rectify: after.api_rectify,
-          }
-        : null,
-      request: getRequestContext(hdrs),
-    });
+
+    if (touchesPdns) {
+      await client.updateZoneSettings(zoneName, patch);
+      const after = await client.getZone(zoneName).catch(() => null);
+      await appendAudit({
+        actor: { type: "user", id: actor.id },
+        action: "zone.settings.update",
+        resource: { type: "zone", id: `${selected.slug}:${zoneName}` },
+        before: before
+          ? {
+              kind: before.kind,
+              masters: before.masters,
+              soa_edit: before.soa_edit,
+              soa_edit_api: before.soa_edit_api,
+              api_rectify: before.api_rectify,
+            }
+          : null,
+        after: after
+          ? {
+              kind: after.kind,
+              masters: after.masters,
+              soa_edit: after.soa_edit,
+              soa_edit_api: after.soa_edit_api,
+              api_rectify: after.api_rectify,
+            }
+          : null,
+        request: getRequestContext(hdrs),
+      });
+    }
+
+    // Audited separately from the PDNS-side settings: it changes app-side zone
+    // identity (which row the amalgamated list shows this zone as), not the
+    // zone object, and a reader of the log should see that distinction.
+    if (body.horizon !== undefined && body.horizon !== horizonBefore) {
+      await setZoneHorizon({
+        scope: horizonScope,
+        zoneName: canonicalZoneName,
+        horizon: body.horizon,
+        actorId: actor.id,
+      });
+      await appendAudit({
+        actor: { type: "user", id: actor.id },
+        action: "zone.horizon.update",
+        resource: { type: "zone", id: `${selected.slug}:${zoneName}` },
+        before: { horizon: horizonBefore },
+        after: { horizon: body.horizon },
+        request: getRequestContext(hdrs),
+      });
+    }
 
     publishZoneEvent({
       type: "zone.updated",

--- a/app/api/admin/pdns/zones/route.ts
+++ b/app/api/admin/pdns/zones/route.ts
@@ -35,6 +35,8 @@ import { redact } from "@/lib/errors/redact";
 import { logger } from "@/lib/logger";
 import { publishZoneEvent } from "@/lib/realtime/event-bus";
 import { scheduleImmediatePoll } from "@/lib/realtime/zone-poller";
+import { horizonScopeFor, setZoneHorizon } from "@/lib/db/repositories/zone-horizons";
+import { DEFAULT_ZONE_HORIZON, ZONE_HORIZONS } from "@/lib/dns/zone-horizon";
 import { ConflictError, ForbiddenError, ValidationError } from "@/lib/errors";
 import { errorResponse } from "@/lib/http/error-response";
 
@@ -70,6 +72,12 @@ const createZoneSchema = z.object({
       "Zone name has invalid label characters.",
     ),
   kind: z.enum(KIND_VALUES),
+  /**
+   * Horizon classification (#121). Omitted / false means the default `public`.
+   * Purely app-side: PowerDNS has no notion of it, so it's applied after the
+   * zone exists and never blocks the create.
+   */
+  horizon: z.enum(ZONE_HORIZONS).optional(),
   /** Operator-supplied NS list. If empty AND a template is selected, the
    *  template's `nameservers` field is used. */
   nameservers: z.array(hostnameLite).max(13).default([]),
@@ -338,6 +346,32 @@ export async function POST(request: Request): Promise<Response> {
       }
     }
 
+    // Horizon classification is app-side state about a zone PowerDNS already
+    // created, so a failure here must not fail (or roll back) the create - the
+    // operator can reclassify from the zone's settings tab. Cluster zones
+    // classify against the cluster, not the peer `choosePeer` happened to pick.
+    const horizon = input.horizon ?? DEFAULT_ZONE_HORIZON;
+    if (horizon !== DEFAULT_ZONE_HORIZON) {
+      try {
+        await setZoneHorizon({
+          scope: horizonScopeFor(server),
+          zoneName,
+          horizon,
+          actorId: user.id,
+        });
+      } catch (err) {
+        logger.warn(
+          {
+            server: server.slug,
+            zone: zoneName,
+            horizon,
+            error: err instanceof Error ? redact(err.message) : "unknown",
+          },
+          "zone.create.horizon.failed",
+        );
+      }
+    }
+
     const tsigResult = input.tsigKeyName
       ? await setZoneTransferKey(server, zoneName, input.tsigKeyName, "add")
       : null;
@@ -367,6 +401,7 @@ export async function POST(request: Request): Promise<Response> {
         masters: isSecondary ? input.masters : [],
         rrsetCount: rrsets.length,
         tsigKeyName: input.tsigKeyName ?? null,
+        horizon,
       },
       request: getRequestContext(hdrs),
     });

--- a/components/domain/zone-horizon-badge.tsx
+++ b/components/domain/zone-horizon-badge.tsx
@@ -1,0 +1,44 @@
+/**
+ * components/domain/zone-horizon-badge.tsx
+ *
+ * The INTERNAL badge - "this copy of the zone is the internal one" (#121,
+ * ADR-0022). Rendered next to the CLUSTER badge in the zones list and next to
+ * the zone name on zone detail, so a fleet running split-horizon reads as
+ * `[CLUSTER] [INTERNAL]` at a glance rather than as two mystery rows with the
+ * same name.
+ *
+ * Only `internal` gets a badge. `public` is the default horizon - badging it
+ * would put a marker on nearly every row and stop the badge meaning anything.
+ *
+ * Same recipe as `capability-badges.tsx` and the CLUSTER badge (rounded, mono,
+ * tracking-wide, uppercase, `bg-<tone>/15`) so every inline state badge in the
+ * app reads as one family. Orange because it must not be confused with the
+ * indigo CLUSTER badge beside it, nor with the green the Sync column uses for
+ * "synced" - and because "you are not looking at the public copy" is worth a
+ * second glance.
+ */
+
+import { type ZoneHorizon } from "@/lib/dns/zone-horizon";
+
+const BADGE =
+  "rounded bg-[color:var(--color-orange)]/15 px-1 py-0.5 font-mono text-[0.625rem] tracking-wide text-[color:var(--color-orange-fg)] uppercase";
+
+const TITLE =
+  "Internal zone - listed separately from a public zone of the same name (split horizon)";
+
+/** Badge for a zone's horizon; renders nothing for the default (`public`). */
+export function ZoneHorizonBadge({
+  horizon,
+  className,
+}: {
+  horizon: ZoneHorizon;
+  /** Extra classes for spacing at the call site (e.g. `ml-2`). */
+  className?: string;
+}) {
+  if (horizon !== "internal") return null;
+  return (
+    <span className={className ? `${BADGE} ${className}` : BADGE} title={TITLE}>
+      internal
+    </span>
+  );
+}

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -321,7 +321,33 @@ can jump straight into the code that owns each feature.
 - **What.** Every zone across every backend in one list. Per-row "Backend" column. Per-row
   Sync chip: "-" for standalones, "synced/desynced (N)" for primaries with secondaries and
   for clusters.
-- **Where.** `app/(app)/zones/page.tsx`, `app/(app)/zones/_components/zones-table.tsx`.
+- **One row per zone identity** - `(horizon, name)`, see § 4.1.1. The same zone reached from a
+  primary and its mirrors collapses to one row, resolved to the backend that owns it; anything
+  genuinely collapsed is summarized in the "duplicate zones hidden" notice.
+- **Where.** `app/(app)/zones/page.tsx`, `app/(app)/zones/_components/zones-table.tsx`,
+  `lib/dns/zone-dedupe.ts`.
+
+### 4.1.1 Split-horizon zones (public / internal)
+
+- **What.** A per-zone **horizon** - "this is the internal copy" - set with a toggle at create time
+  or later on the zone's **Zone settings** tab. An internal zone lists separately from a public zone
+  of the same name, carries an `INTERNAL` badge next to the `CLUSTER` badge, and shows the badge on
+  its detail page so it's unambiguous which copy is open before anyone edits a record. A
+  Public / Internal filter appears above the list once the fleet has at least one internal zone.
+- **Why.** Split-horizon DNS serves the same name differently inside and outside the network,
+  usually from two daemons. Before this, the list keyed on the name alone, so the internal copy
+  vanished into the "duplicate zones hidden" notice - a deliberate setup reported as an accident of
+  replication (#121).
+- **How.** App-side classification (PowerDNS cannot tell the two apart), stored sparsely in
+  `zone_horizons` and scoped to the backend - to the **cluster** for a cluster zone, so it doesn't
+  flicker as peer selection rotates. Unclassified means `public`, so nothing changes for installs
+  that don't use it. A mirror of a managed primary inherits that primary's classification. Changes
+  are audited as `zone.horizon.update`; deleting a zone drops its classification.
+- **Scope.** Presentation and grouping only - it never changes what PowerDNS serves, and it is not
+  PDNS 5.0 Views (which splits horizons _within_ one daemon; complementary, not superseded).
+- **Where.** `lib/dns/zone-horizon.ts`, `lib/dns/zone-dedupe.ts`,
+  `lib/db/{schema,repositories}/zone-horizons.ts`, `components/domain/zone-horizon-badge.tsx`.
+  See [ADR-0022](./adr/0022-zone-horizons.md).
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="../screenshots/dark/zones-list.png" />

--- a/docs/adr/0022-zone-horizons.md
+++ b/docs/adr/0022-zone-horizons.md
@@ -1,0 +1,109 @@
+# ADR 0022 - Zone horizons: app-side split-horizon classification
+
+- **Status:** Accepted
+- **Date:** 2026-08-08
+- **Deciders:** @jseifeddine
+
+## Context
+
+Split-horizon DNS is ordinary practice: the same zone name answers one way to the internet and
+another way inside the network, usually served by two separate daemons. AuthAdmin fronts both
+daemons, and until now it treated a zone **name** as globally unique across the fleet. The
+amalgamated zones list collapsed to one row per name and pushed the rest into a "duplicate zones
+hidden" notice, which described a deliberate internal zone as an accident of replication (#121).
+The operator could not see the internal copy, could not tell which copy they had open, and was told
+their zone was a duplicate to be tidied up.
+
+Nothing lower in the stack required name uniqueness. Identity was already `(backend, name)`:
+`zone_grants` keys on `(server_id, zone_name)`, zone detail routes as `/zones/<name>?server=<slug>`,
+and the create path has no cross-backend uniqueness check - PowerDNS only rejects a name that
+already exists on the same backend. The gap was in the amalgamated view and in the app's vocabulary,
+not in storage.
+
+PowerDNS itself cannot answer "is this the internal copy?". Both zones are just a zone with a name
+on some backend. From 5.0 it grows Views / Networks, its own split-horizon primitive, but that
+serves split horizon from ONE daemon and says nothing about the far more common two-daemon
+deployment - and nothing about how a fleet-wide list should present them.
+
+## Decision
+
+We will model a zone's **horizon** - which audience it serves - as an app-side classification the
+operator sets, and key the amalgamated zone list on `(horizon, name)` instead of `name`.
+
+1. **Vocabulary.** `ZoneHorizon = "public" | "internal"`, in `lib/dns/zone-horizon.ts`. An open enum,
+   not a boolean, so a third horizon (DMZ / partner view) needs no migration and no rewrite of every
+   `if (internal)`. `public` is the default.
+2. **Storage.** A `zone_horizons` table in the app DB, keyed on `(server_id | cluster_id, zone_name)`
+   with exactly one scope set (CHECK-enforced). **Sparse**: only a deviation from the default is
+   stored, so clearing the flag deletes the row and no existing install needs a backfill.
+3. **Scope is the backend, and for a cluster it is the CLUSTER.** A cluster zone's reads and writes
+   resolve a peer per request via `choosePeer`, so a classification stored against one peer would
+   appear and disappear as the strategy rotated.
+4. **Identity.** `dedupeZonesByIdentity()` collapses rows on `(horizon, name)`. Two copies on the
+   same horizon still collapse - that really is replication or a genuine name collision. A mirror of
+   a managed primary inherits its primary's classification when it has none of its own, via the same
+   derived-parent signal the hidden-zones notice already uses.
+5. **Surfaces.** A toggle at create time and on the zone's settings tab; an `INTERNAL` badge in the
+   zones list next to `CLUSTER` and on zone detail; a Public / Internal filter that appears once the
+   fleet has an internal zone; its own audit action, `zone.horizon.update`.
+
+## Rationale
+
+The operator is the only one who knows. Both zones are byte-identical in every property the app can
+observe - the internal one is frequently a real public name (`ngn.au.`), so no heuristic on the name
+works, and no probe distinguishes them. This is the same shape as the `write_mode` exception in
+ADR-0014: an operator-declared field, admitted because PowerDNS is _incapable_ of reporting the
+fact, not merely inconvenient to ask.
+
+Keying the list on identity rather than name is the smallest change that fixes the reported problem,
+because everything below the list already worked per-backend. The alternative - teaching every
+consumer about a second dimension - would have been a far larger change for the same result.
+
+Storing only deviations means the feature is invisible to installs that don't use it: no rows, no
+migration data, no behaviour change, and `public` keeps meaning exactly what "unclassified" meant
+before.
+
+The honest trade-offs:
+
+- **The classification is app-side.** Restore the app DB from backup without it and zones revert to
+  `public`; the zone data on PowerDNS is untouched, but the list collapses again until reclassified.
+- **It is advisory, not enforced.** Nothing stops an operator marking the public zone internal. It
+  changes presentation and grouping, never what PowerDNS serves.
+- **A second dimension in the list.** "One row per name" was easy to explain. "One row per name per
+  horizon" is one clause longer, and the hidden-zones notice had to grow a sentence to match.
+
+## Alternatives considered
+
+- **PowerDNS 5.0 Views / Networks.** The daemon's own split-horizon primitive. Requires PDNS ≥ 5.0,
+  addresses one daemon serving two views, and does nothing about two separate daemons or about the
+  fleet list collapsing. Complementary, not a substitute - a future ADR can layer it.
+- **Store the flag in PowerDNS domain metadata.** Travels with the zone and survives an app-DB
+  restore, but requires a write to the daemon - impossible for a zone on a backend the operator
+  marked `read_only` (#111) or on a mirror we must never write to, which is exactly where internal
+  zones often live. It would also need a new kind on the metadata write-policy allowlist.
+- **Mark the SERVER internal and inherit to its zones.** Fewer clicks, but a backend legitimately
+  hosts both internal-only and publicly-delegated zones, and the operator loses per-zone control. A
+  per-zone flag can still be defaulted from a backend-level hint later without revisiting this.
+- **Infer from the name (RFC 1918 reverse space, non-delegated TLDs).** Guessing. The reported case
+  was a real public name; the two copies are indistinguishable by name by construction.
+- **A boolean `is_internal` column.** Simpler, but closes the door on a third horizon and reads
+  worse at every call site than a named horizon does.
+
+## Consequences
+
+- The zones list can show an internal and a public copy of one name side by side, each resolved to
+  its own primary with its own sync state; the hidden-zones notice counts only same-horizon copies.
+- `ZoneRow` gains a required `horizon`, so every producer of a zone row must resolve one. The zones
+  page loads the whole classification index in one query and looks up in memory.
+- Deleting a zone deletes its classification, so a zone recreated under the same name doesn't
+  silently inherit it. Deleting a backend or cluster cascades the same way.
+- Follow-ups this opens: horizon-aware zone templates (an internal template that presets the flag),
+  a horizon column in provisioning YAML, and eventually PDNS Views for the single-daemon case.
+
+## References
+
+- [#121](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/issues/121) - the report.
+- [ADR-0014](./0014-backend-capability-model.md) - the observe-don't-declare rule and the
+  `write_mode` exception this decision is modelled on.
+- `lib/dns/zone-horizon.ts`, `lib/dns/zone-dedupe.ts`, `lib/db/schema/zone-horizons.ts`,
+  `lib/db/repositories/zone-horizons.ts`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,6 +42,7 @@ durability, not exhaustiveness.
 | 0019 | [WebAuthn: both primary credential and second factor](./0019-webauthn-passkeys.md)                               | Accepted                   |
 | 0020 | [LDAP authentication architecture](./0020-ldap-architecture.md)                                                  | Accepted                   |
 | 0021 | [SAML 2.0 service-provider architecture](./0021-saml-architecture.md)                                            | Accepted                   |
+| 0022 | [Zone horizons: app-side split-horizon classification](./0022-zone-horizons.md)                                  | Accepted                   |
 
 > **Numbering note:** there is no ADR 0003 - that number was reserved for a decision that was
 > withdrawn before it was written. The gap is intentional; numbers are never reused.

--- a/drizzle-sqlite/0006_petite_the_santerians.sql
+++ b/drizzle-sqlite/0006_petite_the_santerians.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `zone_horizons` (
+	`id` text PRIMARY KEY NOT NULL,
+	`server_id` text,
+	`cluster_id` text,
+	`zone_name` text NOT NULL,
+	`horizon` text NOT NULL,
+	`created_by` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`server_id`) REFERENCES `pdns_servers`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`cluster_id`) REFERENCES `pdns_clusters`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+	CONSTRAINT "zone_horizons_scope_check" CHECK(("zone_horizons"."server_id" IS NULL) <> ("zone_horizons"."cluster_id" IS NULL)),
+	CONSTRAINT "zone_horizons_horizon_check" CHECK("zone_horizons"."horizon" IN ('public', 'internal'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `zone_horizons_server_unique_idx` ON `zone_horizons` (`server_id`,`zone_name`) WHERE "zone_horizons"."server_id" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX `zone_horizons_cluster_unique_idx` ON `zone_horizons` (`cluster_id`,`zone_name`) WHERE "zone_horizons"."cluster_id" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX `zone_horizons_zone_idx` ON `zone_horizons` (`zone_name`);

--- a/drizzle-sqlite/meta/0006_snapshot.json
+++ b/drizzle-sqlite/meta/0006_snapshot.json
@@ -1,0 +1,2856 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a93c82ef-1e7a-4149-a708-e12e2c0b0e73",
+  "prevId": "998298ff-6b04-4195-ba67-80d1c8db89f4",
+  "tables": {
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totp_secret_encrypted": {
+          "name": "totp_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mfa_required": {
+          "name": "mfa_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webauthn_credentials": {
+          "name": "webauthn_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_login_count": {
+          "name": "failed_login_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_login_ip": {
+          "name": "last_login_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash_updated_at": {
+          "name": "password_hash_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_lower_idx": {
+          "name": "users_email_lower_idx",
+          "columns": [
+            "lower(\"email\")"
+          ],
+          "isUnique": true
+        },
+        "users_disabled_idx": {
+          "name": "users_disabled_idx",
+          "columns": [
+            "disabled_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mail": {
+          "name": "mail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "teams_slug_idx": {
+          "name": "teams_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "teams_name_idx": {
+          "name": "teams_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_members": {
+      "name": "team_members",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_role": {
+          "name": "team_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_members_team_idx": {
+          "name": "team_members_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_user_id_team_id_pk": {
+          "columns": [
+            "user_id",
+            "team_id"
+          ],
+          "name": "team_members_user_id_team_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "team_members_team_role_check": {
+          "name": "team_members_team_role_check",
+          "value": "\"team_members\".\"team_role\" IN ('owner','member')"
+        }
+      }
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "csrf_secret": {
+          "name": "csrf_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oidc_end_session_url": {
+          "name": "oidc_end_session_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_id_token": {
+          "name": "oidc_id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_client_id": {
+          "name": "oidc_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derived_permissions": {
+          "name": "derived_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "oidc_refresh_token_encrypted": {
+          "name": "oidc_refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idp_provider_type": {
+          "name": "idp_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idp_provider_slug": {
+          "name": "idp_provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "requires_mfa": {
+          "name": "requires_mfa",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "roles_slug_idx": {
+          "name": "roles_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "roles_system_idx": {
+          "name": "roles_system_idx",
+          "columns": [
+            "is_system"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "role_assignments": {
+      "name": "role_assignments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "role_assignments_user_idx": {
+          "name": "role_assignments_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "role_assignments_role_idx": {
+          "name": "role_assignments_role_idx",
+          "columns": [
+            "role_id"
+          ],
+          "isUnique": false
+        },
+        "role_assignments_scope_idx": {
+          "name": "role_assignments_scope_idx",
+          "columns": [
+            "scope_type",
+            "scope_id"
+          ],
+          "isUnique": false
+        },
+        "role_assignments_unique_idx": {
+          "name": "role_assignments_unique_idx",
+          "columns": [
+            "user_id",
+            "role_id",
+            "scope_type",
+            "scope_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "role_assignments_user_id_users_id_fk": {
+          "name": "role_assignments_user_id_users_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignments_role_id_roles_id_fk": {
+          "name": "role_assignments_role_id_roles_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "role_assignments_created_by_users_id_fk": {
+          "name": "role_assignments_created_by_users_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "role_assignments_scope_type_check": {
+          "name": "role_assignments_scope_type_check",
+          "value": "\"role_assignments\".\"scope_type\" IN ('global','team','zone','server')"
+        }
+      }
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_user_idx": {
+          "name": "api_tokens_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "api_tokens_prefix_idx": {
+          "name": "api_tokens_prefix_idx",
+          "columns": [
+            "prefix"
+          ],
+          "isUnique": true
+        },
+        "api_tokens_team_idx": {
+          "name": "api_tokens_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_tokens_team_id_teams_id_fk": {
+          "name": "api_tokens_team_id_teams_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_ts_idx": {
+          "name": "audit_log_ts_idx",
+          "columns": [
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            "actor_type",
+            "actor_id"
+          ],
+          "isUnique": false
+        },
+        "audit_log_resource_idx": {
+          "name": "audit_log_resource_idx",
+          "columns": [
+            "resource_type",
+            "resource_id"
+          ],
+          "isUnique": false
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "audit_log_actor_type_check": {
+          "name": "audit_log_actor_type_check",
+          "value": "\"audit_log\".\"actor_type\" IN ('user','token','system')"
+        }
+      }
+    },
+    "pdns_clusters": {
+      "name": "pdns_clusters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "write_strategy": {
+          "name": "write_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'round_robin'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pdns_clusters_slug_unique": {
+          "name": "pdns_clusters_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pdns_clusters_created_by_users_id_fk": {
+          "name": "pdns_clusters_created_by_users_id_fk",
+          "tableFrom": "pdns_clusters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "pdns_clusters_write_strategy_check": {
+          "name": "pdns_clusters_write_strategy_check",
+          "value": "\"pdns_clusters\".\"write_strategy\" IN ('round_robin','lowest_latency','random','least_load')"
+        }
+      }
+    },
+    "pdns_servers": {
+      "name": "pdns_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'localhost'"
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_cache": {
+          "name": "version_cache",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "advertised_addresses": {
+          "name": "advertised_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "write_mode": {
+          "name": "write_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pdns_servers_slug_idx": {
+          "name": "pdns_servers_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "pdns_servers_default_idx": {
+          "name": "pdns_servers_default_idx",
+          "columns": [
+            "is_default"
+          ],
+          "isUnique": false
+        },
+        "pdns_servers_disabled_idx": {
+          "name": "pdns_servers_disabled_idx",
+          "columns": [
+            "disabled_at"
+          ],
+          "isUnique": false
+        },
+        "pdns_servers_cluster_id_idx": {
+          "name": "pdns_servers_cluster_id_idx",
+          "columns": [
+            "cluster_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pdns_servers_cluster_id_pdns_clusters_id_fk": {
+          "name": "pdns_servers_cluster_id_pdns_clusters_id_fk",
+          "tableFrom": "pdns_servers",
+          "tableTo": "pdns_clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pdns_servers_created_by_users_id_fk": {
+          "name": "pdns_servers_created_by_users_id_fk",
+          "tableFrom": "pdns_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metric_samples": {
+      "name": "metric_samples",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sampled_at": {
+          "name": "sampled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zone_count": {
+          "name": "zone_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_p50_ms": {
+          "name": "latency_p50_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_p95_ms": {
+          "name": "latency_p95_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_sessions": {
+          "name": "active_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "metric_samples_server_time_idx": {
+          "name": "metric_samples_server_time_idx",
+          "columns": [
+            "server_id",
+            "sampled_at"
+          ],
+          "isUnique": false
+        },
+        "metric_samples_time_idx": {
+          "name": "metric_samples_time_idx",
+          "columns": [
+            "sampled_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "backend_advisories": {
+      "name": "backend_advisories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backend_id": {
+          "name": "backend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "backend_advisories_backend_code_idx": {
+          "name": "backend_advisories_backend_code_idx",
+          "columns": [
+            "backend_id",
+            "code"
+          ],
+          "isUnique": true
+        },
+        "backend_advisories_backend_idx": {
+          "name": "backend_advisories_backend_idx",
+          "columns": [
+            "backend_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "backend_advisories_backend_id_pdns_servers_id_fk": {
+          "name": "backend_advisories_backend_id_pdns_servers_id_fk",
+          "tableFrom": "backend_advisories",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "backend_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_updated_by_users_id_fk": {
+          "name": "settings_updated_by_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oidc_providers": {
+      "name": "oidc_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret_encrypted": {
+          "name": "client_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openid profile email'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'name'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "require_email_verified": {
+          "name": "require_email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "discovery_cache": {
+          "name": "discovery_cache",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claim_groups": {
+          "name": "claim_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'groups'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oidc_providers_slug_idx": {
+          "name": "oidc_providers_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oidc_providers_created_by_users_id_fk": {
+          "name": "oidc_providers_created_by_users_id_fk",
+          "tableFrom": "oidc_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saml_providers": {
+      "name": "saml_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_entity_id": {
+          "name": "idp_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_sso_url": {
+          "name": "idp_sso_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_slo_url": {
+          "name": "idp_slo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idp_signing_cert": {
+          "name": "idp_signing_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sp_signing_key_encrypted": {
+          "name": "sp_signing_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sp_signing_cert": {
+          "name": "sp_signing_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sp_encryption_key_encrypted": {
+          "name": "sp_encryption_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sp_encryption_cert": {
+          "name": "sp_encryption_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_signed_response": {
+          "name": "require_signed_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "require_encrypted_assertion": {
+          "name": "require_encrypted_assertion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "signature_algorithm": {
+          "name": "signature_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'sha256'"
+        },
+        "name_id_format": {
+          "name": "name_id_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'name'"
+        },
+        "claim_groups": {
+          "name": "claim_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'groups'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "saml_providers_slug_idx": {
+          "name": "saml_providers_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "saml_providers_created_by_users_id_fk": {
+          "name": "saml_providers_created_by_users_id_fk",
+          "tableFrom": "saml_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ldap_providers": {
+      "name": "ldap_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_tls": {
+          "name": "start_tls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bind_password_encrypted": {
+          "name": "bind_password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_search_base": {
+          "name": "user_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_search_filter": {
+          "name": "user_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'(|(uid={{username}})(sAMAccountName={{username}})(mail={{username}}))'"
+        },
+        "group_search_base": {
+          "name": "group_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_search_filter": {
+          "name": "group_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_attr": {
+          "name": "group_attr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'memberOf'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mail'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'displayName'"
+        },
+        "tls_ca_cert": {
+          "name": "tls_ca_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ldap_providers_slug_idx": {
+          "name": "ldap_providers_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ldap_providers_created_by_users_id_fk": {
+          "name": "ldap_providers_created_by_users_id_fk",
+          "tableFrom": "ldap_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_provider_slugs": {
+      "name": "auth_provider_slugs",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "zone_templates": {
+      "name": "zone_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "soa_ttl": {
+          "name": "soa_ttl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3600
+        },
+        "soa_refresh": {
+          "name": "soa_refresh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3600
+        },
+        "soa_retry": {
+          "name": "soa_retry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900
+        },
+        "soa_expire": {
+          "name": "soa_expire",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 604800
+        },
+        "soa_minimum": {
+          "name": "soa_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3600
+        },
+        "nameservers": {
+          "name": "nameservers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "records": {
+          "name": "records",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Native'"
+        },
+        "soa_edit": {
+          "name": "soa_edit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "soa_edit_api": {
+          "name": "soa_edit_api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_rectify": {
+          "name": "api_rectify",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "default_for_primary_ids": {
+          "name": "default_for_primary_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "zone_templates_slug_idx": {
+          "name": "zone_templates_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "zone_templates_created_by_users_id_fk": {
+          "name": "zone_templates_created_by_users_id_fk",
+          "tableFrom": "zone_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "zone_grants": {
+      "name": "zone_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "zone_grants_user_idx": {
+          "name": "zone_grants_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "zone_grants_team_idx": {
+          "name": "zone_grants_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "zone_grants_zone_idx": {
+          "name": "zone_grants_zone_idx",
+          "columns": [
+            "server_id",
+            "zone_name"
+          ],
+          "isUnique": false
+        },
+        "zone_grants_user_unique_idx": {
+          "name": "zone_grants_user_unique_idx",
+          "columns": [
+            "user_id",
+            "server_id",
+            "zone_name"
+          ],
+          "isUnique": true,
+          "where": "\"zone_grants\".\"user_id\" IS NOT NULL"
+        },
+        "zone_grants_team_unique_idx": {
+          "name": "zone_grants_team_unique_idx",
+          "columns": [
+            "team_id",
+            "server_id",
+            "zone_name"
+          ],
+          "isUnique": true,
+          "where": "\"zone_grants\".\"team_id\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "zone_grants_user_id_users_id_fk": {
+          "name": "zone_grants_user_id_users_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_grants_team_id_teams_id_fk": {
+          "name": "zone_grants_team_id_teams_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_grants_server_id_pdns_servers_id_fk": {
+          "name": "zone_grants_server_id_pdns_servers_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_grants_created_by_users_id_fk": {
+          "name": "zone_grants_created_by_users_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "zone_grants_principal_check": {
+          "name": "zone_grants_principal_check",
+          "value": "(\"zone_grants\".\"user_id\" IS NULL) <> (\"zone_grants\".\"team_id\" IS NULL)"
+        }
+      }
+    },
+    "zone_horizons": {
+      "name": "zone_horizons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "horizon": {
+          "name": "horizon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "zone_horizons_server_unique_idx": {
+          "name": "zone_horizons_server_unique_idx",
+          "columns": [
+            "server_id",
+            "zone_name"
+          ],
+          "isUnique": true,
+          "where": "\"zone_horizons\".\"server_id\" IS NOT NULL"
+        },
+        "zone_horizons_cluster_unique_idx": {
+          "name": "zone_horizons_cluster_unique_idx",
+          "columns": [
+            "cluster_id",
+            "zone_name"
+          ],
+          "isUnique": true,
+          "where": "\"zone_horizons\".\"cluster_id\" IS NOT NULL"
+        },
+        "zone_horizons_zone_idx": {
+          "name": "zone_horizons_zone_idx",
+          "columns": [
+            "zone_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "zone_horizons_server_id_pdns_servers_id_fk": {
+          "name": "zone_horizons_server_id_pdns_servers_id_fk",
+          "tableFrom": "zone_horizons",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_horizons_cluster_id_pdns_clusters_id_fk": {
+          "name": "zone_horizons_cluster_id_pdns_clusters_id_fk",
+          "tableFrom": "zone_horizons",
+          "tableTo": "pdns_clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_horizons_created_by_users_id_fk": {
+          "name": "zone_horizons_created_by_users_id_fk",
+          "tableFrom": "zone_horizons",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "zone_horizons_scope_check": {
+          "name": "zone_horizons_scope_check",
+          "value": "(\"zone_horizons\".\"server_id\" IS NULL) <> (\"zone_horizons\".\"cluster_id\" IS NULL)"
+        },
+        "zone_horizons_horizon_check": {
+          "name": "zone_horizons_horizon_check",
+          "value": "\"zone_horizons\".\"horizon\" IN ('public', 'internal')"
+        }
+      }
+    },
+    "pdns_requests": {
+      "name": "pdns_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_slug": {
+          "name": "server_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "op": {
+          "name": "op",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pdns_requests_request_id_idx": {
+          "name": "pdns_requests_request_id_idx",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "pdns_requests_ts_idx": {
+          "name": "pdns_requests_ts_idx",
+          "columns": [
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "pdns_requests_server_id_idx": {
+          "name": "pdns_requests_server_id_idx",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pdns_requests_server_id_pdns_servers_id_fk": {
+          "name": "pdns_requests_server_id_pdns_servers_id_fk",
+          "tableFrom": "pdns_requests",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pdns_server_stats": {
+      "name": "pdns_server_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "map_value": {
+          "name": "map_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pdns_server_stats_server_ts_idx": {
+          "name": "pdns_server_stats_server_ts_idx",
+          "columns": [
+            "server_id",
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "pdns_server_stats_server_name_ts_idx": {
+          "name": "pdns_server_stats_server_name_ts_idx",
+          "columns": [
+            "server_id",
+            "name",
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "pdns_server_stats_ts_idx": {
+          "name": "pdns_server_stats_ts_idx",
+          "columns": [
+            "ts"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pdns_server_stats_server_id_pdns_servers_id_fk": {
+          "name": "pdns_server_stats_server_id_pdns_servers_id_fk",
+          "tableFrom": "pdns_server_stats",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "users_email_lower_idx": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle-sqlite/meta/_journal.json
+++ b/drizzle-sqlite/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1784668351372,
       "tag": "0005_known_vance_astro",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1786133283567,
+      "tag": "0006_petite_the_santerians",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/0006_nice_butterfly.sql
+++ b/drizzle/0006_nice_butterfly.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "zone_horizons" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"server_id" uuid,
+	"cluster_id" uuid,
+	"zone_name" text NOT NULL,
+	"horizon" text NOT NULL,
+	"created_by" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "zone_horizons_scope_check" CHECK (("zone_horizons"."server_id" IS NULL) <> ("zone_horizons"."cluster_id" IS NULL)),
+	CONSTRAINT "zone_horizons_horizon_check" CHECK ("zone_horizons"."horizon" IN ('public', 'internal'))
+);
+--> statement-breakpoint
+ALTER TABLE "zone_horizons" ADD CONSTRAINT "zone_horizons_server_id_pdns_servers_id_fk" FOREIGN KEY ("server_id") REFERENCES "public"."pdns_servers"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "zone_horizons" ADD CONSTRAINT "zone_horizons_cluster_id_pdns_clusters_id_fk" FOREIGN KEY ("cluster_id") REFERENCES "public"."pdns_clusters"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "zone_horizons" ADD CONSTRAINT "zone_horizons_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "zone_horizons_server_unique_idx" ON "zone_horizons" USING btree ("server_id","zone_name") WHERE "zone_horizons"."server_id" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "zone_horizons_cluster_unique_idx" ON "zone_horizons" USING btree ("cluster_id","zone_name") WHERE "zone_horizons"."cluster_id" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "zone_horizons_zone_idx" ON "zone_horizons" USING btree ("zone_name");

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,3193 @@
+{
+  "id": "70375453-3339-49a1-b26f-214f6c59bc48",
+  "prevId": "2f4b3a64-48bb-4654-8e81-fc16566d0c8b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_tokens_user_idx": {
+          "name": "api_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_prefix_idx": {
+          "name": "api_tokens_prefix_idx",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_team_idx": {
+          "name": "api_tokens_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_tokens_team_id_teams_id_fk": {
+          "name": "api_tokens_team_id_teams_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_ts_idx": {
+          "name": "audit_log_ts_idx",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_resource_idx": {
+          "name": "audit_log_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_provider_slugs": {
+      "name": "auth_provider_slugs",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backend_advisories": {
+      "name": "backend_advisories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "backend_id": {
+          "name": "backend_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "backend_advisories_backend_code_idx": {
+          "name": "backend_advisories_backend_code_idx",
+          "columns": [
+            {
+              "expression": "backend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "backend_advisories_backend_idx": {
+          "name": "backend_advisories_backend_idx",
+          "columns": [
+            {
+              "expression": "backend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "backend_advisories_backend_id_pdns_servers_id_fk": {
+          "name": "backend_advisories_backend_id_pdns_servers_id_fk",
+          "tableFrom": "backend_advisories",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "backend_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ldap_providers": {
+      "name": "ldap_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_tls": {
+          "name": "start_tls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bind_password_encrypted": {
+          "name": "bind_password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_search_base": {
+          "name": "user_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_search_filter": {
+          "name": "user_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'(|(uid={{username}})(sAMAccountName={{username}})(mail={{username}}))'"
+        },
+        "group_search_base": {
+          "name": "group_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_search_filter": {
+          "name": "group_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_attr": {
+          "name": "group_attr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'memberOf'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mail'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'displayName'"
+        },
+        "tls_ca_cert": {
+          "name": "tls_ca_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ldap_providers_slug_idx": {
+          "name": "ldap_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ldap_providers_created_by_users_id_fk": {
+          "name": "ldap_providers_created_by_users_id_fk",
+          "tableFrom": "ldap_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_samples": {
+      "name": "metric_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sampled_at": {
+          "name": "sampled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "zone_count": {
+          "name": "zone_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_p50_ms": {
+          "name": "latency_p50_ms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_p95_ms": {
+          "name": "latency_p95_ms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_sessions": {
+          "name": "active_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "metric_samples_server_time_idx": {
+          "name": "metric_samples_server_time_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sampled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metric_samples_time_idx": {
+          "name": "metric_samples_time_idx",
+          "columns": [
+            {
+              "expression": "sampled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_encrypted": {
+          "name": "client_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openid profile email'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'name'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "require_email_verified": {
+          "name": "require_email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discovery_cache": {
+          "name": "discovery_cache",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_groups": {
+          "name": "claim_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'groups'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oidc_providers_slug_idx": {
+          "name": "oidc_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_providers_created_by_users_id_fk": {
+          "name": "oidc_providers_created_by_users_id_fk",
+          "tableFrom": "oidc_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdns_clusters": {
+      "name": "pdns_clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "write_strategy": {
+          "name": "write_strategy",
+          "type": "pdns_cluster_write_strategy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'round_robin'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdns_clusters_created_by_users_id_fk": {
+          "name": "pdns_clusters_created_by_users_id_fk",
+          "tableFrom": "pdns_clusters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pdns_clusters_slug_unique": {
+          "name": "pdns_clusters_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdns_requests": {
+      "name": "pdns_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_slug": {
+          "name": "server_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "op": {
+          "name": "op",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pdns_requests_request_id_idx": {
+          "name": "pdns_requests_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pdns_requests_ts_idx": {
+          "name": "pdns_requests_ts_idx",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pdns_requests_server_id_idx": {
+          "name": "pdns_requests_server_id_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdns_requests_server_id_pdns_servers_id_fk": {
+          "name": "pdns_requests_server_id_pdns_servers_id_fk",
+          "tableFrom": "pdns_requests",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdns_server_stats": {
+      "name": "pdns_server_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_value": {
+          "name": "map_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pdns_server_stats_server_ts_idx": {
+          "name": "pdns_server_stats_server_ts_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pdns_server_stats_server_name_ts_idx": {
+          "name": "pdns_server_stats_server_name_ts_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pdns_server_stats_ts_idx": {
+          "name": "pdns_server_stats_ts_idx",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdns_server_stats_server_id_pdns_servers_id_fk": {
+          "name": "pdns_server_stats_server_id_pdns_servers_id_fk",
+          "tableFrom": "pdns_server_stats",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdns_servers": {
+      "name": "pdns_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'localhost'"
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_cache": {
+          "name": "version_cache",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advertised_addresses": {
+          "name": "advertised_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "write_mode": {
+          "name": "write_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pdns_servers_slug_idx": {
+          "name": "pdns_servers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pdns_servers_default_idx": {
+          "name": "pdns_servers_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pdns_servers_disabled_idx": {
+          "name": "pdns_servers_disabled_idx",
+          "columns": [
+            {
+              "expression": "disabled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pdns_servers_cluster_id_idx": {
+          "name": "pdns_servers_cluster_id_idx",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdns_servers_cluster_id_pdns_clusters_id_fk": {
+          "name": "pdns_servers_cluster_id_pdns_clusters_id_fk",
+          "tableFrom": "pdns_servers",
+          "tableTo": "pdns_clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pdns_servers_created_by_users_id_fk": {
+          "name": "pdns_servers_created_by_users_id_fk",
+          "tableFrom": "pdns_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_assignments": {
+      "name": "role_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "scope_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_assignments_user_idx": {
+          "name": "role_assignments_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_assignments_role_idx": {
+          "name": "role_assignments_role_idx",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_assignments_scope_idx": {
+          "name": "role_assignments_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_assignments_unique_idx": {
+          "name": "role_assignments_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_assignments_user_id_users_id_fk": {
+          "name": "role_assignments_user_id_users_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_assignments_role_id_roles_id_fk": {
+          "name": "role_assignments_role_id_roles_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "role_assignments_created_by_users_id_fk": {
+          "name": "role_assignments_created_by_users_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_mfa": {
+          "name": "requires_mfa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roles_slug_idx": {
+          "name": "roles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roles_system_idx": {
+          "name": "roles_system_idx",
+          "columns": [
+            {
+              "expression": "is_system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saml_providers": {
+      "name": "saml_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idp_entity_id": {
+          "name": "idp_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idp_sso_url": {
+          "name": "idp_sso_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idp_slo_url": {
+          "name": "idp_slo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idp_signing_cert": {
+          "name": "idp_signing_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sp_signing_key_encrypted": {
+          "name": "sp_signing_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sp_signing_cert": {
+          "name": "sp_signing_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sp_encryption_key_encrypted": {
+          "name": "sp_encryption_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sp_encryption_cert": {
+          "name": "sp_encryption_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_signed_response": {
+          "name": "require_signed_response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "require_encrypted_assertion": {
+          "name": "require_encrypted_assertion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signature_algorithm": {
+          "name": "signature_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sha256'"
+        },
+        "name_id_format": {
+          "name": "name_id_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'name'"
+        },
+        "claim_groups": {
+          "name": "claim_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'groups'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saml_providers_slug_idx": {
+          "name": "saml_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saml_providers_created_by_users_id_fk": {
+          "name": "saml_providers_created_by_users_id_fk",
+          "tableFrom": "saml_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "csrf_secret": {
+          "name": "csrf_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_end_session_url": {
+          "name": "oidc_end_session_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_id_token": {
+          "name": "oidc_id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_client_id": {
+          "name": "oidc_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derived_permissions": {
+          "name": "derived_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "oidc_refresh_token_encrypted": {
+          "name": "oidc_refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idp_provider_type": {
+          "name": "idp_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idp_provider_slug": {
+          "name": "idp_provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_updated_by_users_id_fk": {
+          "name": "settings_updated_by_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_role": {
+          "name": "team_role",
+          "type": "team_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_members_team_idx": {
+          "name": "team_members_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_user_id_team_id_pk": {
+          "name": "team_members_user_id_team_id_pk",
+          "columns": [
+            "user_id",
+            "team_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail": {
+          "name": "mail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_slug_idx": {
+          "name": "teams_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_name_idx": {
+          "name": "teams_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_secret_encrypted": {
+          "name": "totp_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mfa_required": {
+          "name": "mfa_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webauthn_credentials": {
+          "name": "webauthn_credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_login_count": {
+          "name": "failed_login_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_ip": {
+          "name": "last_login_ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password_hash_updated_at": {
+          "name": "password_hash_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_lower_idx": {
+          "name": "users_email_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_disabled_idx": {
+          "name": "users_disabled_idx",
+          "columns": [
+            {
+              "expression": "disabled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zone_grants": {
+      "name": "zone_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zone_grants_user_idx": {
+          "name": "zone_grants_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zone_grants_team_idx": {
+          "name": "zone_grants_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zone_grants_zone_idx": {
+          "name": "zone_grants_zone_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zone_grants_user_unique_idx": {
+          "name": "zone_grants_user_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"zone_grants\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zone_grants_team_unique_idx": {
+          "name": "zone_grants_team_unique_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"zone_grants\".\"team_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zone_grants_user_id_users_id_fk": {
+          "name": "zone_grants_user_id_users_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_grants_team_id_teams_id_fk": {
+          "name": "zone_grants_team_id_teams_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_grants_server_id_pdns_servers_id_fk": {
+          "name": "zone_grants_server_id_pdns_servers_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_grants_created_by_users_id_fk": {
+          "name": "zone_grants_created_by_users_id_fk",
+          "tableFrom": "zone_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "zone_grants_principal_check": {
+          "name": "zone_grants_principal_check",
+          "value": "(\"zone_grants\".\"user_id\" IS NULL) <> (\"zone_grants\".\"team_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.zone_horizons": {
+      "name": "zone_horizons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "horizon": {
+          "name": "horizon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zone_horizons_server_unique_idx": {
+          "name": "zone_horizons_server_unique_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"zone_horizons\".\"server_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zone_horizons_cluster_unique_idx": {
+          "name": "zone_horizons_cluster_unique_idx",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"zone_horizons\".\"cluster_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zone_horizons_zone_idx": {
+          "name": "zone_horizons_zone_idx",
+          "columns": [
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zone_horizons_server_id_pdns_servers_id_fk": {
+          "name": "zone_horizons_server_id_pdns_servers_id_fk",
+          "tableFrom": "zone_horizons",
+          "tableTo": "pdns_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_horizons_cluster_id_pdns_clusters_id_fk": {
+          "name": "zone_horizons_cluster_id_pdns_clusters_id_fk",
+          "tableFrom": "zone_horizons",
+          "tableTo": "pdns_clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zone_horizons_created_by_users_id_fk": {
+          "name": "zone_horizons_created_by_users_id_fk",
+          "tableFrom": "zone_horizons",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "zone_horizons_scope_check": {
+          "name": "zone_horizons_scope_check",
+          "value": "(\"zone_horizons\".\"server_id\" IS NULL) <> (\"zone_horizons\".\"cluster_id\" IS NULL)"
+        },
+        "zone_horizons_horizon_check": {
+          "name": "zone_horizons_horizon_check",
+          "value": "\"zone_horizons\".\"horizon\" IN ('public', 'internal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.zone_templates": {
+      "name": "zone_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soa_ttl": {
+          "name": "soa_ttl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3600
+        },
+        "soa_refresh": {
+          "name": "soa_refresh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3600
+        },
+        "soa_retry": {
+          "name": "soa_retry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 900
+        },
+        "soa_expire": {
+          "name": "soa_expire",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 604800
+        },
+        "soa_minimum": {
+          "name": "soa_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3600
+        },
+        "nameservers": {
+          "name": "nameservers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "records": {
+          "name": "records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Native'"
+        },
+        "soa_edit": {
+          "name": "soa_edit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soa_edit_api": {
+          "name": "soa_edit_api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_rectify": {
+          "name": "api_rectify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "default_for_primary_ids": {
+          "name": "default_for_primary_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zone_templates_slug_idx": {
+          "name": "zone_templates_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zone_templates_created_by_users_id_fk": {
+          "name": "zone_templates_created_by_users_id_fk",
+          "tableFrom": "zone_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "token",
+        "system"
+      ]
+    },
+    "public.pdns_cluster_write_strategy": {
+      "name": "pdns_cluster_write_strategy",
+      "schema": "public",
+      "values": [
+        "round_robin",
+        "lowest_latency",
+        "random",
+        "least_load"
+      ]
+    },
+    "public.scope_type": {
+      "name": "scope_type",
+      "schema": "public",
+      "values": [
+        "global",
+        "team",
+        "zone",
+        "server"
+      ]
+    },
+    "public.team_role": {
+      "name": "team_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1784668374542,
       "tag": "0005_bizarre_ezekiel",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1786133253249,
+      "tag": "0006_nice_butterfly",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/audit/actions.ts
+++ b/lib/audit/actions.ts
@@ -113,6 +113,10 @@ export const AUDIT_ACTIONS = [
   "zone.metadata.set",
   "zone.metadata.delete",
   "zone.settings.update",
+  // Operator (re)classified a zone's horizon - public vs internal (#121). Its
+  // own action, not folded into zone.settings.update, because it changes app-
+  // side zone identity rather than anything on the PowerDNS zone object.
+  "zone.horizon.update",
   "zone.grant.create",
   "zone.grant.delete",
   "zone.export",

--- a/lib/db/repositories/zone-horizons.ts
+++ b/lib/db/repositories/zone-horizons.ts
@@ -1,0 +1,151 @@
+/**
+ * lib/db/repositories/zone-horizons.ts
+ *
+ * Read + write path for `zone_horizons` - the per-zone "this is the internal
+ * copy" classification (ADR-0022, #121).
+ *
+ * Storage is sparse: only a non-default horizon has a row, so `setZoneHorizon`
+ * DELETEs when the operator clears the flag rather than writing `public` back.
+ * Readers therefore never distinguish "explicitly public" from "unclassified" -
+ * both answer `public`, which is the whole point of the default.
+ *
+ * A zone is scoped to either a standalone server or a cluster, never both;
+ * `HorizonScope` makes that unrepresentable in TypeScript, and a DB CHECK backs
+ * it up. Callers resolve the scope from the backend they already have: a server
+ * whose `clusterId` is set belongs to the cluster, not to the peer.
+ *
+ * Zone-name canonicalization (lowercase + trailing dot) happens at the route
+ * layer, matching `zone_grants`; readers here trust the column.
+ */
+
+import "server-only";
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { zoneHorizons } from "@/lib/db/schema";
+import { DEFAULT_ZONE_HORIZON, type ZoneHorizon } from "@/lib/dns/zone-horizon";
+
+/** Which backend a classification belongs to. Exactly one of the two. */
+export type HorizonScope = { serverId: string } | { clusterId: string };
+
+/**
+ * Resolve the scope for a backend row. A server that belongs to a cluster
+ * classifies against the CLUSTER: cluster reads/writes rotate peers per
+ * request, so a flag stored against one peer would flicker.
+ */
+export function horizonScopeFor(server: { id: string; clusterId: string | null }): HorizonScope {
+  return server.clusterId ? { clusterId: server.clusterId } : { serverId: server.id };
+}
+
+/** Stable lookup key for an in-memory index of classifications. */
+export function horizonKey(scope: HorizonScope, zoneName: string): string {
+  return "serverId" in scope
+    ? JSON.stringify(["server", scope.serverId, zoneName])
+    : JSON.stringify(["cluster", scope.clusterId, zoneName]);
+}
+
+/** Every stored classification, indexed by {@link horizonKey}. */
+export type ZoneHorizonIndex = ReadonlyMap<string, ZoneHorizon>;
+
+/**
+ * Load every classification in one query and index it for in-memory lookup.
+ * The amalgamated zones list needs the horizon of every row it renders; the
+ * table holds one row per deliberately-classified zone (single digits to low
+ * hundreds in practice), so a full read beats N per-zone queries by a wide
+ * margin.
+ */
+export async function loadZoneHorizonIndex(): Promise<ZoneHorizonIndex> {
+  const rows = await db
+    .select({
+      serverId: zoneHorizons.serverId,
+      clusterId: zoneHorizons.clusterId,
+      zoneName: zoneHorizons.zoneName,
+      horizon: zoneHorizons.horizon,
+    })
+    .from(zoneHorizons);
+
+  const index = new Map<string, ZoneHorizon>();
+  for (const row of rows) {
+    const scope: HorizonScope | null = row.serverId
+      ? { serverId: row.serverId }
+      : row.clusterId
+        ? { clusterId: row.clusterId }
+        : null;
+    // Unreachable while the CHECK holds; skip rather than throw so one bad row
+    // can't take down the whole zones list.
+    if (!scope) continue;
+    index.set(horizonKey(scope, row.zoneName), row.horizon);
+  }
+  return index;
+}
+
+/** Look a zone up in a loaded index, falling back to the default horizon. */
+export function horizonFrom(
+  index: ZoneHorizonIndex,
+  scope: HorizonScope,
+  zoneName: string,
+): ZoneHorizon {
+  return index.get(horizonKey(scope, zoneName)) ?? DEFAULT_ZONE_HORIZON;
+}
+
+function scopeCondition(scope: HorizonScope) {
+  return "serverId" in scope
+    ? and(eq(zoneHorizons.serverId, scope.serverId), isNull(zoneHorizons.clusterId))
+    : and(eq(zoneHorizons.clusterId, scope.clusterId), isNull(zoneHorizons.serverId));
+}
+
+/** The horizon of one zone. `public` when unclassified. */
+export async function getZoneHorizon(scope: HorizonScope, zoneName: string): Promise<ZoneHorizon> {
+  const [row] = await db
+    .select({ horizon: zoneHorizons.horizon })
+    .from(zoneHorizons)
+    .where(and(scopeCondition(scope), eq(zoneHorizons.zoneName, zoneName)))
+    .limit(1);
+  return row?.horizon ?? DEFAULT_ZONE_HORIZON;
+}
+
+/**
+ * Classify a zone. Setting the default horizon removes the row - the table
+ * records deviations, not every zone. Returns the horizon now in force so
+ * callers can audit the transition without a re-read.
+ *
+ * Not wrapped in a transaction: the delete-then-insert path can only race with
+ * another write to the SAME (scope, zone), where either order leaves exactly
+ * one row (the partial unique index guarantees it) and last-write-wins is the
+ * intended semantics for an operator toggle.
+ */
+export async function setZoneHorizon(input: {
+  scope: HorizonScope;
+  zoneName: string;
+  horizon: ZoneHorizon;
+  actorId: string | null;
+}): Promise<ZoneHorizon> {
+  const { scope, zoneName, horizon, actorId } = input;
+  const where = and(scopeCondition(scope), eq(zoneHorizons.zoneName, zoneName));
+
+  if (horizon === DEFAULT_ZONE_HORIZON) {
+    await db.delete(zoneHorizons).where(where);
+    return DEFAULT_ZONE_HORIZON;
+  }
+
+  const updated = await db
+    .update(zoneHorizons)
+    .set({ horizon, updatedAt: new Date() })
+    .where(where)
+    .returning({ id: zoneHorizons.id });
+  if (updated.length > 0) return horizon;
+
+  await db.insert(zoneHorizons).values({
+    ...("serverId" in scope ? { serverId: scope.serverId } : { clusterId: scope.clusterId }),
+    zoneName,
+    horizon,
+    createdBy: actorId,
+  });
+  return horizon;
+}
+
+/** Drop a zone's classification outright - used when the zone itself is deleted. */
+export async function deleteZoneHorizon(scope: HorizonScope, zoneName: string): Promise<void> {
+  await db
+    .delete(zoneHorizons)
+    .where(and(scopeCondition(scope), eq(zoneHorizons.zoneName, zoneName)));
+}

--- a/lib/db/schema-sqlite/index.ts
+++ b/lib/db/schema-sqlite/index.ts
@@ -24,5 +24,6 @@ export * from "./ldap-providers";
 export * from "./auth-provider-slugs";
 export * from "./zone-templates";
 export * from "./zone-grants";
+export * from "./zone-horizons";
 export * from "./pdns-requests";
 export * from "./pdns-server-stats";

--- a/lib/db/schema-sqlite/zone-horizons.ts
+++ b/lib/db/schema-sqlite/zone-horizons.ts
@@ -1,0 +1,45 @@
+/**
+ * lib/db/schema-sqlite/zone-horizons.ts - SQLite mirror of
+ * `../schema/zone-horizons.ts`.
+ *
+ * See the PG schema for the design rationale (sparse storage, server-or-cluster
+ * scope, partial unique indexes, zone-name canonicalization).
+ */
+
+import { sql } from "drizzle-orm";
+import { check, index, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { type ZoneHorizon } from "@/lib/dns/zone-horizon";
+import { pdnsClusters } from "./pdns-clusters";
+import { pdnsServers } from "./pdns-servers";
+import { users } from "./users";
+import { pk, timestamps } from "./_helpers";
+
+export const zoneHorizons = sqliteTable(
+  "zone_horizons",
+  {
+    id: pk(),
+    serverId: text("server_id").references(() => pdnsServers.id, { onDelete: "cascade" }),
+    clusterId: text("cluster_id").references(() => pdnsClusters.id, { onDelete: "cascade" }),
+    zoneName: text("zone_name").notNull(),
+    horizon: text("horizon").$type<ZoneHorizon>().notNull(),
+    createdBy: text("created_by").references(() => users.id, { onDelete: "set null" }),
+    ...timestamps(),
+  },
+  (t) => ({
+    serverUniq: uniqueIndex("zone_horizons_server_unique_idx")
+      .on(t.serverId, t.zoneName)
+      .where(sql`${t.serverId} IS NOT NULL`),
+    clusterUniq: uniqueIndex("zone_horizons_cluster_unique_idx")
+      .on(t.clusterId, t.zoneName)
+      .where(sql`${t.clusterId} IS NOT NULL`),
+    zoneIdx: index("zone_horizons_zone_idx").on(t.zoneName),
+    scopeCheck: check(
+      "zone_horizons_scope_check",
+      sql`(${t.serverId} IS NULL) <> (${t.clusterId} IS NULL)`,
+    ),
+    horizonCheck: check("zone_horizons_horizon_check", sql`${t.horizon} IN ('public', 'internal')`),
+  }),
+);
+
+export type ZoneHorizonRow = typeof zoneHorizons.$inferSelect;
+export type NewZoneHorizonRow = typeof zoneHorizons.$inferInsert;

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -46,6 +46,7 @@ import * as pgLdapProviders from "./ldap-providers";
 import * as pgAuthProviderSlugs from "./auth-provider-slugs";
 import * as pgZoneTemplates from "./zone-templates";
 import * as pgZoneGrants from "./zone-grants";
+import * as pgZoneHorizons from "./zone-horizons";
 import * as pgPdnsRequests from "./pdns-requests";
 import * as pgPdnsServerStats from "./pdns-server-stats";
 
@@ -68,6 +69,7 @@ import * as sqliteLdapProviders from "@/lib/db/schema-sqlite/ldap-providers";
 import * as sqliteAuthProviderSlugs from "@/lib/db/schema-sqlite/auth-provider-slugs";
 import * as sqliteZoneTemplates from "@/lib/db/schema-sqlite/zone-templates";
 import * as sqliteZoneGrants from "@/lib/db/schema-sqlite/zone-grants";
+import * as sqliteZoneHorizons from "@/lib/db/schema-sqlite/zone-horizons";
 import * as sqlitePdnsRequests from "@/lib/db/schema-sqlite/pdns-requests";
 import * as sqlitePdnsServerStats from "@/lib/db/schema-sqlite/pdns-server-stats";
 
@@ -192,6 +194,11 @@ export type NewZoneTemplate = pgZoneTemplates.NewZoneTemplate;
 export const zoneGrants = pick(pgZoneGrants.zoneGrants, sqliteZoneGrants.zoneGrants);
 export type ZoneGrant = pgZoneGrants.ZoneGrant;
 export type NewZoneGrant = pgZoneGrants.NewZoneGrant;
+
+// --- zone_horizons ---
+export const zoneHorizons = pick(pgZoneHorizons.zoneHorizons, sqliteZoneHorizons.zoneHorizons);
+export type ZoneHorizonRow = pgZoneHorizons.ZoneHorizonRow;
+export type NewZoneHorizonRow = pgZoneHorizons.NewZoneHorizonRow;
 
 // --- pdns_requests ---
 export const pdnsRequests = pick(pgPdnsRequests.pdnsRequests, sqlitePdnsRequests.pdnsRequests);

--- a/lib/db/schema/zone-horizons.ts
+++ b/lib/db/schema/zone-horizons.ts
@@ -1,0 +1,93 @@
+/**
+ * lib/db/schema/zone-horizons.ts
+ *
+ * Per-zone HORIZON classification - "this copy of the zone is the internal
+ * one." Split-horizon DNS serves the same name differently to the internet and
+ * to the internal network, usually from two separate daemons, and PowerDNS has
+ * nothing to distinguish the two: both are just a zone called `example.com.`
+ * on some backend. This table is where the operator says which is which
+ * (ADR-0022, #121).
+ *
+ * Shape notes:
+ *
+ *   - **Sparse by design.** Only a deviation from the default horizon is
+ *     stored; a zone with no row here is `public`. That means no backfill for
+ *     existing installs, and clearing the flag deletes the row rather than
+ *     writing `public` back. The `horizon` column still carries the value so a
+ *     third horizon can be added without a migration.
+ *
+ *   - **Scoped to a backend, not to a name.** `zone_name` alone would be
+ *     wrong - the whole point is that two backends host the same name. Exactly
+ *     one of `server_id` / `cluster_id` is set, enforced by a CHECK.
+ *
+ *   - **Why `cluster_id` at all**, when `zone_grants` keys everything on
+ *     `server_id`: a cluster zone's reads and writes resolve a peer per request
+ *     via `choosePeer`, so a flag stored against one peer would appear and
+ *     disappear as the strategy rotated. Grants solve that by expanding across
+ *     peers on the authz path; a classification has no principal to expand for,
+ *     so it is simply stored against the cluster it belongs to.
+ *
+ *   - `zone_name` is canonical (lowercase, trailing dot), canonicalized by the
+ *     writing route. Not a foreign key - PDNS owns zone identity, so a row can
+ *     outlive a deleted zone. That's harmless: an orphaned classification
+ *     applies to nothing.
+ */
+
+import { sql } from "drizzle-orm";
+import { check, index, pgTable, text, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { type ZoneHorizon } from "@/lib/dns/zone-horizon";
+import { pdnsClusters } from "./pdns-clusters";
+import { pdnsServers } from "./pdns-servers";
+import { users } from "./users";
+import { pk, timestamps } from "./_helpers";
+
+export const zoneHorizons = pgTable(
+  "zone_horizons",
+  {
+    id: pk(),
+
+    /**
+     * Standalone server / primary the zone lives on. NULL for a cluster zone.
+     * Cascade-deleted with the backend - a classification of a zone on a
+     * backend we no longer manage is meaningless.
+     */
+    serverId: uuid("server_id").references(() => pdnsServers.id, { onDelete: "cascade" }),
+
+    /** Cluster the zone lives on. NULL for a standalone-server zone. */
+    clusterId: uuid("cluster_id").references(() => pdnsClusters.id, { onDelete: "cascade" }),
+
+    /** Canonical zone name (lowercase, trailing dot). */
+    zoneName: text("zone_name").notNull(),
+
+    /** Vocabulary in `lib/dns/zone-horizon.ts`; CHECK-constrained below. */
+    horizon: text("horizon").$type<ZoneHorizon>().notNull(),
+
+    /** Who classified it. NULL once that user is deleted - the classification
+     *  itself outlives them (removing it is a deliberate act). */
+    createdBy: uuid("created_by").references(() => users.id, { onDelete: "set null" }),
+
+    ...timestamps(),
+  },
+  (t) => ({
+    // At most one classification per (backend, zone). Partial uniques, because
+    // a composite unique over a nullable column doesn't constrain the rows we
+    // care about - same footgun `zone_grants` documents for its principals.
+    serverUniq: uniqueIndex("zone_horizons_server_unique_idx")
+      .on(t.serverId, t.zoneName)
+      .where(sql`${t.serverId} IS NOT NULL`),
+    clusterUniq: uniqueIndex("zone_horizons_cluster_unique_idx")
+      .on(t.clusterId, t.zoneName)
+      .where(sql`${t.clusterId} IS NOT NULL`),
+    // The zones list loads every classification at once and indexes it in
+    // memory; this supports the per-zone lookups the detail page does.
+    zoneIdx: index("zone_horizons_zone_idx").on(t.zoneName),
+    scopeCheck: check(
+      "zone_horizons_scope_check",
+      sql`(${t.serverId} IS NULL) <> (${t.clusterId} IS NULL)`,
+    ),
+    horizonCheck: check("zone_horizons_horizon_check", sql`${t.horizon} IN ('public', 'internal')`),
+  }),
+);
+
+export type ZoneHorizonRow = typeof zoneHorizons.$inferSelect;
+export type NewZoneHorizonRow = typeof zoneHorizons.$inferInsert;

--- a/lib/dns/zone-dedupe.test.ts
+++ b/lib/dns/zone-dedupe.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { dedupeZonesByIdentity, zoneIdentityKey } from "./zone-dedupe";
+import type { DedupableZoneRow } from "./zone-dedupe";
+
+interface Row extends DedupableZoneRow {
+  backend: string;
+}
+
+const row = (
+  backend: string,
+  name: string,
+  opts: { horizon?: Row["horizon"]; readOnly?: boolean } = {},
+): Row => ({
+  backend,
+  name,
+  horizon: opts.horizon ?? "public",
+  ...(opts.readOnly !== undefined ? { readOnly: opts.readOnly } : {}),
+});
+
+describe("zoneIdentityKey", () => {
+  it("separates the same name on different horizons", () => {
+    expect(zoneIdentityKey(row("a", "ngn.au.", { horizon: "internal" }))).not.toBe(
+      zoneIdentityKey(row("b", "ngn.au.")),
+    );
+  });
+
+  it("is equal for the same (horizon, name) regardless of source backend", () => {
+    expect(zoneIdentityKey(row("a", "ngn.au."))).toBe(zoneIdentityKey(row("b", "ngn.au.")));
+  });
+});
+
+describe("dedupeZonesByIdentity", () => {
+  it("collapses the same name on the same horizon", () => {
+    const { kept, hidden } = dedupeZonesByIdentity([
+      row("primary", "example.com."),
+      row("other-primary", "example.com."),
+    ]);
+    expect(kept.map((r) => r.backend)).toEqual(["primary"]);
+    expect(hidden.map((r) => r.backend)).toEqual(["other-primary"]);
+  });
+
+  // #121 - the whole point. An internal zone is a different zone from the
+  // public one that happens to share its name, so both must list.
+  it("keeps an internal and a public copy of the same name as separate rows", () => {
+    const { kept, hidden } = dedupeZonesByIdentity([
+      row("public-ns", "ngn.au."),
+      row("internal-ns", "ngn.au.", { horizon: "internal" }),
+    ]);
+    expect(kept.map((r) => r.backend)).toEqual(["public-ns", "internal-ns"]);
+    expect(hidden).toEqual([]);
+  });
+
+  it("still collapses two internal copies of one name", () => {
+    const { kept, hidden } = dedupeZonesByIdentity([
+      row("internal-a", "ngn.au.", { horizon: "internal" }),
+      row("internal-b", "ngn.au.", { horizon: "internal" }),
+    ]);
+    expect(kept).toHaveLength(1);
+    expect(hidden.map((r) => r.backend)).toEqual(["internal-b"]);
+  });
+
+  it("prefers an authoritative row over a read-only mirror, whichever arrives first", () => {
+    const mirrorFirst = dedupeZonesByIdentity([
+      row("mirror", "example.com.", { readOnly: true }),
+      row("primary", "example.com."),
+    ]);
+    expect(mirrorFirst.kept.map((r) => r.backend)).toEqual(["primary"]);
+    expect(mirrorFirst.hidden.map((r) => r.backend)).toEqual(["mirror"]);
+
+    const primaryFirst = dedupeZonesByIdentity([
+      row("primary", "example.com."),
+      row("mirror", "example.com.", { readOnly: true }),
+    ]);
+    expect(primaryFirst.kept.map((r) => r.backend)).toEqual(["primary"]);
+    expect(primaryFirst.hidden.map((r) => r.backend)).toEqual(["mirror"]);
+  });
+
+  it("keeps a displaced row's original list position", () => {
+    // The mirror of b. arrives first, so b. sits in the middle; promoting the
+    // primary must not move it to the end.
+    const { kept } = dedupeZonesByIdentity([
+      row("x", "a."),
+      row("mirror", "b.", { readOnly: true }),
+      row("y", "c."),
+      row("primary", "b."),
+    ]);
+    expect(kept.map((r) => r.name)).toEqual(["a.", "b.", "c."]);
+    expect(kept[1]?.backend).toBe("primary");
+  });
+
+  it("keeps the first of two mirrors when no primary serves the zone", () => {
+    const { kept, hidden } = dedupeZonesByIdentity([
+      row("mirror-a", "example.com.", { readOnly: true }),
+      row("mirror-b", "example.com.", { readOnly: true }),
+    ]);
+    expect(kept.map((r) => r.backend)).toEqual(["mirror-a"]);
+    expect(hidden.map((r) => r.backend)).toEqual(["mirror-b"]);
+  });
+
+  it("passes an empty list through", () => {
+    expect(dedupeZonesByIdentity([])).toEqual({ kept: [], hidden: [] });
+  });
+});

--- a/lib/dns/zone-dedupe.ts
+++ b/lib/dns/zone-dedupe.ts
@@ -1,0 +1,75 @@
+/**
+ * lib/dns/zone-dedupe.ts
+ *
+ * Collapse the amalgamated fleet zone list to one row per zone IDENTITY.
+ *
+ * The same zone surfaces from several backends at once - a primary plus its
+ * mirrors, two primaries seeded with the same name, two secondaries of one
+ * external primary - and the list is meant to show it once, resolved to the
+ * backend that actually owns it.
+ *
+ * Identity is `(horizon, name)`, not `name` alone (ADR-0022). A zone the
+ * operator marked `internal` is a different zone from the public one that
+ * happens to share its name: different backend, different records, different
+ * audience. Keying on the name alone made the internal copy vanish into the
+ * "duplicate zones hidden" notice, which described a deliberate split-horizon
+ * setup as an accident of replication (#121). Two copies on the SAME horizon
+ * still collapse - that really is replication, or a genuine name collision.
+ *
+ * Pure, so the rule is unit-testable away from the page that renders it.
+ */
+
+import { type ZoneHorizon } from "./zone-horizon";
+
+/** The subset of a zone row this module reasons about. */
+export interface DedupableZoneRow {
+  /** Canonical zone name (lowercase, trailing dot). */
+  name: string;
+  /** Which audience this copy serves. */
+  horizon: ZoneHorizon;
+  /** True when the row is a read-only mirror rather than an authoritative copy. */
+  readOnly?: boolean;
+}
+
+/**
+ * Identity key for a row - the two facts that make two copies the same zone.
+ * JSON-encoded rather than string-joined so no separator has to be argued
+ * about: distinct `(horizon, name)` pairs cannot produce the same key.
+ */
+export function zoneIdentityKey(row: DedupableZoneRow): string {
+  return JSON.stringify([row.horizon, row.name]);
+}
+
+/**
+ * One row per `(horizon, name)`. An authoritative (writable) row always beats a
+ * read-only mirror of the same identity; among rows of the same tier the first
+ * wins (rows arrive in a stable, name-ordered backend sequence). Net: a zone
+ * resolves to its primary, or - if none is managed - to the first secondary
+ * that serves it.
+ *
+ * `Map` preserves first-insertion order, so replacing a displaced row in place
+ * keeps its original position in the list.
+ */
+export function dedupeZonesByIdentity<T extends DedupableZoneRow>(
+  rows: readonly T[],
+): { kept: T[]; hidden: T[] } {
+  const byIdentity = new Map<string, T>();
+  const hidden: T[] = [];
+  for (const row of rows) {
+    const key = zoneIdentityKey(row);
+    const existing = byIdentity.get(key);
+    if (!existing) {
+      byIdentity.set(key, row);
+      continue;
+    }
+    // Prefer an authoritative row over a read-only mirror; the displaced one is
+    // hidden. Otherwise this duplicate is the one hidden.
+    if (existing.readOnly && !row.readOnly) {
+      byIdentity.set(key, row);
+      hidden.push(existing);
+    } else {
+      hidden.push(row);
+    }
+  }
+  return { kept: [...byIdentity.values()], hidden };
+}

--- a/lib/dns/zone-horizon.test.ts
+++ b/lib/dns/zone-horizon.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ZONE_HORIZON,
+  ZONE_HORIZONS,
+  isZoneHorizon,
+  toZoneHorizon,
+  zoneHorizonLabel,
+} from "./zone-horizon";
+
+describe("zone horizon vocabulary", () => {
+  it("defaults to public - an unclassified zone must not be reclassified", () => {
+    expect(DEFAULT_ZONE_HORIZON).toBe("public");
+  });
+
+  it("accepts only the known horizons", () => {
+    expect(ZONE_HORIZONS).toEqual(["public", "internal"]);
+    expect(isZoneHorizon("public")).toBe(true);
+    expect(isZoneHorizon("internal")).toBe(true);
+    expect(isZoneHorizon("INTERNAL")).toBe(false);
+    expect(isZoneHorizon("dmz")).toBe(false);
+    expect(isZoneHorizon(undefined)).toBe(false);
+    expect(isZoneHorizon(null)).toBe(false);
+    expect(isZoneHorizon(1)).toBe(false);
+  });
+
+  it("coerces anything unrecognized to the default rather than throwing", () => {
+    expect(toZoneHorizon("internal")).toBe("internal");
+    expect(toZoneHorizon("public")).toBe("public");
+    expect(toZoneHorizon("nonsense")).toBe("public");
+    expect(toZoneHorizon(null)).toBe("public");
+  });
+
+  it("labels both horizons", () => {
+    expect(zoneHorizonLabel("internal")).toBe("internal");
+    expect(zoneHorizonLabel("public")).toBe("public");
+  });
+});

--- a/lib/dns/zone-horizon.ts
+++ b/lib/dns/zone-horizon.ts
@@ -1,0 +1,48 @@
+/**
+ * lib/dns/zone-horizon.ts
+ *
+ * A zone's HORIZON - which audience it is served to. Split-horizon DNS is
+ * ordinary practice: the same name answers one way on the internet and another
+ * way inside the network, from two different daemons. The app has no way to
+ * tell those two zones apart on its own (they are identical by name, and the
+ * internal one is frequently a real public name), so the operator classifies
+ * them and everything downstream keys off that.
+ *
+ * Only the deviation from the default is ever stored - a zone with no
+ * classification is `public`, which keeps the table sparse and means no
+ * backfill for the zones that already exist. The type is an open enum rather
+ * than a boolean so a third horizon (a DMZ / partner view) can be added without
+ * a migration and without rewriting every call site's `if (internal)`.
+ *
+ * Pure + dependency-free, so the DB schema, the route handlers, the server
+ * components, and the client components can all share one vocabulary.
+ * ADR-0022.
+ */
+
+/** Which audience a zone is served to. */
+export type ZoneHorizon = "public" | "internal";
+
+/** Every legal horizon, for validators and UI. */
+export const ZONE_HORIZONS = ["public", "internal"] as const satisfies readonly ZoneHorizon[];
+
+/**
+ * The horizon a zone has when the operator hasn't classified it. Public: the
+ * app has always listed zones as if they were internet-facing, so treating an
+ * unclassified zone as anything else would silently reclassify every existing
+ * install's fleet.
+ */
+export const DEFAULT_ZONE_HORIZON: ZoneHorizon = "public";
+
+export function isZoneHorizon(value: unknown): value is ZoneHorizon {
+  return value === "public" || value === "internal";
+}
+
+/** Narrow an untrusted / legacy value to a horizon, falling back to the default. */
+export function toZoneHorizon(value: unknown): ZoneHorizon {
+  return isZoneHorizon(value) ? value : DEFAULT_ZONE_HORIZON;
+}
+
+/** Operator-facing label. Uppercased at the badge call sites, not here. */
+export function zoneHorizonLabel(horizon: ZoneHorizon): string {
+  return horizon === "internal" ? "internal" : "public";
+}

--- a/tests/integration/zones/horizon.test.ts
+++ b/tests/integration/zones/horizon.test.ts
@@ -1,0 +1,171 @@
+/**
+ * tests/integration/zones/horizon.test.ts
+ *
+ * Split-horizon zone classification (#121, ADR-0022) end-to-end: create a zone
+ * as `internal`, reclassify it from the settings route, and check the row lands
+ * in `zone_horizons` against the right scope - the CLUSTER for a cluster zone,
+ * the SERVER for a standalone one. The scope distinction is the part unit tests
+ * can't cover and the part that breaks silently (a flag stored against a
+ * rotating peer appears and disappears with `choosePeer`).
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { type TestHttp } from "../helpers/http";
+import { loginAsBootstrap } from "../helpers/auth";
+import { dbQuery } from "../helpers/db";
+import { resetState } from "../helpers/reset";
+
+const NS = ["ns1.example.com.", "ns2.example.com."] as const;
+
+function randomZone(prefix: string): string {
+  const tag = Math.random().toString(36).slice(2, 8);
+  return `${prefix}-${Date.now()}-${tag}.example.com.`;
+}
+
+interface HorizonRow extends Record<string, unknown> {
+  horizon: string;
+  server_id: string | null;
+  cluster_id: string | null;
+}
+
+async function horizonRows(zoneName: string): Promise<HorizonRow[]> {
+  return dbQuery<HorizonRow>(
+    "SELECT horizon, server_id, cluster_id FROM zone_horizons WHERE zone_name = $1",
+    [zoneName],
+  );
+}
+
+async function createZone(admin: TestHttp, body: Record<string, unknown>): Promise<void> {
+  await admin.sendJson("POST", "/api/admin/pdns/zones", body);
+}
+
+describe("zone horizons", () => {
+  beforeEach(async () => {
+    await resetState();
+  });
+
+  it("stores an internal classification against the standalone server", async () => {
+    const admin = await loginAsBootstrap();
+    const zone = randomZone("internal");
+    await createZone(admin, {
+      serverSlug: "standalone",
+      name: zone,
+      kind: "Master",
+      nameservers: NS,
+      horizon: "internal",
+    });
+
+    const [server] = await dbQuery<{ id: string }>("SELECT id FROM pdns_servers WHERE slug = $1", [
+      "standalone",
+    ]);
+    const rows = await horizonRows(zone);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.horizon).toBe("internal");
+    expect(rows[0]?.server_id).toBe(server?.id);
+    expect(rows[0]?.cluster_id).toBeNull();
+  }, 15_000);
+
+  it("writes nothing for a zone left on the default horizon", async () => {
+    const admin = await loginAsBootstrap();
+    const zone = randomZone("public");
+    await createZone(admin, {
+      serverSlug: "standalone",
+      name: zone,
+      kind: "Master",
+      nameservers: NS,
+    });
+    // Sparse storage: `public` is the absence of a row, not a row saying public.
+    expect(await horizonRows(zone)).toHaveLength(0);
+  }, 15_000);
+
+  it("classifies a cluster zone against the cluster, not the peer that served the write", async () => {
+    const admin = await loginAsBootstrap();
+    const zone = randomZone("cluster-internal");
+    await createZone(admin, {
+      clusterSlug: "prod-cluster",
+      name: zone,
+      kind: "Master",
+      nameservers: NS,
+      horizon: "internal",
+    });
+
+    const [cluster] = await dbQuery<{ id: string }>(
+      "SELECT id FROM pdns_clusters WHERE slug = $1",
+      ["prod-cluster"],
+    );
+    const rows = await horizonRows(zone);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.cluster_id).toBe(cluster?.id);
+    expect(rows[0]?.server_id).toBeNull();
+  }, 20_000);
+
+  it("reclassifies from the settings route and audits the transition", async () => {
+    const admin = await loginAsBootstrap();
+    const zone = randomZone("reclassify");
+    await createZone(admin, {
+      serverSlug: "standalone",
+      name: zone,
+      kind: "Master",
+      nameservers: NS,
+    });
+
+    await admin.sendJson("PUT", `/api/admin/pdns/zones/${encodeURIComponent(zone)}/settings`, {
+      serverSlug: "standalone",
+      horizon: "internal",
+    });
+    expect((await horizonRows(zone))[0]?.horizon).toBe("internal");
+
+    // Back to public - the row is removed rather than rewritten.
+    await admin.sendJson("PUT", `/api/admin/pdns/zones/${encodeURIComponent(zone)}/settings`, {
+      serverSlug: "standalone",
+      horizon: "public",
+    });
+    expect(await horizonRows(zone)).toHaveLength(0);
+
+    const actions = (
+      await dbQuery<{ action: string }>(
+        "SELECT action FROM audit_log WHERE resource_id = $1 ORDER BY ts",
+        [`standalone:${zone}`],
+      )
+    ).map((r) => r.action);
+    expect(actions.filter((a) => a === "zone.horizon.update")).toHaveLength(2);
+    // A horizon-only save touches nothing on PowerDNS, so it must not log a
+    // zone-settings update that updated no zone-object field.
+    expect(actions).not.toContain("zone.settings.update");
+  }, 20_000);
+
+  it("drops the classification when the zone is deleted", async () => {
+    const admin = await loginAsBootstrap();
+    const zone = randomZone("del-internal");
+    await createZone(admin, {
+      serverSlug: "standalone",
+      name: zone,
+      kind: "Master",
+      nameservers: NS,
+      horizon: "internal",
+    });
+    expect(await horizonRows(zone)).toHaveLength(1);
+
+    await admin.sendJson(
+      "DELETE",
+      `/api/admin/pdns/zones/${encodeURIComponent(zone)}?serverSlug=standalone`,
+    );
+    // Otherwise a zone recreated under the same name would silently inherit it.
+    expect(await horizonRows(zone)).toHaveLength(0);
+  }, 15_000);
+
+  it("rejects an unknown horizon (400)", async () => {
+    const admin = await loginAsBootstrap();
+    const res = await admin.call("/api/admin/pdns/zones", {
+      method: "POST",
+      json: {
+        serverSlug: "standalone",
+        name: randomZone("bad-horizon"),
+        kind: "Master",
+        nameservers: NS,
+        horizon: "dmz",
+      },
+    });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## What and why

Bringing an internal copy of an already-managed public zone under management didn't work. The
amalgamated zones list keyed on the zone **name** alone: `dedupeZonesByName()` kept one row per
name and pushed the rest into the "N duplicate zones hidden" notice, which described a deliberate
split-horizon setup as an accident of replication. The internal copy had no row, no badge, no sync
column — and the operator was told their zone was a duplicate to clean up.

Nothing below the list required name uniqueness. `zone_grants` already keys on
`(server_id, zone_name)`, zone detail already routes as `/zones/<name>?server=|?cluster=`, and the
create path never had a cross-backend uniqueness check — PowerDNS only rejects a name that already
exists on the *same* backend. The gap was in the app's vocabulary and in the amalgamated view.

Zones now carry a **horizon**: `public` (the default) or `internal`.

Closes #121

## How

- **Vocabulary** — `lib/dns/zone-horizon.ts`. An open enum rather than a boolean, so a third
  horizon (DMZ / partner view) needs no migration and no rewrite of every `if (internal)`.
- **Identity** — `lib/dns/zone-dedupe.ts` collapses rows on `(horizon, name)`. Two copies on the
  *same* horizon still collapse (that really is replication, or a genuine collision); the existing
  authoritative-beats-mirror precedence and list-position behaviour are unchanged. Extracted from
  the page into a pure module so the rule is unit-testable.
- **Storage** — new `zone_horizons` table, both dialects. **Sparse**: only a deviation from the
  default gets a row, so clearing the flag deletes it, there's no backfill, and installs that don't
  use the feature see zero rows and zero behaviour change.
- **Scope is the backend — and for a cluster, the CLUSTER.** This is the non-obvious bit. Cluster
  reads/writes resolve a peer per request via `choosePeer`, so a flag stored against one peer would
  appear and disappear as the strategy rotated. `zone_grants` solves the same problem by expanding
  grants across peers on the authz path; a classification has no principal to expand for, so it's
  stored against the cluster. Exactly one of `server_id` / `cluster_id`, CHECK-enforced.
- **Mirrors inherit.** A mirror of a managed primary takes its primary's classification when it has
  none of its own, via the same `derivedParentOf` signal the hidden-zones notice and the servers
  page already use. Without this, marking a primary's zone internal would split its own mirror onto
  the public horizon and produce a stray second row — a regression the name-keyed dedupe didn't have.
- **UI** — toggle on the create form and on the zone's Zone settings tab; `INTERNAL` badge next to
  the `CLUSTER` badge in the list and beside the name on zone detail; a Public / Internal filter
  that only renders once the fleet actually has an internal zone. Badge tone is orange: it has to be
  distinguishable from the indigo `CLUSTER` badge next to it and from the green the Sync column uses
  for "synced".
- **Audit** — its own action, `zone.horizon.update`, with before/after. Not folded into
  `zone.settings.update`, because it changes app-side zone identity rather than the PowerDNS zone
  object, and a log reader should see that difference. A horizon-only save no longer issues a
  pointless `PUT /zones/{id}` (or logs a settings-update that updated nothing).
- **Lifecycle** — deleting a zone drops its classification, so a zone recreated under the same name
  doesn't silently inherit it. Deleting a backend or cluster cascades.

Rejected alternatives (full versions in ADR-0022): storing the flag in **PowerDNS domain metadata**
(travels with the zone, but needs a write to daemons we're often forbidden to write to — `read_only`
backends and mirrors, which is exactly where internal zones live); marking the **server** internal
and inheriting (a backend legitimately hosts both internal-only and publicly-delegated zones);
**inferring from the name** (the reported case was a real public name — the two copies are
indistinguishable by construction); **PDNS 5.0 Views** (needs ≥ 5.0, solves split horizon *within*
one daemon, and does nothing about the fleet list — complementary, not a substitute).

## Tests

- `lib/dns/zone-dedupe.test.ts` — the regression this PR exists for (an internal and a public copy
  of one name both list), plus: same-horizon copies still collapse, two internal copies still
  collapse, authoritative-beats-mirror in both arrival orders, a displaced row keeps its list
  position, first-mirror-wins when no primary serves the zone.
- `lib/dns/zone-horizon.test.ts` — the vocabulary, including that the default stays `public` (an
  unclassified zone must never be silently reclassified) and that unknown values coerce rather than
  throw.
- `tests/integration/zones/horizon.test.ts` — end-to-end against real PDNS + Postgres: create as
  internal → row scoped to the **server**; create on the cluster → row scoped to the **cluster**,
  `server_id` NULL (the scope bug that would otherwise only show up intermittently in production);
  default horizon writes no row at all; reclassify both ways from the settings route with the audit
  transitions, asserting a horizon-only save logs no `zone.settings.update`; delete-cleans-up;
  unknown horizon → 400.
- `npm run validate` green: 1013 passed, 15 skipped.

## Threat-modeling

Touches a zone-mutating route and adds a table, so:

- **Authorization.** The horizon toggle rides the existing `zone.update` gate on the settings route
  (the `canActOnZone` EITHER-OR pattern: global permission OR a per-zone grant), and the create-time
  field rides `zone.create`. No new permission and no new path to reach a zone the caller couldn't
  already act on. CSRF is unchanged — same guarded routes.
- **Scope confusion.** The classification is keyed to a backend, so a user who can act on
  `example.com.` on backend A cannot affect how `example.com.` on backend B is classified. The
  partial unique indexes make a duplicate classification unrepresentable and the CHECK makes a
  both-scopes or no-scope row unrepresentable.
- **What it is not.** The flag is advisory presentation state. It never changes what PowerDNS
  serves, never grants or withholds access to a zone, and is not a security boundary — an operator
  can mark the public zone internal and the only consequence is where it sorts and what badge it
  wears. Worth being explicit about, so nobody later mistakes it for a tenancy control (that's #120).
- **Failure modes are non-destructive.** Classification at create time is best-effort *after* the
  zone exists, so a DB hiccup can't fail or roll back a successful zone create; the operator
  reclassifies from the settings tab. A malformed row (impossible while the CHECK holds) is skipped
  when the index loads rather than taking down the whole zones list.
- **Data exposure.** The table stores a zone name, a backend id, and an enum — nothing secret, and
  nothing that reaches a client who couldn't already see the zone in the list.

## Documentation

- **New ADR-0022** (`docs/adr/0022-zone-horizons.md`) — the storage decision, the cluster-scope
  rule, the rejected alternatives, and the honest trade-offs (app-side state is lost on an app-DB
  restore; the flag is advisory; "one row per name" is now one clause longer). Indexed in
  `docs/adr/README.md`.
- `docs/FEATURES.md` § 4.1.1 — the operator-facing description, plus a pointer from § 4.1 that the
  list now keys on zone identity.
- `CHANGELOG.md` — Unreleased entry.

## Checklist

- [x] PR title uses Conventional Commits
- [x] Linked issue exists and is approved
- [x] `npm run validate` passes locally
- [x] New code is documented (file-level + JSDoc on exports)
- [x] No secrets in code, config, logs, or fixture data
- [x] If user-visible: n/a — the app has no i18n layer yet; strings follow the existing inline pattern

## Notes for the reviewer

- **Migrations:** `drizzle/0006_nice_butterfly.sql` + `drizzle-sqlite/0006_petite_the_santerians.sql`,
  one `CREATE TABLE` each, no data migration. Generate the PG one with a `postgres://` `DATABASE_URL`
  in the environment — with the SQLite URL from `.env`, `lib/db/schema/index.ts` dispatches to the
  SQLite tables and `drizzle-kit generate` emits a DROP-everything migration against the PG history.
- **Screenshots not regenerated.** `screenshots/light|dark/zones-list.png` is now slightly stale: the
  badge and the horizon filter only appear when the demo fleet actually has an internal zone, so a
  meaningful regen needs the demo data to gain one first. Happy to do that as a follow-up if you want
  the seed changed.
