### PR TITLE
Granular zone permissions: split SOA, apex NS and zone settings out of record editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,85 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.5.6] - 2026-08-27
+
+Feature release. **No schema change** - the upgrade is a pull-and-recreate. It
+ships one data-only migration that backfills permission lists; there is no DDL
+and no downtime beyond the container restart.
+
+Editing a zone's records and editing the zone itself used to be the same
+permission. A role built for a hosting customer - `record.create` /
+`record.update` / `record.delete` on their own zone - could also rewrite the
+SOA and was shown the Zone settings tab, which is where SOA-EDIT-API, the zone
+kind and the masters list live. There was no way to hand someone their records
+without handing them the zone's authority (#119).
+
+### Added - the SOA, the apex NS and zone settings are their own permissions
+
+Four permissions split those surfaces out of `zone.read` / `record.update`:
+
+| Permission              | Gates                                                                   |
+| ----------------------- | ----------------------------------------------------------------------- |
+| `soa.read`              | The **SOA** tab. Without it the tab is not rendered.                    |
+| `soa.update`            | Every write to the SOA RRset, whatever sent it.                         |
+| `zone.settings.read`    | The **Zone settings** tab (kind, masters, SOA-EDIT(-API), API-RECTIFY). |
+| `record.update.apex-ns` | Writing the zone's **apex NS** - its delegation.                        |
+
+Three things are worth knowing about how they compose:
+
+- **`soa.update` replaces the record permission rather than adding to it.** The
+  SOA is modelled as its own resource, so `soa.update` alone edits it and no
+  amount of `record.*` substitutes for it. `record.update.apex-ns` is the
+  opposite - an _extra_ requirement layered on top of the matching
+  `record.create` / `record.update` / `record.delete`, since an apex NS write is
+  still a record write.
+- **NS below the apex stays an ordinary record.** A child delegation is content
+  the zone serves, not the zone's own standing, so `record.*` covers it.
+- **A missing read permission removes the tab, not just its Save button.** A
+  direct `?tab=soa` or `?tab=settings` link falls back to Records. (Holding
+  `zone.delete` still surfaces the settings tab, because the Danger Zone lives
+  there; the settings panel itself stays hidden.)
+
+Enforcement is server-side, in the RRset route, against each change's
+normalized name - so the SOA panel, the record editor and a hand-rolled `PATCH`
+all get the same answer. In the editor the apex NS rows render as
+`Delegation - locked` and a rename that would move a record onto them is
+refused before it can be staged. All four permissions are grantable per-zone,
+so `soa.update` can be opened on one customer's zone without going fleet-wide.
+
+[ADR-0023](./docs/adr/0023-zone-authority-permissions.md) records why the SOA is
+modelled as its own resource while the apex NS stays a record with an extra
+cost, and what was rejected on the way there.
+
+Thanks to [@vducros-neyrial](https://github.com/vducros-neyrial) for the
+report and the concrete self-service scenario behind it (#119).
+
+### Fixed - the Zone settings panel answered to `record.update` in the UI
+
+`PUT /api/admin/pdns/zones/{zone}/settings` has always required `zone.update`,
+but the page enabled the panel's inputs on `record.update` for any non-mirror
+zone. A record editor got a fully interactive settings form whose Save then
+failed with a 403. The panel now reads `zone.update` on every zone kind, which
+is also what makes the settings tab meaningful to hide.
+
+### Changed - Zone Editor no longer edits the SOA or the apex NS
+
+The seeded **Zone Editor** role is the one you hand to someone who manages
+records in a zone they don't own, so it gets `soa.read` and
+`zone.settings.read` (it still _sees_ both surfaces) but neither `soa.update`
+nor `record.update.apex-ns`. Those move to **Operator** and above, alongside
+the `zone.update` that role already held. **Read Only** gains both read
+permissions and no writes. System roles are re-seeded on every boot, so this
+applies the moment you upgrade.
+
+**Custom roles, zone grants and API tokens are backfilled instead**, by
+migration `0007_granular_zone_permissions_backfill`: anything that held
+`zone.read` gains `soa.read` + `zone.settings.read`, anything that held
+`record.update` gains `soa.update`, and anything that held any `record.*` write
+gains `record.update.apex-ns`. An upgrade therefore changes nothing about what
+your own roles can do - tightening one is an opt-in edit, and unticking
+`soa.update` is now all it takes.
+
 ## [1.5.5] - 2026-08-12
 
 Bug-fix + dependency-security release. **No schema change** - the upgrade is a
@@ -1500,7 +1579,9 @@ First production release.
 - **Distribution** - multi-arch (`linux/amd64` + `linux/arm64`) image published to Docker Hub as
   `jseifeddine/powerdns-authadmin`, plus a one-command minimal-demo stack.
 
-[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.5.4...HEAD
+[Unreleased]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.5.6...HEAD
+[1.5.6]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.5.5...v1.5.6
+[1.5.5]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.5.4...v1.5.5
 [1.5.4]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.5.3...v1.5.4
 [1.5.3]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.5.2...v1.5.3
 [1.5.2]: https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/compare/v1.5.1...v1.5.2

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ ready-to-use install without a single click.
   PowerDNS itself reports as ordinary writable primaries.
 - **Real RBAC.** Five system roles plus org-defined custom roles. Permissions span ~60 actions
   across zones, records, DNSSEC, TSIG, metadata, autoprimaries, templates, users, teams, servers,
-  API tokens, audit, and OIDC providers. Assignments scope to global / team / zone / server.
+  API tokens, audit, and auth providers. Assignments scope to global / team / zone / server.
+  A zone's authority is held apart from its records - the SOA, the apex NS and the Zone
+  settings tab each answer to their own permission, so a hosting customer can manage their
+  records without ever being shown the knobs that break the zone.
 - **Auth.** Local accounts (Argon2id), generic OIDC with PKCE + per-provider group→role mapping,
   TOTP MFA (greyed out for SSO-only users - the IdP is the trust root), `pda_pat_` API tokens
   with per-token permission scopes.

--- a/app/(app)/zones/[zoneId]/_components/editable-record-table.tsx
+++ b/app/(app)/zones/[zoneId]/_components/editable-record-table.tsx
@@ -34,6 +34,7 @@ import {
   typesForZone,
   type RRValidationResult,
 } from "@/lib/validators/rr-types";
+import { protectedRRsetPermission } from "@/lib/rbac/protected-rrsets";
 import { BareDiff, computeBindDiff } from "./bare-diff";
 import { NumberInput } from "./number-input";
 import { RRContentField } from "@/components/domain/rr-editors";
@@ -73,6 +74,14 @@ interface EditableRecordTableProps {
   canCreate: boolean;
   canUpdate: boolean;
   canDelete: boolean;
+  /**
+   * `record.update.apex-ns`. The apex NS RRset is the zone's delegation,
+   * so it costs a permission of its own on top of the record ones (#119).
+   * Without it those rows render locked and the editor refuses to stage a
+   * change touching them - the RRset route enforces the same rule, this
+   * just stops the operator finding out via a 403.
+   */
+  canUpdateApexNs: boolean;
   /** Live ENABLE-LUA-RECORDS=1 state for this zone. */
   luaRecordsEnabled: boolean;
 }
@@ -160,6 +169,15 @@ export function EditableRecordTable(props: EditableRecordTableProps) {
 
   const showActions = props.canUpdate || props.canDelete;
 
+  /**
+   * True when this row is an apex NS the actor may not touch. Uses the
+   * same classifier the RRset route does, so the lock and the 403 can't
+   * drift apart.
+   */
+  const isLockedRow = (row: { name: string; type: string }): boolean =>
+    !props.canUpdateApexNs &&
+    protectedRRsetPermission(row.name, row.type, props.zoneName) === "record.update.apex-ns";
+
   const columns = useMemo<Array<ColumnDef<RecordRow, unknown>>>(() => {
     const base: Array<ColumnDef<RecordRow, unknown>> = [
       {
@@ -227,6 +245,16 @@ export function EditableRecordTable(props: EditableRecordTableProps) {
         meta: { className: "w-[14%] text-right" },
         cell: (ctx) => {
           const row = ctx.row.original;
+          if (isLockedRow(row)) {
+            return (
+              <span
+                className="text-xs text-[color:var(--color-fg-subtle)]"
+                title="The apex NS records are this zone's delegation. Editing them needs record.update.apex-ns."
+              >
+                Delegation - locked
+              </span>
+            );
+          }
           return (
             <span className="text-xs">
               {props.canUpdate ? (
@@ -261,7 +289,7 @@ export function EditableRecordTable(props: EditableRecordTableProps) {
     // `nonSoaRef.current`, see below), so rebuilding the column defs when they
     // change would be churn without correctness benefit.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.canUpdate, props.canDelete, props.zoneName, showActions]);
+  }, [props.canUpdate, props.canDelete, props.canUpdateApexNs, props.zoneName, showActions]);
 
   // ===== Editor handlers =====================================================
 
@@ -284,6 +312,7 @@ export function EditableRecordTable(props: EditableRecordTableProps) {
   }
 
   function openEdit(row: RecordRow) {
+    if (isLockedRow(row)) return;
     setEditorError(null);
     setOverrideErrors(false);
     setEditor({
@@ -303,6 +332,7 @@ export function EditableRecordTable(props: EditableRecordTableProps) {
   }
 
   async function handleDeleteRow(row: RecordRow) {
+    if (isLockedRow(row)) return;
     const ok = await confirm({
       title: "Delete this record?",
       description: `Removes ${row.type} value "${row.value}" from ${displayName(row.name, props.zoneName) || "@"}. Other ${row.type} records on this name (if any) stay.`,
@@ -417,6 +447,17 @@ export function EditableRecordTable(props: EditableRecordTableProps) {
 
     if (changes.length === 0) {
       setEditorError("Nothing to change.");
+      return;
+    }
+
+    // A rename can move a record ONTO the apex NS RRset (or off it), so
+    // check the changes the edit actually produces rather than the form's
+    // target alone. The RRset route rejects the same set - this just says
+    // so before the operator has staged a diff.
+    if (changes.some((c) => isLockedRow(c))) {
+      setEditorError(
+        "The apex NS records are this zone's delegation and need the record.update.apex-ns permission.",
+      );
       return;
     }
 

--- a/app/(app)/zones/[zoneId]/_components/zone-tabs.tsx
+++ b/app/(app)/zones/[zoneId]/_components/zone-tabs.tsx
@@ -17,6 +17,19 @@ interface ZoneTabsProps {
   serverSlug: string;
   canReadDnssec: boolean;
   canReadMetadata: boolean;
+  /**
+   * Gates the SOA tab (`soa.read`). The SOA carries the zone's authority
+   * and its transfer timers, so a self-service editor can be given the
+   * records without ever being shown it (#119).
+   */
+  canReadSoa: boolean;
+  /**
+   * Gates the Zone settings tab - `zone.settings.read`, or `zone.delete`
+   * for the Danger Zone that shares the tab. Same reasoning as the SOA
+   * tab: record editing must not imply seeing the zone's kind, masters
+   * or SOA-EDIT-API.
+   */
+  showSettings: boolean;
   canReadAudit: boolean;
   /**
    * Gates the Access tab. The tab lists roles + teams + users that
@@ -39,6 +52,8 @@ export function ZoneTabs({
   serverSlug,
   canReadDnssec,
   canReadMetadata,
+  canReadSoa,
+  showSettings,
   canReadAudit,
   canReadAccess,
   showPollingFeatures,
@@ -67,12 +82,16 @@ export function ZoneTabs({
         <TabLink href={detailHref} active={active === "records"}>
           Records
         </TabLink>
-        <TabLink href={soaHref} active={active === "soa"}>
-          SOA
-        </TabLink>
-        <TabLink href={settingsHref} active={active === "settings"}>
-          Zone settings
-        </TabLink>
+        {canReadSoa ? (
+          <TabLink href={soaHref} active={active === "soa"}>
+            SOA
+          </TabLink>
+        ) : null}
+        {showSettings ? (
+          <TabLink href={settingsHref} active={active === "settings"}>
+            Zone settings
+          </TabLink>
+        ) : null}
         {canReadDnssec ? (
           <TabLink href={dnssecHref} active={active === "dnssec"}>
             DNSSEC

--- a/app/(app)/zones/[zoneId]/page.tsx
+++ b/app/(app)/zones/[zoneId]/page.tsx
@@ -285,9 +285,17 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
   const canUpdate = ops.rrsets && zoneCan("record.update");
   const canDelete = ops.rrsets && zoneCan("record.delete");
   const canEdit = canCreate || canUpdate || canDelete;
-  // `masters` (which primaries a mirror pulls from) is editable on a read-only
-  // zone, so the settings panel stays writable there for users with zone.update.
-  const canEditSettings = canUpdate || (isReadOnlyZone && zoneCan("zone.update"));
+  // Apex NS is the zone's delegation, so it costs a permission of its own on
+  // top of the record ones (#119). Rows for it stay visible but locked without
+  // it; the RRset route enforces the same rule.
+  const canUpdateApexNs = ops.rrsets && zoneCan("record.update.apex-ns");
+  // Zone settings (kind, masters, SOA-EDIT*, API-RECTIFY, horizon) are the
+  // knobs that decide the zone's authority and how it transfers - they answer
+  // to `zone.update`, NEVER to `record.update`. `masters` is meaningful on a
+  // read-only mirror too, so the panel stays writable there on the same
+  // permission.
+  const canEditSettings = zoneCan("zone.update");
+  const canReadSettings = zoneCan("zone.settings.read");
   // Zone creation isn't grantable per-zone - it's a global capability.
   const canCreateZone = globalPermissions.has("zone.create");
   const canDeleteZone = zoneCan("zone.delete");
@@ -299,6 +307,12 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
   const canReadAccess = globalPermissions.has("user.read");
   const canReadDnssec = zoneCan("dnssec.read");
   const canReadMetadata = zoneCan("metadata.read");
+  const canReadSoa = zoneCan("soa.read");
+  const canEditSoa = ops.rrsets && zoneCan("soa.update");
+  // The Danger Zone (delete this zone) lives on the settings tab, so a
+  // `zone.delete` holder who can't read settings still needs a way in - the
+  // tab renders with the panel omitted.
+  const showSettingsTab = canReadSettings || canDeleteZone;
 
   // Which audience this copy of the zone serves (#121). Cluster zones classify
   // against the cluster, so the answer doesn't change as `choosePeer` rotates.
@@ -359,9 +373,9 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
       ? "history"
       : requestedTab === "access" && canReadAccess
         ? "access"
-        : requestedTab === "soa"
+        : requestedTab === "soa" && canReadSoa
           ? "soa"
-          : requestedTab === "settings"
+          : requestedTab === "settings" && showSettingsTab
             ? "settings"
             : requestedTab === "dnssec" && canReadDnssec
               ? "dnssec"
@@ -463,6 +477,8 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
           serverSlug={selected.slug}
           canReadDnssec={canReadDnssec}
           canReadMetadata={canReadMetadata}
+          canReadSoa={canReadSoa}
+          showSettings={showSettingsTab}
           canReadAudit={canReadAudit}
           canReadAccess={canReadAccess}
           showPollingFeatures={pdnsBackgroundPollingEnabled}
@@ -497,6 +513,7 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
               canCreate={canCreate}
               canUpdate={canUpdate}
               canDelete={canDelete}
+              canUpdateApexNs={canUpdateApexNs}
               luaRecordsEnabled={luaRecordsEnabled}
             />
           ) : (
@@ -523,23 +540,25 @@ export default async function ZoneDetailPage({ params, searchParams }: PageProps
             zoneIdEncoded={encodeURIComponent(zone.id)}
             current={soaFields}
             ttl={soaTtl}
-            canEdit={canUpdate}
+            canEdit={canEditSoa}
           />
         ) : tab === "settings" ? (
           <div className="space-y-6">
-            <ZoneSettingsPanel
-              zoneIdEncoded={encodeURIComponent(zone.id)}
-              serverSlug={selected.slug}
-              initial={{
-                kind: zone.kind,
-                ...(zone.masters !== undefined ? { masters: zone.masters } : {}),
-                ...(zone.soa_edit !== undefined ? { soa_edit: zone.soa_edit } : {}),
-                ...(zone.soa_edit_api !== undefined ? { soa_edit_api: zone.soa_edit_api } : {}),
-                ...(zone.api_rectify !== undefined ? { api_rectify: zone.api_rectify } : {}),
-                horizon: zoneHorizon,
-              }}
-              canEdit={canEditSettings}
-            />
+            {canReadSettings ? (
+              <ZoneSettingsPanel
+                zoneIdEncoded={encodeURIComponent(zone.id)}
+                serverSlug={selected.slug}
+                initial={{
+                  kind: zone.kind,
+                  ...(zone.masters !== undefined ? { masters: zone.masters } : {}),
+                  ...(zone.soa_edit !== undefined ? { soa_edit: zone.soa_edit } : {}),
+                  ...(zone.soa_edit_api !== undefined ? { soa_edit_api: zone.soa_edit_api } : {}),
+                  ...(zone.api_rectify !== undefined ? { api_rectify: zone.api_rectify } : {}),
+                  horizon: zoneHorizon,
+                }}
+                canEdit={canEditSettings}
+              />
+            ) : null}
             <ZoneDangerZone
               zoneIdEncoded={encodeURIComponent(zone.id)}
               serverSlug={selected.slug}

--- a/app/api/admin/pdns/zones/[zoneId]/rrsets/route.ts
+++ b/app/api/admin/pdns/zones/[zoneId]/rrsets/route.ts
@@ -4,7 +4,8 @@
  * PATCH - apply one or more RRset changes to a zone.
  *
  * Flow:
- *   1. Permission check (record.* - discriminated per change kind).
+ *   1. Permission check (record.* - discriminated per change kind; the SOA
+ *      and apex-NS RRsets cost soa.update / record.update.apex-ns, #119).
  *   2. Resolve the backend (by `serverSlug` in the body).
  *   3. Fetch the zone via PdnsClient (current RRsets for the audit snapshot).
  *   4. Build a single PATCH body that bundles every change:
@@ -46,6 +47,7 @@ import { deleteRRset, replaceRRset, zonePatchBody, type RRsetPatch } from "@/lib
 import { detectRRsetConflicts } from "@/lib/pdns/rrset-hash";
 import { PdnsError, PdnsNotFoundError } from "@/lib/pdns/errors";
 import { canActOnZone } from "@/lib/rbac/zone-permissions";
+import { protectedRRsetPermission } from "@/lib/rbac/protected-rrsets";
 import { patchRRsetsSchema } from "@/lib/validators/rrsets";
 
 interface RouteContext {
@@ -99,31 +101,53 @@ export async function PATCH(request: Request, context: RouteContext): Promise<Re
       throw new ValidationError("Unknown or disabled PowerDNS backend.");
     }
 
-    // Permission check, per-change. Each action passes if EITHER:
-    //   - the user holds the permission at GLOBAL scope via a role
-    //     assignment (`globalPermissions.has("record.<perm>")`), OR
+    // Permission check, per-change. Each permission passes if EITHER:
+    //   - the user holds it at GLOBAL scope via a role assignment
+    //     (`globalPermissions.has(...)`), OR
     //   - the user holds a zone_grant for THIS (server, zone) that
-    //     includes the permission (`hasZonePermissionViaGrant`).
-    //
-    // We require:
-    //   - record.update OR record.create for upsert (whichever the
-    //     user has; since we can't know without the current state we
-    //     accept either),
-    //   - record.delete for delete.
-    const hasRecordPerm = (perm: "create" | "update" | "delete"): boolean =>
+    //     includes it (`hasZonePermissionViaGrant`).
+    const hasZonePerm = (permission: string): boolean =>
       canActOnZone({
-        hasGlobalPermission: globalPermissions.has(`record.${perm}`),
+        hasGlobalPermission: globalPermissions.has(permission),
         grants: zoneGrants,
         serverId: server.id,
         zoneName,
-        permission: `record.${perm}`,
+        permission,
       });
-    const needsCreateOrUpdate = input.changes.some((c) => c.kind === "upsert");
-    const needsDelete = input.changes.some((c) => c.kind === "delete");
-    if (needsCreateOrUpdate && !hasRecordPerm("create") && !hasRecordPerm("update")) {
+
+    // Two RRsets cost more than `record.*` (#119): the SOA is its own
+    // resource (`soa.update`, INSTEAD of the record permission - it has
+    // its own editor and its own read gate), and the apex NS carries
+    // the zone's delegation (`record.update.apex-ns`, ADDITIONAL to the
+    // record permission). Classified here rather than at the panel that
+    // happens to send the change, so a hand-rolled PATCH answers to the
+    // same rule the SOA panel does. See lib/rbac/protected-rrsets.ts.
+    //
+    // Classify against the SAME normalized name the patch will carry, so
+    // a relative or `@` spelling can't land somewhere the check didn't
+    // look.
+    const classified = input.changes.map((change) => ({
+      kind: change.kind,
+      extra: protectedRRsetPermission(normalizeName(change.name, zoneName), change.type, zoneName),
+    }));
+
+    for (const { extra } of classified) {
+      if (extra !== null && !hasZonePerm(extra)) {
+        throw new ForbiddenError(`Missing ${extra} for this zone.`);
+      }
+    }
+
+    // `soa.update` REPLACES the record permission; every other change,
+    // apex NS included, still needs its `record.*` one.
+    const ordinary = classified.filter((c) => c.extra !== "soa.update");
+    const needsCreateOrUpdate = ordinary.some((c) => c.kind === "upsert");
+    const needsDelete = ordinary.some((c) => c.kind === "delete");
+    // For an upsert we accept create OR update: without the zone's
+    // current state we can't tell which one the change turns out to be.
+    if (needsCreateOrUpdate && !hasZonePerm("record.create") && !hasZonePerm("record.update")) {
       throw new ForbiddenError("Missing record.create or record.update.");
     }
-    if (needsDelete && !hasRecordPerm("delete")) {
+    if (needsDelete && !hasZonePerm("record.delete")) {
       throw new ForbiddenError("Missing record.delete.");
     }
 

--- a/app/api/admin/pdns/zones/[zoneId]/rrsets/route.ts
+++ b/app/api/admin/pdns/zones/[zoneId]/rrsets/route.ts
@@ -106,7 +106,7 @@ export async function PATCH(request: Request, context: RouteContext): Promise<Re
     //     (`globalPermissions.has(...)`), OR
     //   - the user holds a zone_grant for THIS (server, zone) that
     //     includes it (`hasZonePermissionViaGrant`).
-    const hasZonePerm = (permission: string): boolean =>
+    const hasZonePermission = (permission: string): boolean =>
       canActOnZone({
         hasGlobalPermission: globalPermissions.has(permission),
         grants: zoneGrants,
@@ -132,7 +132,7 @@ export async function PATCH(request: Request, context: RouteContext): Promise<Re
     }));
 
     for (const { extra } of classified) {
-      if (extra !== null && !hasZonePerm(extra)) {
+      if (extra !== null && !hasZonePermission(extra)) {
         throw new ForbiddenError(`Missing ${extra} for this zone.`);
       }
     }
@@ -144,10 +144,14 @@ export async function PATCH(request: Request, context: RouteContext): Promise<Re
     const needsDelete = ordinary.some((c) => c.kind === "delete");
     // For an upsert we accept create OR update: without the zone's
     // current state we can't tell which one the change turns out to be.
-    if (needsCreateOrUpdate && !hasZonePerm("record.create") && !hasZonePerm("record.update")) {
+    if (
+      needsCreateOrUpdate &&
+      !hasZonePermission("record.create") &&
+      !hasZonePermission("record.update")
+    ) {
       throw new ForbiddenError("Missing record.create or record.update.");
     }
-    if (needsDelete && !hasZonePerm("record.delete")) {
+    if (needsDelete && !hasZonePermission("record.delete")) {
       throw new ForbiddenError("Missing record.delete.");
     }
 

--- a/docs/07-RBAC.md
+++ b/docs/07-RBAC.md
@@ -87,6 +87,10 @@ Notes worth knowing:
 - **These work as per-zone grants too**, so you can allow `soa.update` on one
   customer's zone without granting it fleet-wide.
 
+[ADR-0023](./adr/0023-zone-authority-permissions.md) records why the SOA is
+modelled as its own resource while the apex NS stays a record with an extra
+cost, and what was rejected on the way there.
+
 A self-service role for a hosting customer therefore looks like:
 
 ```yaml

--- a/docs/07-RBAC.md
+++ b/docs/07-RBAC.md
@@ -15,13 +15,13 @@ Seeded on first boot and protected from deletion. Each builds on the previous -
 the description shown here is the one seeded into the `roles.description`
 column, surfaced verbatim on the Roles list and detail pages.
 
-| Role            | Seeded description                                                                          | Permissions, in addition to the role above…                                                                                 |
-| --------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| **Read Only**   | View access to assigned zones. No changes. Useful for auditors and observers.               | View zones, records, DNSSEC, metadata, teams, users, roles, servers, settings; use templates; manage own API tokens (read). |
-| **Zone Editor** | Edit records on assigned zones. Cannot create or delete zones.                              | Create/update/delete **records**; create/delete own API tokens.                                                             |
-| **Operator**    | Day-to-day zone and record administration within a team. No DNSSEC or member management.    | Create/update/delete/import/export **zones**; write metadata; manage templates.                                             |
-| **Team Owner**  | Full control of a team's zones and members. Cannot manage other teams or app-wide settings. | Configure DNSSEC; manage TSIG + autoprimaries; update team + manage members.                                                |
-| **Super Admin** | Full access to everything: users, roles, servers, settings, audit.                          | Everything: users, roles, teams, servers, settings, audit, OIDC, all API tokens.                                            |
+| Role            | Seeded description                                                                                     | Permissions, in addition to the role above…                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| **Read Only**   | View access to assigned zones. No changes. Useful for auditors and observers.                          | View zones, records, DNSSEC, metadata, teams, users, roles, servers, settings; use templates; manage own API tokens (read). |
+| **Zone Editor** | Edit records on assigned zones. Cannot create or delete zones, change the SOA, or repoint the apex NS. | Create/update/delete **records**; create/delete own API tokens.                                                             |
+| **Operator**    | Day-to-day zone and record administration within a team. No DNSSEC or member management.               | Update the **SOA** + **apex NS**; create/update/delete/import/export **zones**; write metadata; manage templates.           |
+| **Team Owner**  | Full control of a team's zones and members. Cannot manage other teams or app-wide settings.            | Configure DNSSEC; manage TSIG + autoprimaries; update team + manage members.                                                |
+| **Super Admin** | Full access to everything: users, roles, servers, settings, audit.                                     | Everything: users, roles, teams, servers, settings, audit, OIDC, all API tokens.                                            |
 
 The seed asserts Super Admin contains every permission, so a new permission added
 to the codebase is always held by Super Admin. The seeded descriptions are owned
@@ -35,22 +35,65 @@ naturally as "what does this role do?" context for newer operators.
 
 Custom roles are built from these. Names are stable strings (`resource.action`):
 
-| Group            | Permissions                                                                                |
-| ---------------- | ------------------------------------------------------------------------------------------ |
-| Zones            | `zone.read` `zone.create` `zone.update` `zone.delete` `zone.export` `zone.import`          |
-| Records          | `record.read` `record.create` `record.update` `record.delete`                              |
-| DNSSEC           | `dnssec.read` `dnssec.configure`                                                           |
-| Metadata         | `metadata.read` `metadata.write`                                                           |
-| TSIG             | `tsig.read` (list) · `tsig.manage` (create/regenerate/reveal)                              |
-| Autoprimary      | `autoprimary.manage`                                                                       |
-| Templates        | `template.use` `template.manage`                                                           |
-| Users            | `user.read` `user.create` `user.update` `user.delete` `user.disable` `user.reset-password` |
-| Teams            | `team.read` `team.create` `team.update` `team.delete` `team.manage-members`                |
-| Roles            | `role.read` `role.create` `role.update` `role.delete` `role.assign`                        |
-| Servers          | `server.read` `server.create` `server.update` `server.delete`                              |
-| API tokens       | `token.read.own` `token.create.own` `token.delete.own` `token.read.all` `token.delete.all` |
-| Audit & settings | `audit.read` `settings.read` `settings.write`                                              |
-| OIDC             | `oidc.read` `oidc.manage`                                                                  |
+| Group            | Permissions                                                                                            |
+| ---------------- | ------------------------------------------------------------------------------------------------------ |
+| Zones            | `zone.read` `zone.create` `zone.update` `zone.delete` `zone.export` `zone.import` `zone.settings.read` |
+| Records          | `record.read` `record.create` `record.update` `record.delete` `record.update.apex-ns`                  |
+| SOA              | `soa.read` (see the SOA tab) · `soa.update` (edit it)                                                  |
+| DNSSEC           | `dnssec.read` `dnssec.configure`                                                                       |
+| Metadata         | `metadata.read` `metadata.write`                                                                       |
+| TSIG             | `tsig.read` (list) · `tsig.manage` (create/regenerate/reveal)                                          |
+| Autoprimary      | `autoprimary.manage`                                                                                   |
+| Templates        | `template.use` `template.manage`                                                                       |
+| Users            | `user.read` `user.create` `user.update` `user.delete` `user.disable` `user.reset-password`             |
+| Teams            | `team.read` `team.create` `team.update` `team.delete` `team.manage-members`                            |
+| Roles            | `role.read` `role.create` `role.update` `role.delete` `role.assign`                                    |
+| Servers          | `server.read` `server.create` `server.update` `server.delete`                                          |
+| API tokens       | `token.read.own` `token.create.own` `token.delete.own` `token.read.all` `token.delete.all`             |
+| Audit & settings | `audit.read` `settings.read` `settings.write`                                                          |
+| Auth providers   | `auth.read` `auth.manage` (OIDC, SAML, LDAP)                                                           |
+| System           | `system.backup`                                                                                        |
+
+## Splitting record editing from a zone's authority
+
+Three surfaces decide whether a zone works at all, and each answers to its own
+permission rather than riding along with `record.update`. This is what lets you
+hand someone their zone's records without handing them the zone.
+
+| Surface                                                             | Read                 | Write                                       |
+| ------------------------------------------------------------------- | -------------------- | ------------------------------------------- |
+| **SOA tab** - primary NS, responsible mailbox, refresh/retry/expire | `soa.read`           | `soa.update`                                |
+| **Apex NS records** - the zone's delegation                         | `record.read`        | `record.*` **plus** `record.update.apex-ns` |
+| **Zone settings tab** - kind, masters, SOA-EDIT(-API), API-RECTIFY  | `zone.settings.read` | `zone.update`                               |
+
+Notes worth knowing:
+
+- **Tabs disappear, they don't grey out.** Without `soa.read` there is no SOA
+  tab; without `zone.settings.read` there is no Zone settings tab, and a direct
+  `?tab=soa` / `?tab=settings` link falls back to Records. (A user holding
+  `zone.delete` still gets the settings tab, because the Danger Zone lives
+  there - the settings panel itself stays hidden.)
+- **`soa.update` replaces the record permission, it doesn't add to it.** The SOA
+  is its own resource: `soa.update` alone is enough to edit it, and no amount of
+  `record.*` substitutes for it. `record.update.apex-ns` works the other way -
+  it is an _extra_ requirement layered on top of the matching `record.create` /
+  `record.update` / `record.delete`.
+- **NS below the apex is an ordinary record.** A child delegation
+  (`sub.example.com. NS`) is content this zone serves, so `record.*` covers it.
+  Only the apex NS is protected.
+- **The gate is server-side.** Every write lands on the same RRset route
+  whichever panel sent it, and the route classifies each change by its
+  normalized name - a hand-rolled `PATCH` gets the same answer the UI does.
+- **These work as per-zone grants too**, so you can allow `soa.update` on one
+  customer's zone without granting it fleet-wide.
+
+A self-service role for a hosting customer therefore looks like:
+
+```yaml
+permissions: [zone.read, record.read, record.create, record.update, record.delete, dnssec.read]
+```
+
+Records: yes. SOA, apex NS, zone settings: not shown, not writable.
 
 ## Scopes
 

--- a/docs/09-UPGRADING.md
+++ b/docs/09-UPGRADING.md
@@ -37,6 +37,60 @@ half-migrated schema; fix the cause and restart.
 
 ## Version-specific notes
 
+### Upgrading to 1.5.6 (from 1.5.5)
+
+**No schema change**, but there IS a migration -
+`0007_granular_zone_permissions_backfill` is data-only: it rewrites permission
+lists, adds no tables and no columns. Pull and recreate:
+
+```sh
+docker compose pull
+docker compose up -d
+docker compose logs app | grep migrate   # expect 0007_… in the applied list
+```
+
+**What changed.** Editing a zone's records and editing the zone itself are no
+longer the same permission. `soa.read` / `soa.update` gate the SOA tab,
+`zone.settings.read` gates the Zone settings tab (writing it stays
+`zone.update`), and `record.update.apex-ns` is now required - on top of the
+matching `record.*` - to write the zone's apex NS. Missing a read permission
+hides the tab outright. See
+[RBAC → Splitting record editing from a zone's authority](./07-RBAC.md#splitting-record-editing-from-a-zones-authority).
+
+**Your own roles keep working.** The migration backfills every operator-defined
+role, zone grant and API token that held the permission which used to imply the
+new one:
+
+| Held before          | Gains                            |
+| -------------------- | -------------------------------- |
+| `zone.read`          | `soa.read`, `zone.settings.read` |
+| `record.update`      | `soa.update`                     |
+| any `record.*` write | `record.update.apex-ns`          |
+
+An API token with an EMPTY scope list is untouched - empty already means
+"everything the user currently holds". Nothing you have configured loses access
+on upgrade; tightening a role is now an edit you make deliberately, by
+unticking `soa.update` (and `record.update.apex-ns`, and `zone.settings.read`)
+on it.
+
+**The seeded system roles DO change**, because they are re-upserted from
+`lib/rbac/default-roles.ts` on every boot:
+
+- **Zone Editor** loses `soa.update` and `record.update.apex-ns`. It keeps
+  `soa.read` and `zone.settings.read`, so both tabs stay visible, read-only.
+  This is the role to assign a hosting customer.
+- **Operator** and above gain both, alongside the `zone.update` they already
+  held.
+
+If you rely on Zone Editor being able to rewrite the SOA, copy it to a custom
+role with `soa.update` ticked and reassign - system-role permissions can't be
+edited in place by design.
+
+**Rolling back.** 1.5.5 has the same schema, so a downgrade is a straight image
+swap. The backfilled permissions simply become strings 1.5.5 doesn't recognise
+(the ability builder logs and skips unknown names), and the old implicit
+behaviour returns.
+
 ### Upgrading to 1.5.5 (from 1.5.4)
 
 **No schema change** - nothing to watch in the boot log beyond the usual

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -142,8 +142,8 @@ can jump straight into the code that owns each feature.
 ### 2.1 Permissions vocabulary
 
 - **What.** A typed list of ~60 permission strings spanning every action surface: zones,
-  records, DNSSEC, metadata, TSIG, autoprimaries, templates, users, teams, roles, PDNS
-  servers, API tokens, audit, settings, OIDC providers.
+  records, SOA, DNSSEC, metadata, TSIG, autoprimaries, templates, users, teams, roles, PDNS
+  servers, API tokens, audit, settings, auth providers.
 - **Where.** `lib/rbac/permissions.ts`.
 - **How.** Use a permission in a route via `requireUser({ can: "zone.create" })` or in a page
   component via `requireUserForPage({ can: "zone.create" })`. The CASL ability builder
@@ -164,7 +164,24 @@ can jump straight into the code that owns each feature.
   <img src="../screenshots/light/roles.png" alt="Roles" width="720" />
 </picture>
 
-### 2.3 Scoped assignments
+### 2.3 Zone-authority permissions
+
+- **What.** The SOA, the apex NS RRset, and the zone-settings object are held apart from
+  ordinary record editing, so a role can be given a zone's records without being given the
+  zone. `soa.read` / `soa.update` gate the SOA tab; `record.update.apex-ns` is an extra
+  requirement on top of `record.*` for writing the apex NS; `zone.settings.read` gates the
+  Zone settings tab, whose writes stay on `zone.update`. Missing the read permission removes
+  the tab outright rather than greying it out.
+- **Where.** `lib/rbac/protected-rrsets.ts` (the classifier both sides share),
+  `app/api/admin/pdns/zones/[zoneId]/rrsets/route.ts`,
+  `app/api/admin/pdns/zones/[zoneId]/settings/route.ts`,
+  `app/(app)/zones/[zoneId]/page.tsx`.
+- **How.** The RRset route classifies every change by its normalized name before touching
+  PowerDNS, so any client - the SOA panel, the record editor, or a hand-rolled `PATCH` - gets
+  the same answer. The permissions work as per-zone grants too. See
+  [docs/07-RBAC.md](./07-RBAC.md#splitting-record-editing-from-a-zones-authority).
+
+### 2.4 Scoped assignments
 
 - **What.** Every assignment is `(user, role, scope)` where scope is one of
   `global` / `team:<id>` / `zone:<fqdn>` / `server:<id>`. The CASL builder walks scopes at

--- a/docs/adr/0023-zone-authority-permissions.md
+++ b/docs/adr/0023-zone-authority-permissions.md
@@ -1,0 +1,132 @@
+# ADR 0023 - Zone authority is a separate permission from zone records
+
+- **Status:** Accepted
+- **Date:** 2026-08-27
+- **Deciders:** @jseifeddine
+
+## Context
+
+The permission vocabulary modelled a zone as two things: the zone object (`zone.*`) and the records
+inside it (`record.*`). That split does not survive contact with the case that prompted this: a
+hosting provider giving each customer their own zone, so the customer can point an A record at a new
+box without filing a ticket (#119).
+
+Three surfaces sat on the wrong side of the line.
+
+The **SOA** is an RRset, so it answered to `record.update` like any other. It is also the record that
+decides who is authoritative for the zone and how often every secondary refreshes, retries, and
+expires it - a customer who edits it can stall transfers or expire the zone off its secondaries.
+
+The **apex NS** RRset is the zone's delegation. It too was an ordinary record, so `record.delete`
+removed it and took the zone off the internet, more completely than any SOA mistake would.
+
+The **Zone settings** tab - kind, masters, `SOA-EDIT`, `SOA-EDIT-API`, `API-RECTIFY` - had no read
+permission at all. It rendered for anyone who could open the zone, which is anyone with `zone.read`.
+Its writes did answer to `zone.update`, but the page enabled the panel's inputs on `record.update`,
+so a record editor got a fully interactive form whose Save then 403'd.
+
+There was no permission an operator could withhold to close any of this. `record.update` was
+load-bearing for the customer's actual job, and everything above rode along with it.
+
+## Decision
+
+We will model a zone's **authority** - the SOA, the apex NS, and the zone-settings object - as
+distinct from its **records**, with four permissions:
+
+| Permission              | Gates                                                  |
+| ----------------------- | ------------------------------------------------------ |
+| `soa.read`              | The SOA tab.                                           |
+| `soa.update`            | Every write to the SOA RRset.                          |
+| `zone.settings.read`    | The Zone settings tab. Writing it stays `zone.update`. |
+| `record.update.apex-ns` | Writing the apex NS RRset.                             |
+
+Three rules make them compose predictably:
+
+1. **The SOA is its own resource.** `soa.update` _replaces_ the `record.*` requirement rather than
+   adding to it - `soa.update` alone edits the SOA, and no amount of `record.*` substitutes for it.
+   `Soa` joins the `SubjectType` union in `lib/rbac/ability.ts` alongside `Dnssec` and `Metadata`,
+   which are likewise facets of a zone rather than tables.
+2. **The apex NS stays a record.** `record.update.apex-ns` is an _additional_ requirement layered on
+   top of the matching `record.create` / `record.update` / `record.delete`. NS below the apex is
+   content the zone serves, not the zone's own standing, so `record.*` alone covers it.
+3. **A missing read permission removes the surface, not just its Save button.** The tab is not
+   rendered and a direct `?tab=` link falls back to Records.
+
+One pure module, `lib/rbac/protected-rrsets.ts`, answers "does writing this (name, type) cost more
+than `record.*`?". The RRset route runs it over every change **against the normalized name the patch
+will carry**, before anything reaches PowerDNS; the record editor imports the same function to lock
+apex NS rows. It carries no `import "server-only"` precisely so the client component can share it.
+
+## Rationale
+
+Putting the classifier in one pure function is the load-bearing part. The alternative - each panel
+deciding what it is allowed to send - is how a UI lock and a server check drift apart, and the drift
+is always in the permissive direction because the UI is what gets tested by hand. A shared predicate
+run on the server means a hand-rolled `PATCH` gets exactly what the UI gets, and the editor's lock
+cannot claim more or less than the route enforces.
+
+Modelling the SOA as its own resource rather than as `record.update.soa` is the trade we thought
+hardest about. `record.update.soa` would have kept everything under one prefix and read as a
+narrowing of `record.update`. But it would have made the SOA permission _additive_, so editing the
+SOA would require `record.update` as well - and a role whose whole point is "may fix the SOA, may
+not touch records" would be unexpressible. Making it a resource costs a `SubjectType` entry and a
+line of documentation about the asymmetry with `record.update.apex-ns`; that asymmetry is the honest
+shape of the domain, since one of these is a record and the other is the zone's identity.
+
+The downside we accept: the vocabulary now has two composition rules instead of one, and an operator
+reading the checkbox list cannot tell which is which. Documentation carries that weight
+(`docs/07-RBAC.md`, `provisioning.example.yaml`), and the permission picker is grouped by resource,
+so `soa.*` at least appears as its own box.
+
+## Alternatives considered
+
+- **A UI-only fix - hide the tabs, keep the permissions.** Was what the report literally asked for.
+  Rejected: the RRset route would still have accepted a SOA write from anyone with `record.update`,
+  so the guarantee would have been cosmetic. A permission an operator can reason about has to be one
+  the server enforces.
+- **`record.update.soa`, additive like the apex-NS one.** Rejected for the reason above - it makes
+  "may fix the SOA, may not touch records" unexpressible, and that separation is the entire point.
+- **Deny SOA and apex-NS writes to everyone below Operator, with no new permission.** Simpler, and
+  needs no migration. Rejected: it hard-codes one org's policy. Operators who deliberately let a
+  Zone Editor set the SOA would have had no way back, and per-zone grants could not express "this
+  one customer may".
+- **A boolean on the role ("may edit zone authority").** Rejected: it does not compose with
+  `zone_grants`, which store literal permission strings, so it would have been global-only - exactly
+  the granularity the report was asking us to escape.
+- **Reuse `metadata.write` for the settings tab.** Rejected: `SOA-EDIT` and friends are written
+  through `PUT /zones/{id}`, not the metadata endpoint (PowerDNS 4.9 rejects them there), and the
+  two are separately grantable today. Conflating them would silently widen `metadata.write`.
+
+## Consequences
+
+**Easier.** A self-service role is now `[zone.read, record.read, record.create, record.update,
+record.delete, dnssec.read]` and nothing else - records visible and writable, the zone's authority
+neither shown nor writable. All four permissions are grantable per-zone, so `soa.update` can be
+opened on one customer's zone without going fleet-wide.
+
+**Harder.** Two composition rules to explain instead of one. And every future "protected RRset" must
+be added to `protected-rrsets.ts` rather than to a route - the right place, but a less obvious one
+for someone patching a single handler. `DNSKEY` and `CDS`/`CDNSKEY` are the likely next candidates
+if operators ask, and they should follow the apex-NS shape, not the SOA one.
+
+**Upgrade.** Behaviour is preserved rather than tightened by default: migration
+`0007_granular_zone_permissions_backfill` (data-only, both dialects) gives every operator-defined
+role, zone grant and API token the new permission implied by the one it already held. Tightening is
+then an opt-in edit. The seeded system roles do change, because the seed re-upserts them on every
+boot: Zone Editor keeps both read permissions and loses both writes, which move to Operator and
+above. That is a deliberate change of what the seeded role means, and it is the one thing an
+operator has to read the release notes for.
+
+**Not covered.** Zone creation and zonefile import write an SOA and apex NS as part of creating a
+whole zone; they stay on `zone.create` / `zone.import`. Splitting those would gate the creation of a
+zone on permission to edit a zone that does not exist yet.
+
+## References
+
+- Discussion [#119](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/discussions/119) -
+  the report, and the self-service hosting scenario behind it.
+- [ADR 0004](./0004-three-layer-architecture.md) - the auth → RBAC → business-logic ordering this
+  check sits inside.
+- [ADR 0014](./0014-backend-capability-model.md) - per-zone authority as the app already models it.
+- `docs/07-RBAC.md` § Splitting record editing from a zone's authority.
+- RFC 1035 § 3.3.13 (SOA), RFC 1034 § 4.2.1 (apex NS as the zone's delegation).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,6 +43,7 @@ durability, not exhaustiveness.
 | 0020 | [LDAP authentication architecture](./0020-ldap-architecture.md)                                                  | Accepted                   |
 | 0021 | [SAML 2.0 service-provider architecture](./0021-saml-architecture.md)                                            | Accepted                   |
 | 0022 | [Zone horizons: app-side split-horizon classification](./0022-zone-horizons.md)                                  | Accepted                   |
+| 0023 | [Zone authority is a separate permission from zone records](./0023-zone-authority-permissions.md)                | Accepted                   |
 
 > **Numbering note:** there is no ADR 0003 - that number was reserved for a decision that was
 > withdrawn before it was written. The gap is intentional; numbers are never reused.

--- a/drizzle-sqlite/0007_granular_zone_permissions_backfill.sql
+++ b/drizzle-sqlite/0007_granular_zone_permissions_backfill.sql
@@ -1,0 +1,96 @@
+-- Granular zone permissions (#119) - data-only backfill, no schema change.
+-- SQLite mirror of drizzle/0007_granular_zone_permissions_backfill.sql; see
+-- that file for why each rule exists.
+--
+--   soa.read              was implied by zone.read
+--   zone.settings.read    was implied by zone.read
+--   soa.update            was implied by record.update
+--   record.update.apex-ns was implied by record.create/update/delete
+--
+-- System roles are excluded: `scripts/seed.ts` re-upserts them from
+-- `lib/rbac/default-roles.ts` on every boot, and 1.5.6 deliberately changes
+-- what Zone Editor grants.
+
+-- === roles (operator-defined only) =========================================
+UPDATE "roles" SET "permissions" = json_insert("permissions", '$[#]', 'soa.read')
+WHERE "is_system" = 0
+  AND EXISTS (SELECT 1 FROM json_each("roles"."permissions") WHERE "value" = 'zone.read')
+  AND NOT EXISTS (SELECT 1 FROM json_each("roles"."permissions") WHERE "value" = 'soa.read');
+--> statement-breakpoint
+
+UPDATE "roles" SET "permissions" = json_insert("permissions", '$[#]', 'zone.settings.read')
+WHERE "is_system" = 0
+  AND EXISTS (SELECT 1 FROM json_each("roles"."permissions") WHERE "value" = 'zone.read')
+  AND NOT EXISTS (SELECT 1 FROM json_each("roles"."permissions") WHERE "value" = 'zone.settings.read');
+--> statement-breakpoint
+
+UPDATE "roles" SET "permissions" = json_insert("permissions", '$[#]', 'soa.update')
+WHERE "is_system" = 0
+  AND EXISTS (SELECT 1 FROM json_each("roles"."permissions") WHERE "value" = 'record.update')
+  AND NOT EXISTS (SELECT 1 FROM json_each("roles"."permissions") WHERE "value" = 'soa.update');
+--> statement-breakpoint
+
+UPDATE "roles" SET "permissions" = json_insert("permissions", '$[#]', 'record.update.apex-ns')
+WHERE "is_system" = 0
+  AND (
+    EXISTS (SELECT 1 FROM json_each("roles"."permissions") WHERE "value" = 'record.create')
+    OR EXISTS (SELECT 1 FROM json_each("roles"."permissions") WHERE "value" = 'record.update')
+    OR EXISTS (SELECT 1 FROM json_each("roles"."permissions") WHERE "value" = 'record.delete')
+  )
+  AND NOT EXISTS (SELECT 1 FROM json_each("roles"."permissions") WHERE "value" = 'record.update.apex-ns');
+--> statement-breakpoint
+
+-- === zone_grants ============================================================
+UPDATE "zone_grants" SET "permissions" = json_insert("permissions", '$[#]', 'soa.read')
+WHERE EXISTS (SELECT 1 FROM json_each("zone_grants"."permissions") WHERE "value" = 'zone.read')
+  AND NOT EXISTS (SELECT 1 FROM json_each("zone_grants"."permissions") WHERE "value" = 'soa.read');
+--> statement-breakpoint
+
+UPDATE "zone_grants" SET "permissions" = json_insert("permissions", '$[#]', 'zone.settings.read')
+WHERE EXISTS (SELECT 1 FROM json_each("zone_grants"."permissions") WHERE "value" = 'zone.read')
+  AND NOT EXISTS (SELECT 1 FROM json_each("zone_grants"."permissions") WHERE "value" = 'zone.settings.read');
+--> statement-breakpoint
+
+UPDATE "zone_grants" SET "permissions" = json_insert("permissions", '$[#]', 'soa.update')
+WHERE EXISTS (SELECT 1 FROM json_each("zone_grants"."permissions") WHERE "value" = 'record.update')
+  AND NOT EXISTS (SELECT 1 FROM json_each("zone_grants"."permissions") WHERE "value" = 'soa.update');
+--> statement-breakpoint
+
+UPDATE "zone_grants" SET "permissions" = json_insert("permissions", '$[#]', 'record.update.apex-ns')
+WHERE (
+    EXISTS (SELECT 1 FROM json_each("zone_grants"."permissions") WHERE "value" = 'record.create')
+    OR EXISTS (SELECT 1 FROM json_each("zone_grants"."permissions") WHERE "value" = 'record.update')
+    OR EXISTS (SELECT 1 FROM json_each("zone_grants"."permissions") WHERE "value" = 'record.delete')
+  )
+  AND NOT EXISTS (SELECT 1 FROM json_each("zone_grants"."permissions") WHERE "value" = 'record.update.apex-ns');
+--> statement-breakpoint
+
+-- === api_tokens =============================================================
+-- An EMPTY scopes array means "everything the user currently has" and must
+-- stay empty, hence the json_array_length guard.
+UPDATE "api_tokens" SET "scopes" = json_insert("scopes", '$[#]', 'soa.read')
+WHERE json_array_length("scopes") > 0
+  AND EXISTS (SELECT 1 FROM json_each("api_tokens"."scopes") WHERE "value" = 'zone.read')
+  AND NOT EXISTS (SELECT 1 FROM json_each("api_tokens"."scopes") WHERE "value" = 'soa.read');
+--> statement-breakpoint
+
+UPDATE "api_tokens" SET "scopes" = json_insert("scopes", '$[#]', 'zone.settings.read')
+WHERE json_array_length("scopes") > 0
+  AND EXISTS (SELECT 1 FROM json_each("api_tokens"."scopes") WHERE "value" = 'zone.read')
+  AND NOT EXISTS (SELECT 1 FROM json_each("api_tokens"."scopes") WHERE "value" = 'zone.settings.read');
+--> statement-breakpoint
+
+UPDATE "api_tokens" SET "scopes" = json_insert("scopes", '$[#]', 'soa.update')
+WHERE json_array_length("scopes") > 0
+  AND EXISTS (SELECT 1 FROM json_each("api_tokens"."scopes") WHERE "value" = 'record.update')
+  AND NOT EXISTS (SELECT 1 FROM json_each("api_tokens"."scopes") WHERE "value" = 'soa.update');
+--> statement-breakpoint
+
+UPDATE "api_tokens" SET "scopes" = json_insert("scopes", '$[#]', 'record.update.apex-ns')
+WHERE json_array_length("scopes") > 0
+  AND (
+    EXISTS (SELECT 1 FROM json_each("api_tokens"."scopes") WHERE "value" = 'record.create')
+    OR EXISTS (SELECT 1 FROM json_each("api_tokens"."scopes") WHERE "value" = 'record.update')
+    OR EXISTS (SELECT 1 FROM json_each("api_tokens"."scopes") WHERE "value" = 'record.delete')
+  )
+  AND NOT EXISTS (SELECT 1 FROM json_each("api_tokens"."scopes") WHERE "value" = 'record.update.apex-ns');

--- a/drizzle-sqlite/meta/0007_snapshot.json
+++ b/drizzle-sqlite/meta/0007_snapshot.json
@@ -1,0 +1,2856 @@
+{
+  "id": "22be60ea-dc71-4911-8490-397dbe11b8b8",
+  "prevId": "a93c82ef-1e7a-4149-a708-e12e2c0b0e73",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totp_secret_encrypted": {
+          "name": "totp_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mfa_required": {
+          "name": "mfa_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webauthn_credentials": {
+          "name": "webauthn_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_login_count": {
+          "name": "failed_login_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_login_ip": {
+          "name": "last_login_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash_updated_at": {
+          "name": "password_hash_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_lower_idx": {
+          "name": "users_email_lower_idx",
+          "columns": [
+            "lower(\"email\")"
+          ],
+          "isUnique": true
+        },
+        "users_disabled_idx": {
+          "name": "users_disabled_idx",
+          "columns": [
+            "disabled_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mail": {
+          "name": "mail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "teams_slug_idx": {
+          "name": "teams_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "teams_name_idx": {
+          "name": "teams_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_members": {
+      "name": "team_members",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_role": {
+          "name": "team_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_members_team_idx": {
+          "name": "team_members_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_user_id_team_id_pk": {
+          "columns": [
+            "user_id",
+            "team_id"
+          ],
+          "name": "team_members_user_id_team_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "team_members_team_role_check": {
+          "name": "team_members_team_role_check",
+          "value": "\"team_members\".\"team_role\" IN ('owner','member')"
+        }
+      }
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "csrf_secret": {
+          "name": "csrf_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oidc_end_session_url": {
+          "name": "oidc_end_session_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_id_token": {
+          "name": "oidc_id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_client_id": {
+          "name": "oidc_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derived_permissions": {
+          "name": "derived_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "oidc_refresh_token_encrypted": {
+          "name": "oidc_refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idp_provider_type": {
+          "name": "idp_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idp_provider_slug": {
+          "name": "idp_provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "requires_mfa": {
+          "name": "requires_mfa",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "roles_slug_idx": {
+          "name": "roles_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "roles_system_idx": {
+          "name": "roles_system_idx",
+          "columns": [
+            "is_system"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "role_assignments": {
+      "name": "role_assignments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "role_assignments_user_idx": {
+          "name": "role_assignments_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "role_assignments_role_idx": {
+          "name": "role_assignments_role_idx",
+          "columns": [
+            "role_id"
+          ],
+          "isUnique": false
+        },
+        "role_assignments_scope_idx": {
+          "name": "role_assignments_scope_idx",
+          "columns": [
+            "scope_type",
+            "scope_id"
+          ],
+          "isUnique": false
+        },
+        "role_assignments_unique_idx": {
+          "name": "role_assignments_unique_idx",
+          "columns": [
+            "user_id",
+            "role_id",
+            "scope_type",
+            "scope_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "role_assignments_user_id_users_id_fk": {
+          "name": "role_assignments_user_id_users_id_fk",
+          "tableFrom": "role_assignments",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "role_assignments_role_id_roles_id_fk": {
+          "name": "role_assignments_role_id_roles_id_fk",
+          "tableFrom": "role_assignments",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "tableTo": "roles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "role_assignments_created_by_users_id_fk": {
+          "name": "role_assignments_created_by_users_id_fk",
+          "tableFrom": "role_assignments",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "role_assignments_scope_type_check": {
+          "name": "role_assignments_scope_type_check",
+          "value": "\"role_assignments\".\"scope_type\" IN ('global','team','zone','server')"
+        }
+      }
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_user_idx": {
+          "name": "api_tokens_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "api_tokens_prefix_idx": {
+          "name": "api_tokens_prefix_idx",
+          "columns": [
+            "prefix"
+          ],
+          "isUnique": true
+        },
+        "api_tokens_team_idx": {
+          "name": "api_tokens_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "api_tokens_team_id_teams_id_fk": {
+          "name": "api_tokens_team_id_teams_id_fk",
+          "tableFrom": "api_tokens",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_ts_idx": {
+          "name": "audit_log_ts_idx",
+          "columns": [
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            "actor_type",
+            "actor_id"
+          ],
+          "isUnique": false
+        },
+        "audit_log_resource_idx": {
+          "name": "audit_log_resource_idx",
+          "columns": [
+            "resource_type",
+            "resource_id"
+          ],
+          "isUnique": false
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "audit_log_actor_type_check": {
+          "name": "audit_log_actor_type_check",
+          "value": "\"audit_log\".\"actor_type\" IN ('user','token','system')"
+        }
+      }
+    },
+    "pdns_clusters": {
+      "name": "pdns_clusters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "write_strategy": {
+          "name": "write_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'round_robin'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pdns_clusters_slug_unique": {
+          "name": "pdns_clusters_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pdns_clusters_created_by_users_id_fk": {
+          "name": "pdns_clusters_created_by_users_id_fk",
+          "tableFrom": "pdns_clusters",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "pdns_clusters_write_strategy_check": {
+          "name": "pdns_clusters_write_strategy_check",
+          "value": "\"pdns_clusters\".\"write_strategy\" IN ('round_robin','lowest_latency','random','least_load')"
+        }
+      }
+    },
+    "pdns_servers": {
+      "name": "pdns_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'localhost'"
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_cache": {
+          "name": "version_cache",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "advertised_addresses": {
+          "name": "advertised_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "write_mode": {
+          "name": "write_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pdns_servers_slug_idx": {
+          "name": "pdns_servers_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "pdns_servers_default_idx": {
+          "name": "pdns_servers_default_idx",
+          "columns": [
+            "is_default"
+          ],
+          "isUnique": false
+        },
+        "pdns_servers_disabled_idx": {
+          "name": "pdns_servers_disabled_idx",
+          "columns": [
+            "disabled_at"
+          ],
+          "isUnique": false
+        },
+        "pdns_servers_cluster_id_idx": {
+          "name": "pdns_servers_cluster_id_idx",
+          "columns": [
+            "cluster_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pdns_servers_cluster_id_pdns_clusters_id_fk": {
+          "name": "pdns_servers_cluster_id_pdns_clusters_id_fk",
+          "tableFrom": "pdns_servers",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "tableTo": "pdns_clusters",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "pdns_servers_created_by_users_id_fk": {
+          "name": "pdns_servers_created_by_users_id_fk",
+          "tableFrom": "pdns_servers",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metric_samples": {
+      "name": "metric_samples",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sampled_at": {
+          "name": "sampled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zone_count": {
+          "name": "zone_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_p50_ms": {
+          "name": "latency_p50_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_p95_ms": {
+          "name": "latency_p95_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_sessions": {
+          "name": "active_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "metric_samples_server_time_idx": {
+          "name": "metric_samples_server_time_idx",
+          "columns": [
+            "server_id",
+            "sampled_at"
+          ],
+          "isUnique": false
+        },
+        "metric_samples_time_idx": {
+          "name": "metric_samples_time_idx",
+          "columns": [
+            "sampled_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "backend_advisories": {
+      "name": "backend_advisories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backend_id": {
+          "name": "backend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "backend_advisories_backend_code_idx": {
+          "name": "backend_advisories_backend_code_idx",
+          "columns": [
+            "backend_id",
+            "code"
+          ],
+          "isUnique": true
+        },
+        "backend_advisories_backend_idx": {
+          "name": "backend_advisories_backend_idx",
+          "columns": [
+            "backend_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "backend_advisories_backend_id_pdns_servers_id_fk": {
+          "name": "backend_advisories_backend_id_pdns_servers_id_fk",
+          "tableFrom": "backend_advisories",
+          "columnsFrom": [
+            "backend_id"
+          ],
+          "tableTo": "pdns_servers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_updated_by_users_id_fk": {
+          "name": "settings_updated_by_users_id_fk",
+          "tableFrom": "settings",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oidc_providers": {
+      "name": "oidc_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret_encrypted": {
+          "name": "client_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openid profile email'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'name'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "require_email_verified": {
+          "name": "require_email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "discovery_cache": {
+          "name": "discovery_cache",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claim_groups": {
+          "name": "claim_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'groups'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oidc_providers_slug_idx": {
+          "name": "oidc_providers_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oidc_providers_created_by_users_id_fk": {
+          "name": "oidc_providers_created_by_users_id_fk",
+          "tableFrom": "oidc_providers",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saml_providers": {
+      "name": "saml_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_entity_id": {
+          "name": "idp_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_sso_url": {
+          "name": "idp_sso_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_slo_url": {
+          "name": "idp_slo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idp_signing_cert": {
+          "name": "idp_signing_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sp_signing_key_encrypted": {
+          "name": "sp_signing_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sp_signing_cert": {
+          "name": "sp_signing_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sp_encryption_key_encrypted": {
+          "name": "sp_encryption_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sp_encryption_cert": {
+          "name": "sp_encryption_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_signed_response": {
+          "name": "require_signed_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "require_encrypted_assertion": {
+          "name": "require_encrypted_assertion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "signature_algorithm": {
+          "name": "signature_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'sha256'"
+        },
+        "name_id_format": {
+          "name": "name_id_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'name'"
+        },
+        "claim_groups": {
+          "name": "claim_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'groups'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "saml_providers_slug_idx": {
+          "name": "saml_providers_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "saml_providers_created_by_users_id_fk": {
+          "name": "saml_providers_created_by_users_id_fk",
+          "tableFrom": "saml_providers",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ldap_providers": {
+      "name": "ldap_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_tls": {
+          "name": "start_tls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bind_password_encrypted": {
+          "name": "bind_password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_search_base": {
+          "name": "user_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_search_filter": {
+          "name": "user_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'(|(uid={{username}})(sAMAccountName={{username}})(mail={{username}}))'"
+        },
+        "group_search_base": {
+          "name": "group_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_search_filter": {
+          "name": "group_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_attr": {
+          "name": "group_attr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'memberOf'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mail'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'displayName'"
+        },
+        "tls_ca_cert": {
+          "name": "tls_ca_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ldap_providers_slug_idx": {
+          "name": "ldap_providers_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ldap_providers_created_by_users_id_fk": {
+          "name": "ldap_providers_created_by_users_id_fk",
+          "tableFrom": "ldap_providers",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_provider_slugs": {
+      "name": "auth_provider_slugs",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "zone_templates": {
+      "name": "zone_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "soa_ttl": {
+          "name": "soa_ttl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3600
+        },
+        "soa_refresh": {
+          "name": "soa_refresh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3600
+        },
+        "soa_retry": {
+          "name": "soa_retry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 900
+        },
+        "soa_expire": {
+          "name": "soa_expire",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 604800
+        },
+        "soa_minimum": {
+          "name": "soa_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3600
+        },
+        "nameservers": {
+          "name": "nameservers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "records": {
+          "name": "records",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Native'"
+        },
+        "soa_edit": {
+          "name": "soa_edit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "soa_edit_api": {
+          "name": "soa_edit_api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_rectify": {
+          "name": "api_rectify",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "default_for_primary_ids": {
+          "name": "default_for_primary_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "zone_templates_slug_idx": {
+          "name": "zone_templates_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "zone_templates_created_by_users_id_fk": {
+          "name": "zone_templates_created_by_users_id_fk",
+          "tableFrom": "zone_templates",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "zone_grants": {
+      "name": "zone_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "zone_grants_user_idx": {
+          "name": "zone_grants_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "zone_grants_team_idx": {
+          "name": "zone_grants_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "zone_grants_zone_idx": {
+          "name": "zone_grants_zone_idx",
+          "columns": [
+            "server_id",
+            "zone_name"
+          ],
+          "isUnique": false
+        },
+        "zone_grants_user_unique_idx": {
+          "name": "zone_grants_user_unique_idx",
+          "columns": [
+            "user_id",
+            "server_id",
+            "zone_name"
+          ],
+          "where": "\"zone_grants\".\"user_id\" IS NOT NULL",
+          "isUnique": true
+        },
+        "zone_grants_team_unique_idx": {
+          "name": "zone_grants_team_unique_idx",
+          "columns": [
+            "team_id",
+            "server_id",
+            "zone_name"
+          ],
+          "where": "\"zone_grants\".\"team_id\" IS NOT NULL",
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "zone_grants_user_id_users_id_fk": {
+          "name": "zone_grants_user_id_users_id_fk",
+          "tableFrom": "zone_grants",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "zone_grants_team_id_teams_id_fk": {
+          "name": "zone_grants_team_id_teams_id_fk",
+          "tableFrom": "zone_grants",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "zone_grants_server_id_pdns_servers_id_fk": {
+          "name": "zone_grants_server_id_pdns_servers_id_fk",
+          "tableFrom": "zone_grants",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "tableTo": "pdns_servers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "zone_grants_created_by_users_id_fk": {
+          "name": "zone_grants_created_by_users_id_fk",
+          "tableFrom": "zone_grants",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "zone_grants_principal_check": {
+          "name": "zone_grants_principal_check",
+          "value": "(\"zone_grants\".\"user_id\" IS NULL) <> (\"zone_grants\".\"team_id\" IS NULL)"
+        }
+      }
+    },
+    "zone_horizons": {
+      "name": "zone_horizons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "horizon": {
+          "name": "horizon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "zone_horizons_server_unique_idx": {
+          "name": "zone_horizons_server_unique_idx",
+          "columns": [
+            "server_id",
+            "zone_name"
+          ],
+          "where": "\"zone_horizons\".\"server_id\" IS NOT NULL",
+          "isUnique": true
+        },
+        "zone_horizons_cluster_unique_idx": {
+          "name": "zone_horizons_cluster_unique_idx",
+          "columns": [
+            "cluster_id",
+            "zone_name"
+          ],
+          "where": "\"zone_horizons\".\"cluster_id\" IS NOT NULL",
+          "isUnique": true
+        },
+        "zone_horizons_zone_idx": {
+          "name": "zone_horizons_zone_idx",
+          "columns": [
+            "zone_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "zone_horizons_server_id_pdns_servers_id_fk": {
+          "name": "zone_horizons_server_id_pdns_servers_id_fk",
+          "tableFrom": "zone_horizons",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "tableTo": "pdns_servers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "zone_horizons_cluster_id_pdns_clusters_id_fk": {
+          "name": "zone_horizons_cluster_id_pdns_clusters_id_fk",
+          "tableFrom": "zone_horizons",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "tableTo": "pdns_clusters",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "zone_horizons_created_by_users_id_fk": {
+          "name": "zone_horizons_created_by_users_id_fk",
+          "tableFrom": "zone_horizons",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "zone_horizons_scope_check": {
+          "name": "zone_horizons_scope_check",
+          "value": "(\"zone_horizons\".\"server_id\" IS NULL) <> (\"zone_horizons\".\"cluster_id\" IS NULL)"
+        },
+        "zone_horizons_horizon_check": {
+          "name": "zone_horizons_horizon_check",
+          "value": "\"zone_horizons\".\"horizon\" IN ('public', 'internal')"
+        }
+      }
+    },
+    "pdns_requests": {
+      "name": "pdns_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_slug": {
+          "name": "server_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "op": {
+          "name": "op",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pdns_requests_request_id_idx": {
+          "name": "pdns_requests_request_id_idx",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "pdns_requests_ts_idx": {
+          "name": "pdns_requests_ts_idx",
+          "columns": [
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "pdns_requests_server_id_idx": {
+          "name": "pdns_requests_server_id_idx",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pdns_requests_server_id_pdns_servers_id_fk": {
+          "name": "pdns_requests_server_id_pdns_servers_id_fk",
+          "tableFrom": "pdns_requests",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "tableTo": "pdns_servers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pdns_server_stats": {
+      "name": "pdns_server_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "map_value": {
+          "name": "map_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pdns_server_stats_server_ts_idx": {
+          "name": "pdns_server_stats_server_ts_idx",
+          "columns": [
+            "server_id",
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "pdns_server_stats_server_name_ts_idx": {
+          "name": "pdns_server_stats_server_name_ts_idx",
+          "columns": [
+            "server_id",
+            "name",
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "pdns_server_stats_ts_idx": {
+          "name": "pdns_server_stats_ts_idx",
+          "columns": [
+            "ts"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pdns_server_stats_server_id_pdns_servers_id_fk": {
+          "name": "pdns_server_stats_server_id_pdns_servers_id_fk",
+          "tableFrom": "pdns_server_stats",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "tableTo": "pdns_servers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {
+      "users_email_lower_idx": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle-sqlite/meta/_journal.json
+++ b/drizzle-sqlite/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1786133283567,
       "tag": "0006_petite_the_santerians",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1787788309672,
+      "tag": "0007_granular_zone_permissions_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/0007_granular_zone_permissions_backfill.sql
+++ b/drizzle/0007_granular_zone_permissions_backfill.sql
@@ -1,0 +1,109 @@
+-- Granular zone permissions (#119) - data-only backfill, no schema change.
+--
+-- 1.5.6 splits three capabilities out of the permissions that used to imply
+-- them:
+--
+--   soa.read              was implied by zone.read       (the SOA tab rendered
+--                                                         for anyone who could
+--                                                         open the zone)
+--   zone.settings.read    was implied by zone.read       (ditto, Zone settings)
+--   soa.update            was implied by record.update   (the SOA panel PATCHed
+--                                                         the RRset route)
+--   record.update.apex-ns was implied by record.create /
+--                         record.update / record.delete  (apex NS was an
+--                                                         ordinary record)
+--
+-- An upgrade must not silently change what an existing role can do, so every
+-- operator-defined role, zone grant and API token that held the implying
+-- permission gets the new explicit one. Tightening is then an opt-in edit:
+-- untick soa.update on the role and the SOA becomes read-only for it.
+--
+-- SYSTEM roles are deliberately excluded - `scripts/seed.ts` upserts them from
+-- `lib/rbac/default-roles.ts` on every boot, and 1.5.6 intentionally changes
+-- what Zone Editor grants (records yes, SOA and apex NS no). Backfilling them
+-- here would be overwritten on the next boot anyway.
+
+-- === roles (operator-defined only) =========================================
+
+UPDATE "roles" SET "permissions" = "permissions" || '["soa.read"]'::jsonb
+WHERE "is_system" = false
+  AND "permissions" @> '"zone.read"'::jsonb
+  AND NOT ("permissions" @> '"soa.read"'::jsonb);
+--> statement-breakpoint
+
+UPDATE "roles" SET "permissions" = "permissions" || '["zone.settings.read"]'::jsonb
+WHERE "is_system" = false
+  AND "permissions" @> '"zone.read"'::jsonb
+  AND NOT ("permissions" @> '"zone.settings.read"'::jsonb);
+--> statement-breakpoint
+
+UPDATE "roles" SET "permissions" = "permissions" || '["soa.update"]'::jsonb
+WHERE "is_system" = false
+  AND "permissions" @> '"record.update"'::jsonb
+  AND NOT ("permissions" @> '"soa.update"'::jsonb);
+--> statement-breakpoint
+
+UPDATE "roles" SET "permissions" = "permissions" || '["record.update.apex-ns"]'::jsonb
+WHERE "is_system" = false
+  AND ("permissions" @> '"record.create"'::jsonb
+       OR "permissions" @> '"record.update"'::jsonb
+       OR "permissions" @> '"record.delete"'::jsonb)
+  AND NOT ("permissions" @> '"record.update.apex-ns"'::jsonb);
+--> statement-breakpoint
+
+-- === zone_grants ============================================================
+-- Per-(user|team, server, zone) literal permission lists. Same rules; there is
+-- no system/custom distinction here, every row is operator-issued.
+
+UPDATE "zone_grants" SET "permissions" = "permissions" || '["soa.read"]'::jsonb
+WHERE "permissions" @> '"zone.read"'::jsonb
+  AND NOT ("permissions" @> '"soa.read"'::jsonb);
+--> statement-breakpoint
+
+UPDATE "zone_grants" SET "permissions" = "permissions" || '["zone.settings.read"]'::jsonb
+WHERE "permissions" @> '"zone.read"'::jsonb
+  AND NOT ("permissions" @> '"zone.settings.read"'::jsonb);
+--> statement-breakpoint
+
+UPDATE "zone_grants" SET "permissions" = "permissions" || '["soa.update"]'::jsonb
+WHERE "permissions" @> '"record.update"'::jsonb
+  AND NOT ("permissions" @> '"soa.update"'::jsonb);
+--> statement-breakpoint
+
+UPDATE "zone_grants" SET "permissions" = "permissions" || '["record.update.apex-ns"]'::jsonb
+WHERE ("permissions" @> '"record.create"'::jsonb
+       OR "permissions" @> '"record.update"'::jsonb
+       OR "permissions" @> '"record.delete"'::jsonb)
+  AND NOT ("permissions" @> '"record.update.apex-ns"'::jsonb);
+--> statement-breakpoint
+
+-- === api_tokens =============================================================
+-- Token scopes are a FLOOR over the user's own permissions, so a token that
+-- listed record.update would otherwise lose SOA editing the moment the split
+-- lands. An EMPTY scopes array means "everything the user currently has" and
+-- must stay empty - jsonb_array_length filters those out.
+
+UPDATE "api_tokens" SET "scopes" = "scopes" || '["soa.read"]'::jsonb
+WHERE jsonb_array_length("scopes") > 0
+  AND "scopes" @> '"zone.read"'::jsonb
+  AND NOT ("scopes" @> '"soa.read"'::jsonb);
+--> statement-breakpoint
+
+UPDATE "api_tokens" SET "scopes" = "scopes" || '["zone.settings.read"]'::jsonb
+WHERE jsonb_array_length("scopes") > 0
+  AND "scopes" @> '"zone.read"'::jsonb
+  AND NOT ("scopes" @> '"zone.settings.read"'::jsonb);
+--> statement-breakpoint
+
+UPDATE "api_tokens" SET "scopes" = "scopes" || '["soa.update"]'::jsonb
+WHERE jsonb_array_length("scopes") > 0
+  AND "scopes" @> '"record.update"'::jsonb
+  AND NOT ("scopes" @> '"soa.update"'::jsonb);
+--> statement-breakpoint
+
+UPDATE "api_tokens" SET "scopes" = "scopes" || '["record.update.apex-ns"]'::jsonb
+WHERE jsonb_array_length("scopes") > 0
+  AND ("scopes" @> '"record.create"'::jsonb
+       OR "scopes" @> '"record.update"'::jsonb
+       OR "scopes" @> '"record.delete"'::jsonb)
+  AND NOT ("scopes" @> '"record.update.apex-ns"'::jsonb);

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,3193 @@
+{
+  "id": "057aeafb-ae0c-480f-8c0b-5e963f591de9",
+  "prevId": "70375453-3339-49a1-b26f-214f6c59bc48",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_tokens_user_idx": {
+          "name": "api_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "api_tokens_prefix_idx": {
+          "name": "api_tokens_prefix_idx",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "api_tokens_team_idx": {
+          "name": "api_tokens_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "api_tokens_team_id_teams_id_fk": {
+          "name": "api_tokens_team_id_teams_id_fk",
+          "tableFrom": "api_tokens",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_ts_idx": {
+          "name": "audit_log_ts_idx",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "audit_log_resource_idx": {
+          "name": "audit_log_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_provider_slugs": {
+      "name": "auth_provider_slugs",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backend_advisories": {
+      "name": "backend_advisories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "backend_id": {
+          "name": "backend_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "backend_advisories_backend_code_idx": {
+          "name": "backend_advisories_backend_code_idx",
+          "columns": [
+            {
+              "expression": "backend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "backend_advisories_backend_idx": {
+          "name": "backend_advisories_backend_idx",
+          "columns": [
+            {
+              "expression": "backend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "backend_advisories_backend_id_pdns_servers_id_fk": {
+          "name": "backend_advisories_backend_id_pdns_servers_id_fk",
+          "tableFrom": "backend_advisories",
+          "columnsFrom": [
+            "backend_id"
+          ],
+          "tableTo": "pdns_servers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ldap_providers": {
+      "name": "ldap_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_tls": {
+          "name": "start_tls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bind_password_encrypted": {
+          "name": "bind_password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_search_base": {
+          "name": "user_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_search_filter": {
+          "name": "user_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'(|(uid={{username}})(sAMAccountName={{username}})(mail={{username}}))'"
+        },
+        "group_search_base": {
+          "name": "group_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_search_filter": {
+          "name": "group_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_attr": {
+          "name": "group_attr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'memberOf'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mail'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'displayName'"
+        },
+        "tls_ca_cert": {
+          "name": "tls_ca_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ldap_providers_slug_idx": {
+          "name": "ldap_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "ldap_providers_created_by_users_id_fk": {
+          "name": "ldap_providers_created_by_users_id_fk",
+          "tableFrom": "ldap_providers",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_samples": {
+      "name": "metric_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sampled_at": {
+          "name": "sampled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "zone_count": {
+          "name": "zone_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_p50_ms": {
+          "name": "latency_p50_ms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_p95_ms": {
+          "name": "latency_p95_ms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_sessions": {
+          "name": "active_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "metric_samples_server_time_idx": {
+          "name": "metric_samples_server_time_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sampled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "metric_samples_time_idx": {
+          "name": "metric_samples_time_idx",
+          "columns": [
+            {
+              "expression": "sampled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_encrypted": {
+          "name": "client_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openid profile email'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'name'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "require_email_verified": {
+          "name": "require_email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discovery_cache": {
+          "name": "discovery_cache",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_groups": {
+          "name": "claim_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'groups'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oidc_providers_slug_idx": {
+          "name": "oidc_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "oidc_providers_created_by_users_id_fk": {
+          "name": "oidc_providers_created_by_users_id_fk",
+          "tableFrom": "oidc_providers",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdns_clusters": {
+      "name": "pdns_clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "write_strategy": {
+          "name": "write_strategy",
+          "type": "pdns_cluster_write_strategy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'round_robin'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdns_clusters_created_by_users_id_fk": {
+          "name": "pdns_clusters_created_by_users_id_fk",
+          "tableFrom": "pdns_clusters",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pdns_clusters_slug_unique": {
+          "name": "pdns_clusters_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdns_requests": {
+      "name": "pdns_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_slug": {
+          "name": "server_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "op": {
+          "name": "op",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pdns_requests_request_id_idx": {
+          "name": "pdns_requests_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pdns_requests_ts_idx": {
+          "name": "pdns_requests_ts_idx",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pdns_requests_server_id_idx": {
+          "name": "pdns_requests_server_id_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "pdns_requests_server_id_pdns_servers_id_fk": {
+          "name": "pdns_requests_server_id_pdns_servers_id_fk",
+          "tableFrom": "pdns_requests",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "tableTo": "pdns_servers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdns_server_stats": {
+      "name": "pdns_server_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_value": {
+          "name": "map_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pdns_server_stats_server_ts_idx": {
+          "name": "pdns_server_stats_server_ts_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pdns_server_stats_server_name_ts_idx": {
+          "name": "pdns_server_stats_server_name_ts_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pdns_server_stats_ts_idx": {
+          "name": "pdns_server_stats_ts_idx",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "pdns_server_stats_server_id_pdns_servers_id_fk": {
+          "name": "pdns_server_stats_server_id_pdns_servers_id_fk",
+          "tableFrom": "pdns_server_stats",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "tableTo": "pdns_servers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdns_servers": {
+      "name": "pdns_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'localhost'"
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_cache": {
+          "name": "version_cache",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advertised_addresses": {
+          "name": "advertised_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "write_mode": {
+          "name": "write_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pdns_servers_slug_idx": {
+          "name": "pdns_servers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pdns_servers_default_idx": {
+          "name": "pdns_servers_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pdns_servers_disabled_idx": {
+          "name": "pdns_servers_disabled_idx",
+          "columns": [
+            {
+              "expression": "disabled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pdns_servers_cluster_id_idx": {
+          "name": "pdns_servers_cluster_id_idx",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "pdns_servers_cluster_id_pdns_clusters_id_fk": {
+          "name": "pdns_servers_cluster_id_pdns_clusters_id_fk",
+          "tableFrom": "pdns_servers",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "tableTo": "pdns_clusters",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "pdns_servers_created_by_users_id_fk": {
+          "name": "pdns_servers_created_by_users_id_fk",
+          "tableFrom": "pdns_servers",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_assignments": {
+      "name": "role_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "scope_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_assignments_user_idx": {
+          "name": "role_assignments_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "role_assignments_role_idx": {
+          "name": "role_assignments_role_idx",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "role_assignments_scope_idx": {
+          "name": "role_assignments_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "role_assignments_unique_idx": {
+          "name": "role_assignments_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "role_assignments_user_id_users_id_fk": {
+          "name": "role_assignments_user_id_users_id_fk",
+          "tableFrom": "role_assignments",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "role_assignments_role_id_roles_id_fk": {
+          "name": "role_assignments_role_id_roles_id_fk",
+          "tableFrom": "role_assignments",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "tableTo": "roles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "role_assignments_created_by_users_id_fk": {
+          "name": "role_assignments_created_by_users_id_fk",
+          "tableFrom": "role_assignments",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_mfa": {
+          "name": "requires_mfa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roles_slug_idx": {
+          "name": "roles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "roles_system_idx": {
+          "name": "roles_system_idx",
+          "columns": [
+            {
+              "expression": "is_system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saml_providers": {
+      "name": "saml_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idp_entity_id": {
+          "name": "idp_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idp_sso_url": {
+          "name": "idp_sso_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idp_slo_url": {
+          "name": "idp_slo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idp_signing_cert": {
+          "name": "idp_signing_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sp_signing_key_encrypted": {
+          "name": "sp_signing_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sp_signing_cert": {
+          "name": "sp_signing_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sp_encryption_key_encrypted": {
+          "name": "sp_encryption_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sp_encryption_cert": {
+          "name": "sp_encryption_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_signed_response": {
+          "name": "require_signed_response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "require_encrypted_assertion": {
+          "name": "require_encrypted_assertion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signature_algorithm": {
+          "name": "signature_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sha256'"
+        },
+        "name_id_format": {
+          "name": "name_id_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "claim_name": {
+          "name": "claim_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'name'"
+        },
+        "claim_groups": {
+          "name": "claim_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'groups'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mappings": {
+          "name": "group_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saml_providers_slug_idx": {
+          "name": "saml_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "saml_providers_created_by_users_id_fk": {
+          "name": "saml_providers_created_by_users_id_fk",
+          "tableFrom": "saml_providers",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "csrf_secret": {
+          "name": "csrf_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_end_session_url": {
+          "name": "oidc_end_session_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_id_token": {
+          "name": "oidc_id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_client_id": {
+          "name": "oidc_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derived_permissions": {
+          "name": "derived_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "oidc_refresh_token_encrypted": {
+          "name": "oidc_refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idp_provider_type": {
+          "name": "idp_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idp_provider_slug": {
+          "name": "idp_provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_updated_by_users_id_fk": {
+          "name": "settings_updated_by_users_id_fk",
+          "tableFrom": "settings",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_role": {
+          "name": "team_role",
+          "type": "team_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_members_team_idx": {
+          "name": "team_members_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_user_id_team_id_pk": {
+          "name": "team_members_user_id_team_id_pk",
+          "columns": [
+            "user_id",
+            "team_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail": {
+          "name": "mail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_slug_idx": {
+          "name": "teams_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "teams_name_idx": {
+          "name": "teams_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_secret_encrypted": {
+          "name": "totp_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mfa_required": {
+          "name": "mfa_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webauthn_credentials": {
+          "name": "webauthn_credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_login_count": {
+          "name": "failed_login_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_ip": {
+          "name": "last_login_ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password_hash_updated_at": {
+          "name": "password_hash_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_lower_idx": {
+          "name": "users_email_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_disabled_idx": {
+          "name": "users_disabled_idx",
+          "columns": [
+            {
+              "expression": "disabled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zone_grants": {
+      "name": "zone_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zone_grants_user_idx": {
+          "name": "zone_grants_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "zone_grants_team_idx": {
+          "name": "zone_grants_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "zone_grants_zone_idx": {
+          "name": "zone_grants_zone_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "zone_grants_user_unique_idx": {
+          "name": "zone_grants_user_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"zone_grants\".\"user_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "zone_grants_team_unique_idx": {
+          "name": "zone_grants_team_unique_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"zone_grants\".\"team_id\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "zone_grants_user_id_users_id_fk": {
+          "name": "zone_grants_user_id_users_id_fk",
+          "tableFrom": "zone_grants",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "zone_grants_team_id_teams_id_fk": {
+          "name": "zone_grants_team_id_teams_id_fk",
+          "tableFrom": "zone_grants",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "zone_grants_server_id_pdns_servers_id_fk": {
+          "name": "zone_grants_server_id_pdns_servers_id_fk",
+          "tableFrom": "zone_grants",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "tableTo": "pdns_servers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "zone_grants_created_by_users_id_fk": {
+          "name": "zone_grants_created_by_users_id_fk",
+          "tableFrom": "zone_grants",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "zone_grants_principal_check": {
+          "name": "zone_grants_principal_check",
+          "value": "(\"zone_grants\".\"user_id\" IS NULL) <> (\"zone_grants\".\"team_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.zone_horizons": {
+      "name": "zone_horizons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "horizon": {
+          "name": "horizon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zone_horizons_server_unique_idx": {
+          "name": "zone_horizons_server_unique_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"zone_horizons\".\"server_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "zone_horizons_cluster_unique_idx": {
+          "name": "zone_horizons_cluster_unique_idx",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"zone_horizons\".\"cluster_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "zone_horizons_zone_idx": {
+          "name": "zone_horizons_zone_idx",
+          "columns": [
+            {
+              "expression": "zone_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "zone_horizons_server_id_pdns_servers_id_fk": {
+          "name": "zone_horizons_server_id_pdns_servers_id_fk",
+          "tableFrom": "zone_horizons",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "tableTo": "pdns_servers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "zone_horizons_cluster_id_pdns_clusters_id_fk": {
+          "name": "zone_horizons_cluster_id_pdns_clusters_id_fk",
+          "tableFrom": "zone_horizons",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "tableTo": "pdns_clusters",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "zone_horizons_created_by_users_id_fk": {
+          "name": "zone_horizons_created_by_users_id_fk",
+          "tableFrom": "zone_horizons",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "zone_horizons_scope_check": {
+          "name": "zone_horizons_scope_check",
+          "value": "(\"zone_horizons\".\"server_id\" IS NULL) <> (\"zone_horizons\".\"cluster_id\" IS NULL)"
+        },
+        "zone_horizons_horizon_check": {
+          "name": "zone_horizons_horizon_check",
+          "value": "\"zone_horizons\".\"horizon\" IN ('public', 'internal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.zone_templates": {
+      "name": "zone_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soa_ttl": {
+          "name": "soa_ttl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3600
+        },
+        "soa_refresh": {
+          "name": "soa_refresh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3600
+        },
+        "soa_retry": {
+          "name": "soa_retry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 900
+        },
+        "soa_expire": {
+          "name": "soa_expire",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 604800
+        },
+        "soa_minimum": {
+          "name": "soa_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3600
+        },
+        "nameservers": {
+          "name": "nameservers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "records": {
+          "name": "records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Native'"
+        },
+        "soa_edit": {
+          "name": "soa_edit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soa_edit_api": {
+          "name": "soa_edit_api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_rectify": {
+          "name": "api_rectify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "default_for_primary_ids": {
+          "name": "default_for_primary_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zone_templates_slug_idx": {
+          "name": "zone_templates_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "zone_templates_created_by_users_id_fk": {
+          "name": "zone_templates_created_by_users_id_fk",
+          "tableFrom": "zone_templates",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "token",
+        "system"
+      ]
+    },
+    "public.pdns_cluster_write_strategy": {
+      "name": "pdns_cluster_write_strategy",
+      "schema": "public",
+      "values": [
+        "round_robin",
+        "lowest_latency",
+        "random",
+        "least_load"
+      ]
+    },
+    "public.scope_type": {
+      "name": "scope_type",
+      "schema": "public",
+      "values": [
+        "global",
+        "team",
+        "zone",
+        "server"
+      ]
+    },
+    "public.team_role": {
+      "name": "team_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1786133253249,
       "tag": "0006_nice_butterfly",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1787788306369,
+      "tag": "0007_granular_zone_permissions_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/rbac/README.md
+++ b/lib/rbac/README.md
@@ -1,7 +1,14 @@
 ## lib/rbac
 
 Authorization policy: permission vocabulary, CASL ability building, target
-ceilings, default roles, and zone-grant permission helpers.
+ceilings, default roles, zone-grant permission helpers, and the classifier for
+RRsets that cost more than `record.*` (the SOA and the apex NS - ADR-0023).
+
+Most modules here are `server-only`. Two deliberately are not:
+`zone-permissions.ts` (so it unit-tests without a `pg` import) and
+`protected-rrsets.ts` (so the record editor, a client component, decides which
+rows to lock with the same predicate the write route enforces). Keep them free
+of imports that would pull `server-only` back in.
 
 RBAC decides what an already-authenticated actor can do. It should not query the
 database directly from repositories, render UI, or talk to PowerDNS.

--- a/lib/rbac/ability.ts
+++ b/lib/rbac/ability.ts
@@ -38,6 +38,7 @@ import type { Permission } from "./permissions";
 export type SubjectType =
   | "Zone"
   | "Record"
+  | "Soa"
   | "Dnssec"
   | "Metadata"
   | "Tsig"

--- a/lib/rbac/default-roles.test.ts
+++ b/lib/rbac/default-roles.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_ROLES, SUPER_ADMIN_SLUG } from "./default-roles";
+import { PERMISSIONS, type Permission } from "./permissions";
+
+function permsOf(slug: string): Permission[] {
+  const role = DEFAULT_ROLES.find((r) => r.slug === slug);
+  if (!role) throw new Error(`no seeded role "${slug}"`);
+  return role.permissions;
+}
+
+describe("seeded system roles", () => {
+  it("Super Admin holds every permission in the vocabulary", () => {
+    // The seed relies on this: a permission added to the codebase must be
+    // reachable by someone on the very next boot.
+    const superAdmin = new Set<string>(permsOf(SUPER_ADMIN_SLUG));
+    expect(PERMISSIONS.filter((p) => !superAdmin.has(p))).toEqual([]);
+  });
+
+  it("lists no permission twice", () => {
+    for (const role of DEFAULT_ROLES) {
+      expect(new Set(role.permissions).size, `${role.slug} has a duplicate`).toBe(
+        role.permissions.length,
+      );
+    }
+  });
+
+  // #119: the hosting-provider case. Zone Editor is the role handed to a
+  // customer who manages their own records; it must not reach the RRsets
+  // and settings that decide the zone's authority.
+  describe("Zone Editor is safe to hand to a self-service customer", () => {
+    const zoneEditor = new Set<string>(permsOf("zone-editor"));
+
+    it("can manage ordinary records", () => {
+      expect(zoneEditor.has("record.create")).toBe(true);
+      expect(zoneEditor.has("record.update")).toBe(true);
+      expect(zoneEditor.has("record.delete")).toBe(true);
+    });
+
+    it("cannot rewrite the SOA or the apex NS", () => {
+      expect(zoneEditor.has("soa.update")).toBe(false);
+      expect(zoneEditor.has("record.update.apex-ns")).toBe(false);
+    });
+
+    it("cannot change the zone object or delete the zone", () => {
+      expect(zoneEditor.has("zone.update")).toBe(false);
+      expect(zoneEditor.has("zone.delete")).toBe(false);
+      expect(zoneEditor.has("metadata.write")).toBe(false);
+    });
+
+    it("still SEES both surfaces - hiding them is a role edit, not the default", () => {
+      expect(zoneEditor.has("soa.read")).toBe(true);
+      expect(zoneEditor.has("zone.settings.read")).toBe(true);
+    });
+  });
+
+  it("Operator owns the zone's shape: SOA, apex NS and the zone object", () => {
+    const operator = new Set<string>(permsOf("operator"));
+    expect(operator.has("soa.update")).toBe(true);
+    expect(operator.has("record.update.apex-ns")).toBe(true);
+    expect(operator.has("zone.update")).toBe(true);
+  });
+
+  it("Read Only sees every zone surface and writes none of them", () => {
+    const readOnly = new Set<string>(permsOf("read-only"));
+    expect(readOnly.has("soa.read")).toBe(true);
+    expect(readOnly.has("zone.settings.read")).toBe(true);
+    expect(readOnly.has("soa.update")).toBe(false);
+    expect(readOnly.has("record.update.apex-ns")).toBe(false);
+  });
+});

--- a/lib/rbac/default-roles.test.ts
+++ b/lib/rbac/default-roles.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_ROLES, SUPER_ADMIN_SLUG } from "./default-roles";
 import { PERMISSIONS, type Permission } from "./permissions";
 
-function permsOf(slug: string): Permission[] {
+function permissionsOf(slug: string): Permission[] {
   const role = DEFAULT_ROLES.find((r) => r.slug === slug);
   if (!role) throw new Error(`no seeded role "${slug}"`);
   return role.permissions;
@@ -12,7 +12,7 @@ describe("seeded system roles", () => {
   it("Super Admin holds every permission in the vocabulary", () => {
     // The seed relies on this: a permission added to the codebase must be
     // reachable by someone on the very next boot.
-    const superAdmin = new Set<string>(permsOf(SUPER_ADMIN_SLUG));
+    const superAdmin = new Set<string>(permissionsOf(SUPER_ADMIN_SLUG));
     expect(PERMISSIONS.filter((p) => !superAdmin.has(p))).toEqual([]);
   });
 
@@ -28,7 +28,7 @@ describe("seeded system roles", () => {
   // customer who manages their own records; it must not reach the RRsets
   // and settings that decide the zone's authority.
   describe("Zone Editor is safe to hand to a self-service customer", () => {
-    const zoneEditor = new Set<string>(permsOf("zone-editor"));
+    const zoneEditor = new Set<string>(permissionsOf("zone-editor"));
 
     it("can manage ordinary records", () => {
       expect(zoneEditor.has("record.create")).toBe(true);
@@ -54,14 +54,14 @@ describe("seeded system roles", () => {
   });
 
   it("Operator owns the zone's shape: SOA, apex NS and the zone object", () => {
-    const operator = new Set<string>(permsOf("operator"));
+    const operator = new Set<string>(permissionsOf("operator"));
     expect(operator.has("soa.update")).toBe(true);
     expect(operator.has("record.update.apex-ns")).toBe(true);
     expect(operator.has("zone.update")).toBe(true);
   });
 
   it("Read Only sees every zone surface and writes none of them", () => {
-    const readOnly = new Set<string>(permsOf("read-only"));
+    const readOnly = new Set<string>(permissionsOf("read-only"));
     expect(readOnly.has("soa.read")).toBe(true);
     expect(readOnly.has("zone.settings.read")).toBe(true);
     expect(readOnly.has("soa.update")).toBe(false);

--- a/lib/rbac/default-roles.ts
+++ b/lib/rbac/default-roles.ts
@@ -27,7 +27,9 @@ export interface DefaultRoleSpec {
  */
 const READ_ONLY: Permission[] = [
   "zone.read",
+  "zone.settings.read",
   "record.read",
+  "soa.read",
   "dnssec.read",
   "metadata.read",
   "template.use",
@@ -52,6 +54,13 @@ const ZONE_EDITOR: Permission[] = [
 /** Operator - typical day-to-day admin scope within a team. */
 const OPERATOR: Permission[] = [
   ...ZONE_EDITOR,
+  // The two RRsets that decide whether the zone works at all: its SOA
+  // (authority + transfer timers) and its apex NS (delegation). Held
+  // from Operator up, alongside `zone.update`, so the tier that owns
+  // the zone's shape owns these too - Zone Editor edits the records
+  // inside the zone, not the zone's standing in DNS.
+  "soa.update",
+  "record.update.apex-ns",
   "zone.create",
   "zone.update",
   "zone.delete",
@@ -126,7 +135,8 @@ export const DEFAULT_ROLES: readonly DefaultRoleSpec[] = [
   {
     slug: "zone-editor",
     name: "Zone Editor",
-    description: "Edit records on assigned zones. Cannot create or delete zones.",
+    description:
+      "Edit records on assigned zones. Cannot create or delete zones, change the SOA, or repoint the apex NS.",
     permissions: ZONE_EDITOR,
   },
   {

--- a/lib/rbac/permissions.ts
+++ b/lib/rbac/permissions.ts
@@ -49,11 +49,12 @@ export const PERMISSIONS = [
   // repoints it takes the zone off the internet as surely as a bad SOA
   // does, so a self-service editor gets the record permissions without
   // this one. NS records BELOW the apex (child delegations) are
-  // ordinary records and need only `record.*`.
+  // ordinary records and need only `record.*`. ADR-0023 covers why this one
+  // is additive while `soa.update` replaces the record permission.
   "record.update.apex-ns",
 
   // === SOA ===
-  // The SOA RRset is its own resource, not a `record.*` action: it
+  // The SOA RRset is its own resource, not a `record.*` action (ADR-0023): it
   // carries the zone's authority and transfer timers, has a dedicated
   // editor tab, and is the one RRset a zone cannot exist without.
   // `soa.read` gates the SOA tab; `soa.update` gates every write to

--- a/lib/rbac/permissions.ts
+++ b/lib/rbac/permissions.ts
@@ -30,12 +30,37 @@ export const PERMISSIONS = [
   "zone.delete",
   "zone.export",
   "zone.import",
+  // Read-only view of the Zone settings tab (kind, masters, SOA-EDIT,
+  // SOA-EDIT-API, API-RECTIFY, horizon). Held separately from
+  // `zone.update` so a role can be given record editing without ever
+  // seeing - let alone changing - the knobs that decide the zone's
+  // authority and how it transfers. Without it the tab is not rendered
+  // and `?tab=settings` falls back to Records.
+  "zone.settings.read",
 
   // === Records ===
   "record.read",
   "record.create",
   "record.update",
   "record.delete",
+  // ADDITIONAL permission, required on top of the matching
+  // `record.create/update/delete`, to write an NS RRset at the zone
+  // apex. Apex NS is the zone's delegation: an operator who removes or
+  // repoints it takes the zone off the internet as surely as a bad SOA
+  // does, so a self-service editor gets the record permissions without
+  // this one. NS records BELOW the apex (child delegations) are
+  // ordinary records and need only `record.*`.
+  "record.update.apex-ns",
+
+  // === SOA ===
+  // The SOA RRset is its own resource, not a `record.*` action: it
+  // carries the zone's authority and transfer timers, has a dedicated
+  // editor tab, and is the one RRset a zone cannot exist without.
+  // `soa.read` gates the SOA tab; `soa.update` gates every write to
+  // the SOA RRset, whether it arrives from the SOA panel or a
+  // hand-rolled PATCH.
+  "soa.read",
+  "soa.update",
 
   // === DNSSEC ===
   "dnssec.read",

--- a/lib/rbac/protected-rrsets.fuzz.test.ts
+++ b/lib/rbac/protected-rrsets.fuzz.test.ts
@@ -33,6 +33,18 @@ const zoneNameArbitrary = fc.oneof(
  * than about surviving hostile input - `"a\t"` and `"a\t."` differ by a tab
  * before the dot, so they are two different names, not two spellings of one.
  */
+/**
+ * Uppercase A-Z and nothing else. DNS case-insensitivity is defined over
+ * ASCII alone (RFC 4343 § 3), so `String.prototype.toUpperCase` does NOT
+ * produce another spelling of the same name: it maps U+1F54 to a three-
+ * codepoint sequence that lowercases back to a different character, and
+ * U+017F LATIN SMALL LETTER LONG S to "S". Use this where the property is
+ * "these are the same name spelled differently" - a fuzz run caught the
+ * naive version asserting that about two genuinely different names.
+ */
+const asciiUpperCase = (value: string): string =>
+  value.replace(/[a-z]/g, (character) => character.toUpperCase());
+
 const dnsNameArbitrary = fc
   .array(
     fc.stringMatching(/^[a-zA-Z0-9-]{1,20}$/).filter((label) => label.length > 0),
@@ -83,7 +95,7 @@ describe("protectedRRsetPermission - fuzz", () => {
       fc.property(zoneNameArbitrary, fc.constantFrom("NS", "ns", "Ns", " ns "), (zone, type) => {
         // Every spelling `normalizeName` in the RRset route can resolve to the
         // apex must reach the same verdict.
-        for (const apexSpelling of ["@", "", "  ", zone, zone.toUpperCase()]) {
+        for (const apexSpelling of ["@", "", "  ", zone, asciiUpperCase(zone)]) {
           expect(protectedRRsetPermission(apexSpelling, type, zone)).toBe("record.update.apex-ns");
         }
       }),
@@ -108,7 +120,7 @@ describe("protectedRRsetPermission - fuzz", () => {
         // Four spellings of one name, all denoting the same RRset. PowerDNS is
         // case-insensitive here and inconsistent about the trailing dot across
         // endpoints, so all four have to reach the same verdict.
-        const verdicts = [zone, zone.toUpperCase(), bare, bare.toUpperCase()].map((spelling) =>
+        const verdicts = [zone, asciiUpperCase(zone), bare, asciiUpperCase(bare)].map((spelling) =>
           protectedRRsetPermission(spelling, "NS", zone),
         );
         expect(new Set(verdicts)).toEqual(new Set(["record.update.apex-ns"]));

--- a/lib/rbac/protected-rrsets.fuzz.test.ts
+++ b/lib/rbac/protected-rrsets.fuzz.test.ts
@@ -1,0 +1,134 @@
+/**
+ * lib/rbac/protected-rrsets.fuzz.test.ts
+ *
+ * Property-based (fuzz) tests for the protected-RRset classifier. It runs on
+ * every RRset write with a name and type the requester chose, so it takes
+ * untrusted string input on an authorization path - the case CONTRIBUTING
+ * names for fast-check.
+ *
+ * The invariants are the ones an attacker would go after:
+ *   - it never throws, so a hostile name can't turn the permission check into
+ *     a 500 that skips it;
+ *   - it never answers `null` (= "ordinary record, record.* is enough") for a
+ *     spelling of the apex NS or for any SOA;
+ *   - the answer is stable across the spellings that all normalize to the same
+ *     RRset, so no casing or trailing-dot trick reaches a different verdict.
+ */
+
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+import { isZoneApex, protectedRRsetPermission } from "./protected-rrsets";
+
+const RUNS = { numRuns: 1000 };
+
+/** Zone names shaped like the real ones, plus adversarial free-form strings. */
+const zoneNameArbitrary = fc.oneof(
+  fc.constantFrom("example.com.", "EXAMPLE.COM.", "a.", "sub.zone.example.org.", "xn--80ak6aa92e."),
+  fc.string({ unit: "binary" }),
+);
+
+/**
+ * A name built from the characters a DNS label can actually hold. Used where
+ * the property is about the SPELLINGS of one name (case, trailing dot) rather
+ * than about surviving hostile input - `"a\t"` and `"a\t."` differ by a tab
+ * before the dot, so they are two different names, not two spellings of one.
+ */
+const dnsNameArbitrary = fc
+  .array(
+    fc.stringMatching(/^[a-zA-Z0-9-]{1,20}$/).filter((label) => label.length > 0),
+    { minLength: 1, maxLength: 4 },
+  )
+  .map((labels) => labels.join("."));
+
+const recordTypeArbitrary = fc.oneof(
+  fc.constantFrom("A", "AAAA", "NS", "ns", "Ns", "SOA", "soa", "CNAME", "MX", "TXT", "DS"),
+  fc.string({ unit: "binary" }),
+);
+
+describe("protectedRRsetPermission - fuzz", () => {
+  it("never throws, and answers only with a known permission or null", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ unit: "binary" }),
+        recordTypeArbitrary,
+        zoneNameArbitrary,
+        (name, type, zone) => {
+          const out = protectedRRsetPermission(name, type, zone);
+          expect(out === null || out === "soa.update" || out === "record.update.apex-ns").toBe(
+            true,
+          );
+        },
+      ),
+      RUNS,
+    );
+  });
+
+  it("never lets a SOA through as an ordinary record", () => {
+    // Any casing or surrounding whitespace of the mnemonic, at any name.
+    fc.assert(
+      fc.property(
+        fc.string({ unit: "binary" }),
+        zoneNameArbitrary,
+        fc.constantFrom("SOA", "soa", "Soa", " SOA ", "sOa"),
+        (name, zone, type) => {
+          expect(protectedRRsetPermission(name, type, zone)).toBe("soa.update");
+        },
+      ),
+      RUNS,
+    );
+  });
+
+  it("never lets an apex NS through as an ordinary record", () => {
+    fc.assert(
+      fc.property(zoneNameArbitrary, fc.constantFrom("NS", "ns", "Ns", " ns "), (zone, type) => {
+        // Every spelling `normalizeName` in the RRset route can resolve to the
+        // apex must reach the same verdict.
+        for (const apexSpelling of ["@", "", "  ", zone, zone.toUpperCase()]) {
+          expect(protectedRRsetPermission(apexSpelling, type, zone)).toBe("record.update.apex-ns");
+        }
+      }),
+      RUNS,
+    );
+  });
+
+  it("agrees with isZoneApex on every NS name", () => {
+    fc.assert(
+      fc.property(fc.string({ unit: "binary" }), zoneNameArbitrary, (name, zone) => {
+        const expected = isZoneApex(name, zone) ? "record.update.apex-ns" : null;
+        expect(protectedRRsetPermission(name, "NS", zone)).toBe(expected);
+      }),
+      RUNS,
+    );
+  });
+
+  it("is case- and trailing-dot-insensitive about the apex", () => {
+    fc.assert(
+      fc.property(dnsNameArbitrary, (bare) => {
+        const zone = `${bare}.`;
+        // Four spellings of one name, all denoting the same RRset. PowerDNS is
+        // case-insensitive here and inconsistent about the trailing dot across
+        // endpoints, so all four have to reach the same verdict.
+        const verdicts = [zone, zone.toUpperCase(), bare, bare.toUpperCase()].map((spelling) =>
+          protectedRRsetPermission(spelling, "NS", zone),
+        );
+        expect(new Set(verdicts)).toEqual(new Set(["record.update.apex-ns"]));
+      }),
+      RUNS,
+    );
+  });
+
+  it("keeps a child name out of the apex verdict, however it is spelled", () => {
+    fc.assert(
+      fc.property(dnsNameArbitrary, dnsNameArbitrary, (child, bare) => {
+        const zone = `${bare}.`;
+        // `child.zone.` is inside the zone but below its apex - an ordinary
+        // delegation, which `record.*` alone covers.
+        expect(protectedRRsetPermission(`${child}.${zone}`, "NS", zone)).toBeNull();
+        // And a zone whose name merely ENDS with the same labels is not this
+        // zone's apex either.
+        expect(protectedRRsetPermission(`x${zone}`, "NS", zone)).toBeNull();
+      }),
+      RUNS,
+    );
+  });
+});

--- a/lib/rbac/protected-rrsets.test.ts
+++ b/lib/rbac/protected-rrsets.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { isZoneApex, protectedRRsetPermission } from "./protected-rrsets";
+
+const ZONE = "example.com.";
+
+describe("isZoneApex", () => {
+  it("treats @, empty and the zone name itself as the apex", () => {
+    expect(isZoneApex("@", ZONE)).toBe(true);
+    expect(isZoneApex("", ZONE)).toBe(true);
+    expect(isZoneApex("  ", ZONE)).toBe(true);
+    expect(isZoneApex("example.com.", ZONE)).toBe(true);
+  });
+
+  it("ignores case and a missing trailing dot", () => {
+    expect(isZoneApex("EXAMPLE.COM.", ZONE)).toBe(true);
+    expect(isZoneApex("example.com", ZONE)).toBe(true);
+    expect(isZoneApex("example.com.", "EXAMPLE.COM")).toBe(true);
+  });
+
+  it("does not treat a child name as the apex", () => {
+    expect(isZoneApex("www.example.com.", ZONE)).toBe(false);
+    expect(isZoneApex("sub.example.com.", ZONE)).toBe(false);
+    // A different zone that merely ends with the same labels.
+    expect(isZoneApex("notexample.com.", ZONE)).toBe(false);
+  });
+});
+
+describe("protectedRRsetPermission", () => {
+  it("charges soa.update for any SOA write", () => {
+    expect(protectedRRsetPermission(ZONE, "SOA", ZONE)).toBe("soa.update");
+    expect(protectedRRsetPermission("@", "SOA", ZONE)).toBe("soa.update");
+    expect(protectedRRsetPermission(ZONE, "soa", ZONE)).toBe("soa.update");
+  });
+
+  it("charges record.update.apex-ns for the apex NS RRset", () => {
+    expect(protectedRRsetPermission(ZONE, "NS", ZONE)).toBe("record.update.apex-ns");
+    expect(protectedRRsetPermission("@", "NS", ZONE)).toBe("record.update.apex-ns");
+    expect(protectedRRsetPermission("", "ns", ZONE)).toBe("record.update.apex-ns");
+  });
+
+  it("leaves a child delegation as an ordinary record", () => {
+    // NS below the apex is content this zone serves, not its own
+    // delegation - `record.*` alone covers it.
+    expect(protectedRRsetPermission("sub.example.com.", "NS", ZONE)).toBeNull();
+  });
+
+  it("leaves ordinary records alone, apex or not", () => {
+    expect(protectedRRsetPermission("www.example.com.", "A", ZONE)).toBeNull();
+    expect(protectedRRsetPermission(ZONE, "A", ZONE)).toBeNull();
+    expect(protectedRRsetPermission("@", "MX", ZONE)).toBeNull();
+    expect(protectedRRsetPermission(ZONE, "TXT", ZONE)).toBeNull();
+  });
+});

--- a/lib/rbac/protected-rrsets.test.ts
+++ b/lib/rbac/protected-rrsets.test.ts
@@ -1,7 +1,36 @@
 import { describe, expect, it } from "vitest";
-import { isZoneApex, protectedRRsetPermission } from "./protected-rrsets";
+import { PERMISSIONS } from "./permissions";
+import {
+  isZoneApex,
+  protectedRRsetPermission,
+  type ProtectedRRsetPermission,
+} from "./protected-rrsets";
 
 const ZONE = "example.com.";
+
+/**
+ * Every member of `ProtectedRRsetPermission`. Typing it as a `Record` over the
+ * union makes it exhaustive - adding a third protected RRset stops this file
+ * compiling until it is listed here, and named in the assertion below.
+ */
+const EVERY_PROTECTED_PERMISSION: Record<ProtectedRRsetPermission, true> = {
+  "soa.update": true,
+  "record.update.apex-ns": true,
+};
+
+describe("the permissions the classifier names", () => {
+  it("all exist in the master vocabulary", () => {
+    // The classifier declares them as string literals rather than importing
+    // `Permission`, so it can stay free of `server-only` and be shared with the
+    // record editor (a client component). This is what keeps those literals
+    // honest: rename one in permissions.ts without touching the classifier and
+    // it would demand a permission no role can ever hold - denying silently
+    // instead of failing loudly.
+    for (const permission of Object.keys(EVERY_PROTECTED_PERMISSION)) {
+      expect(PERMISSIONS).toContain(permission);
+    }
+  });
+});
 
 describe("isZoneApex", () => {
   it("treats @, empty and the zone name itself as the apex", () => {

--- a/lib/rbac/protected-rrsets.ts
+++ b/lib/rbac/protected-rrsets.ts
@@ -22,6 +22,10 @@
  *
  * NS *below* the apex is an ordinary record - a child delegation is
  * content, not this zone's own authority - so it needs only `record.*`.
+ *
+ * ADR-0023 records why the SOA is modelled as its own resource (so
+ * `soa.update` REPLACES the record permission) while the apex NS stays a
+ * record with an extra cost (`record.update.apex-ns` is ADDITIVE).
  */
 
 /**

--- a/lib/rbac/protected-rrsets.ts
+++ b/lib/rbac/protected-rrsets.ts
@@ -44,6 +44,17 @@ export type ProtectedRRsetPermission = "soa.update" | "record.update.apex-ns";
  * them: lowercased, with exactly one trailing dot. Callers pass names in
  * whatever form the request carried; PowerDNS is case-insensitive here
  * and inconsistent about the trailing dot depending on the endpoint.
+ *
+ * Full `toLowerCase()` rather than an ASCII-only fold (which is all RFC
+ * 4343 defines for DNS) on purpose, for two reasons. It is byte-for-byte
+ * what `normalizeZoneId` and the RRset route's `normalizeName` already
+ * do, so this can never fold LESS than the value it is handed - folding
+ * less is the direction that misses an apex match and lets a write
+ * through. And where Unicode folds more than DNS would (U+212A KELVIN
+ * SIGN onto "k", say), the extra match errs toward "this RRset is
+ * protected", i.e. toward denying a write that did not need the
+ * permission. Names that reach here are punycode for anything non-ASCII
+ * anyway, so neither case is reachable with a real zone.
  */
 function sameName(a: string, b: string): boolean {
   const norm = (s: string): string => {

--- a/lib/rbac/protected-rrsets.ts
+++ b/lib/rbac/protected-rrsets.ts
@@ -1,0 +1,80 @@
+/**
+ * lib/rbac/protected-rrsets.ts
+ *
+ * Two RRsets in every zone are not "records" in the sense a self-service
+ * editor means it - they are the zone's standing in DNS:
+ *
+ *   - **SOA** at the apex: authority, the responsible mailbox, and the
+ *     refresh/retry/expire/minimum timers every secondary obeys. Get it
+ *     wrong and transfers stall or the zone expires off the secondaries.
+ *   - **NS** at the apex: the delegation. Remove it and the zone stops
+ *     being served, however healthy the rest of the records are.
+ *
+ * Both used to be reachable with plain `record.update`, which is the
+ * permission a hosting provider hands their customers so they can point
+ * an A record at a new box (#119). This module names the extra
+ * permission each one costs, so the RRset write path and the record
+ * editor agree on the answer without either re-deriving it.
+ *
+ * Deliberately pure and dependency-free (no `server-only`): the record
+ * editor is a client component and needs the same predicate to decide
+ * which rows to lock, and the unit tests want it without a DB.
+ *
+ * NS *below* the apex is an ordinary record - a child delegation is
+ * content, not this zone's own authority - so it needs only `record.*`.
+ */
+
+/**
+ * Extra permission a write to this RRset costs, or `null` when the
+ * RRset is an ordinary record.
+ *
+ * `soa.update` REPLACES the `record.*` requirement (SOA is its own
+ * resource, with its own editor and its own read permission).
+ * `record.update.apex-ns` is ADDITIVE - an apex NS write still needs
+ * the matching `record.create`/`record.update`/`record.delete`.
+ */
+export type ProtectedRRsetPermission = "soa.update" | "record.update.apex-ns";
+
+/**
+ * Compare two DNS names for equality the way the rest of the app stores
+ * them: lowercased, with exactly one trailing dot. Callers pass names in
+ * whatever form the request carried; PowerDNS is case-insensitive here
+ * and inconsistent about the trailing dot depending on the endpoint.
+ */
+function sameName(a: string, b: string): boolean {
+  const norm = (s: string): string => {
+    const t = s.trim().toLowerCase();
+    return t.endsWith(".") ? t : `${t}.`;
+  };
+  return norm(a) === norm(b);
+}
+
+/** True when `name` is the zone apex (`@`, empty, or the zone name itself). */
+export function isZoneApex(name: string, zoneName: string): boolean {
+  const trimmed = name.trim();
+  if (trimmed === "" || trimmed === "@") return true;
+  return sameName(trimmed, zoneName);
+}
+
+/**
+ * The extra permission this (name, type) write costs on `zoneName`, or
+ * `null` for an ordinary record.
+ *
+ * @example
+ *   protectedRRsetPermission("example.com.", "SOA", "example.com.")   // "soa.update"
+ *   protectedRRsetPermission("@", "NS", "example.com.")               // "record.update.apex-ns"
+ *   protectedRRsetPermission("sub.example.com.", "NS", "example.com.") // null - child delegation
+ *   protectedRRsetPermission("www.example.com.", "A", "example.com.")  // null
+ */
+export function protectedRRsetPermission(
+  name: string,
+  type: string,
+  zoneName: string,
+): ProtectedRRsetPermission | null {
+  const upperType = type.trim().toUpperCase();
+  // A SOA can only legally exist at the apex, but don't make the answer
+  // depend on that: any SOA write is an SOA write.
+  if (upperType === "SOA") return "soa.update";
+  if (upperType === "NS" && isZoneApex(name, zoneName)) return "record.update.apex-ns";
+  return null;
+}

--- a/lib/rbac/zone-grant-permissions.ts
+++ b/lib/rbac/zone-grant-permissions.ts
@@ -14,5 +14,5 @@
 import { PERMISSIONS } from "./permissions";
 
 export const ZONE_GRANT_PERMISSIONS: readonly string[] = PERMISSIONS.filter((p) =>
-  /^(zone|record|dnssec|metadata|tsig)\./.test(p),
+  /^(zone|record|soa|dnssec|metadata|tsig)\./.test(p),
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerdns-authadmin",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "license": "MIT",
       "dependencies": {
         "@casl/ability": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9600,9 +9600,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerdns-authadmin",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "private": true,
   "description": "Modern, self-hosted DNS administration UI for PowerDNS - multi-team RBAC, real audit, real SSO. From-scratch rebuild of PowerDNS-Admin in Node.js + TypeScript.",
   "license": "MIT",

--- a/provisioning.example.yaml
+++ b/provisioning.example.yaml
@@ -112,8 +112,16 @@ settings:
 # logs + skips them). The full vocabulary, grouped:
 #
 #   Zones:        zone.read, zone.create, zone.update, zone.delete,
-#                 zone.export, zone.import
-#   Records:      record.read, record.create, record.update, record.delete
+#                 zone.export, zone.import,
+#                 zone.settings.read  (see the Zone settings tab; writing it
+#                                       is zone.update)
+#   Records:      record.read, record.create, record.update, record.delete,
+#                 record.update.apex-ns  (EXTRA, on top of the matching
+#                                          record.* one, to write the apex NS -
+#                                          the zone's delegation. NS below the
+#                                          apex is an ordinary record.)
+#   SOA:          soa.read (see the SOA tab), soa.update (edit it - this
+#                 REPLACES the record.* requirement, it is not additive)
 #   DNSSEC:       dnssec.read, dnssec.configure
 #   Metadata:     metadata.read, metadata.write
 #   TSIG keys:    tsig.read, tsig.manage     (tsig.read = list-only; manage
@@ -130,7 +138,12 @@ settings:
 #   API tokens:   token.read.own, token.create.own, token.delete.own,
 #                 token.read.all, token.delete.all
 #   Audit/settings: audit.read, settings.read, settings.write
-#   OIDC IdPs:    oidc.read, oidc.manage
+#   Auth IdPs:    auth.read, auth.manage   (OIDC, SAML, LDAP)
+#   System:       system.backup
+#
+# Leaving soa.read / zone.settings.read off a role HIDES those tabs entirely -
+# which is how you give a hosting customer their records without giving them
+# the zone's authority. See docs/07-RBAC.md.
 # -----------------------------------------------------------------------------
 roles:
   - slug: zone-noc # lowercase kebab-case

--- a/tests/integration/rbac/zone-authority.test.ts
+++ b/tests/integration/rbac/zone-authority.test.ts
@@ -1,0 +1,186 @@
+/**
+ * tests/integration/rbac/zone-authority.test.ts
+ *
+ * The three surfaces that decide a zone's standing in DNS - its SOA, its
+ * apex NS, and the zone-settings object (kind / masters / SOA-EDIT* /
+ * API-RECTIFY) - are held apart from ordinary record editing (#119).
+ *
+ * The persona under test is the one the discussion describes: a hosting
+ * customer who may freely manage A/AAAA/CNAME/MX/TXT in their own zone
+ * and must not be able to break its authority or its transfers. That is
+ * exactly the seeded Zone Editor role from 1.5.6 on.
+ *
+ * A zone_grant carrying the explicit permission has to open the same
+ * doors a global role does - the two are ORed by `canActOnZone`, and a
+ * regression in either half would leave one path silently permissive.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { createAndLogin, loginAsBootstrap, SYSTEM_ROLES, uniqueEmail } from "../helpers/auth";
+import { getZone, PDNS_BY_TOPOLOGY } from "../helpers/pdns";
+import { resetState } from "../helpers/reset";
+import { type TestHttp } from "../helpers/http";
+
+const NS = ["ns1.example.com.", "ns2.example.com."] as const;
+
+function randomZone(prefix: string): string {
+  const tag = Math.random().toString(36).slice(2, 8);
+  return `${prefix}-${Date.now()}-${tag}.example.com.`;
+}
+
+async function createZone(admin: TestHttp, name: string): Promise<void> {
+  await admin.sendJson("POST", "/api/admin/pdns/zones", {
+    serverSlug: "standalone",
+    name,
+    kind: "Master",
+    nameservers: NS,
+  });
+}
+
+async function getStandaloneId(admin: TestHttp): Promise<string> {
+  const { servers } = await admin.getJson<{
+    servers: Array<{ id: string; slug: string }>;
+  }>("/api/admin/pdns-servers");
+  const standalone = servers.find((s) => s.slug === "standalone");
+  if (!standalone) throw new Error("standalone server not found");
+  return standalone.id;
+}
+
+function patchRRset(
+  client: TestHttp,
+  zone: string,
+  change: Record<string, unknown>,
+): Promise<Response> {
+  return client.call(`/api/admin/pdns/zones/${encodeURIComponent(zone)}/rrsets`, {
+    method: "PATCH",
+    json: { serverSlug: "standalone", changes: [change] },
+  });
+}
+
+const soaUpsert = (zone: string): Record<string, unknown> => ({
+  kind: "upsert",
+  name: zone,
+  type: "SOA",
+  ttl: 3600,
+  records: [{ content: `ns1.example.com. hostmaster.example.com. 1 10800 3600 604800 3600` }],
+});
+
+const apexNsUpsert = (zone: string): Record<string, unknown> => ({
+  kind: "upsert",
+  name: zone,
+  type: "NS",
+  ttl: 3600,
+  records: [{ content: "ns1.example.com." }, { content: "ns3.example.com." }],
+});
+
+const ordinaryUpsert = (zone: string): Record<string, unknown> => ({
+  kind: "upsert",
+  name: `www.${zone}`,
+  type: "A",
+  ttl: 60,
+  records: [{ content: "192.0.2.40" }],
+});
+
+describe("zone authority - SOA, apex NS and zone settings are held apart from record editing", () => {
+  beforeEach(async () => {
+    await resetState();
+  });
+
+  it("zone-editor edits records but is refused the SOA, the apex NS and zone settings", async () => {
+    const admin = await loginAsBootstrap();
+    const zone = randomZone("authority");
+    await createZone(admin, zone);
+
+    const { client } = await createAndLogin(admin, {
+      email: uniqueEmail("client"),
+      name: "Hosting customer",
+      password: "hosting-client-pw-1234",
+      roleSlug: SYSTEM_ROLES.zoneEditor,
+    });
+
+    expect((await patchRRset(client, zone, ordinaryUpsert(zone))).status).toBe(200);
+
+    expect((await patchRRset(client, zone, soaUpsert(zone))).status).toBe(403);
+    expect((await patchRRset(client, zone, apexNsUpsert(zone))).status).toBe(403);
+    expect(
+      (await patchRRset(client, zone, { kind: "delete", name: zone, type: "NS" })).status,
+    ).toBe(403);
+
+    const settings = await client.call(
+      `/api/admin/pdns/zones/${encodeURIComponent(zone)}/settings`,
+      { method: "PUT", json: { serverSlug: "standalone", soa_edit_api: "EPOCH" } },
+    );
+    expect(settings.status).toBe(403);
+  }, 30_000);
+
+  it("a batch is rejected whole when one change touches the SOA", async () => {
+    const admin = await loginAsBootstrap();
+    const zone = randomZone("batch");
+    await createZone(admin, zone);
+
+    const { client } = await createAndLogin(admin, {
+      email: uniqueEmail("batch"),
+      name: "Batch editor",
+      password: "batch-editor-pw-1234",
+      roleSlug: SYSTEM_ROLES.zoneEditor,
+    });
+
+    const res = await client.call(`/api/admin/pdns/zones/${encodeURIComponent(zone)}/rrsets`, {
+      method: "PATCH",
+      json: {
+        serverSlug: "standalone",
+        changes: [ordinaryUpsert(zone), soaUpsert(zone)],
+      },
+    });
+    expect(res.status).toBe(403);
+
+    // The permitted half of the batch must not have landed either - the
+    // refusal happens before anything reaches PowerDNS.
+    const after = await getZone(PDNS_BY_TOPOLOGY.standalone, zone);
+    const rrsets = after.rrsets ?? [];
+    expect(rrsets.some((rr) => rr.name === `www.${zone}` && rr.type === "A")).toBe(false);
+  }, 30_000);
+
+  it("operator holds soa.update and record.update.apex-ns, so both writes land", async () => {
+    const admin = await loginAsBootstrap();
+    const zone = randomZone("operator");
+    await createZone(admin, zone);
+
+    const { client } = await createAndLogin(admin, {
+      email: uniqueEmail("operator"),
+      name: "Operator",
+      password: "operator-test-pw-1234",
+      roleSlug: SYSTEM_ROLES.operator,
+    });
+
+    expect((await patchRRset(client, zone, soaUpsert(zone))).status).toBe(200);
+    expect((await patchRRset(client, zone, apexNsUpsert(zone))).status).toBe(200);
+  }, 30_000);
+
+  it("a zone_grant carrying soa.update opens the SOA on that zone only", async () => {
+    const admin = await loginAsBootstrap();
+    const standaloneId = await getStandaloneId(admin);
+    const granted = randomZone("granted-soa");
+    const otherZone = randomZone("ungranted-soa");
+    await createZone(admin, granted);
+    await createZone(admin, otherZone);
+
+    const { user, client } = await createAndLogin(admin, {
+      email: uniqueEmail("soa-grantee"),
+      name: "SOA grantee",
+      password: "soa-grantee-pw-1234",
+      roleSlug: SYSTEM_ROLES.readOnly,
+    });
+
+    await admin.sendJson("POST", `/api/admin/users/${user.id}/zone-grants`, {
+      serverId: standaloneId,
+      zoneName: granted,
+      permissions: ["zone.read", "soa.read", "soa.update"],
+    });
+
+    expect((await patchRRset(client, granted, soaUpsert(granted))).status).toBe(200);
+    expect((await patchRRset(client, otherZone, soaUpsert(otherZone))).status).toBe(403);
+    // The grant carries no record.* permission, so ordinary records stay shut.
+    expect((await patchRRset(client, granted, ordinaryUpsert(granted))).status).toBe(403);
+  }, 30_000);
+});


### PR DESCRIPTION
## What and why

Closes #132 · Reported in discussion [#119](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/discussions/119)

Editing a zone's *records* and editing the *zone* were the same permission. A role built for a hosting customer — `record.create` / `record.update` / `record.delete` on their own zone — could also rewrite the **SOA**, could delete the **apex NS** (taking the zone off the internet), and was shown the **Zone settings** tab where `SOA-EDIT-API`, the zone kind and the masters list live. There was no permission an operator could withhold to close any of it, because `record.update` was load-bearing for the customer's actual job and everything above rode along with it.

This splits a zone's *authority* out of its *records*, so "manage your own records" becomes a thing you can actually grant.

## How

Four permissions, and one shared classifier:

| Permission | Gates |
| --- | --- |
| `soa.read` | The **SOA** tab. Without it the tab is not rendered. |
| `soa.update` | Every write to the SOA RRset, whatever sent it. |
| `zone.settings.read` | The **Zone settings** tab. Writing it stays `zone.update`. |
| `record.update.apex-ns` | Writing the zone's **apex NS**. |

- **`soa.update` *replaces* the record permission; `record.update.apex-ns` *adds* to it.** The asymmetry is deliberate and is the main thing to review. The SOA is modelled as its own resource (`Soa` joins the `SubjectType` union alongside `Dnssec` and `Metadata`, which are likewise facets of a zone rather than tables), so `soa.update` alone edits it — which is what makes "may fix the SOA, may not touch records" expressible at all. An apex NS write is still a record write, so it needs the matching `record.create`/`update`/`delete` *plus* the extra one.
  - Rejected: `record.update.soa`, additive like the apex-NS one. Kept everything under one prefix, but would have made that role unexpressible — the whole point of the change. Three other rejected options are in the ADR.
- **NS below the apex stays an ordinary record.** A child delegation is content the zone serves, not the zone's own standing.
- **A missing read permission removes the tab, not just its Save button** — which is what the discussion asked for. `?tab=soa` / `?tab=settings` fall back to Records. Holding `zone.delete` still surfaces the settings tab, because the Danger Zone shares it; the settings panel itself stays hidden.
- **One classifier, both sides.** `lib/rbac/protected-rrsets.ts` answers "does writing this (name, type) cost more than `record.*`?". The RRset route runs it over every change **against the normalized name the patch will carry**; the record editor imports the same function to render apex NS rows as `Delegation - locked` and to refuse a rename that would move a record onto them. The module carries no `import "server-only"` precisely so the client component can share it — noted in `lib/rbac/README.md` so nobody "fixes" that.
- **Also fixed:** the settings panel enabled its inputs on `record.update` for any non-mirror zone while `PUT /settings` has always required `zone.update` — a record editor got an interactive form whose Save then 403'd.

**Upgrade is behaviour-preserving.** `0007_granular_zone_permissions_backfill` is data-only (no DDL, both dialects, verified against real Postgres 17 and better-sqlite3). Operator-defined roles, zone grants and API tokens gain the new permission implied by the one they already held, so nothing configured loses access; tightening is then an opt-in untick. Seeded roles *do* change, since the seed re-upserts them on boot: **Zone Editor** keeps both read permissions and loses both writes; **Operator** and above gain them, alongside the `zone.update` they already had. Called out in `docs/09-UPGRADING.md`.

## Tests

- `lib/rbac/protected-rrsets.test.ts` — the classifier: `@` / empty / FQDN / case / trailing-dot spellings of the apex, child delegations, the `notexample.com.` near-miss, and an exhaustive `Record<ProtectedRRsetPermission, true>` checked against `PERMISSIONS` (the classifier names its permissions as string literals to stay free of `server-only`; this is what keeps them honest).
- `lib/rbac/protected-rrsets.fuzz.test.ts` — property-based, 1000 runs per property, per CONTRIBUTING § Testing. Never throws on binary input; never answers "ordinary record" for a SOA or any apex-NS spelling; one verdict across the spellings that normalize to the same RRset; agrees with `isZoneApex` on every NS name.
- `lib/rbac/default-roles.test.ts` — the seeded-role contract, including "Super Admin holds every permission" and the #119 invariants on Zone Editor.
- `tests/integration/rbac/zone-authority.test.ts` — Zone Editor edits records and is refused the SOA, the apex NS (upsert *and* delete) and `PUT /settings`; a mixed batch is rejected whole with the permitted half verified **absent from PowerDNS** afterwards; Operator writes both; a `zone_grant` carrying `soa.update` opens the SOA on that zone only and still refuses ordinary records.

`npm run validate` clean. Full integration suite: 241 passed, 6 skipped. `npm audit --audit-level=high` clean with and without `--omit=dev`.

## Threat-modeling

- **A client bypasses the UI and PATCHes the SOA directly.** The gate is in the route, not the panel — every path to an RRset runs through the same `protectedRRsetPermission` call. The integration tests are pure HTTP and never touch the UI.
- **A spelling trick reaches a different verdict.** `@`, `""`, a relative name, an uppercased FQDN and a missing trailing dot all denote the apex. The route classifies against `normalizeName(change.name, zoneName)` — the *same* normalized value the patch carries — so the classifier and the write cannot disagree about which RRset is in play. Two fuzz properties cover this.
- **A mixed batch smuggles a forbidden change past a permitted one.** Every change is classified before anything reaches PowerDNS, and one refusal rejects the whole request. Tested, including that the permitted half did not land.
- **A hostile name turns the check into a 500 that skips it.** The classifier is pure and total — no throw path, fuzzed over binary strings.
- **A rename escalates.** Editing an ordinary record to `@ / NS` moves it onto the apex NS RRset. The editor classifies the changes the edit *produces*, not the form's target, so it is refused before staging; the route refuses it independently.
- **The classifier drifts from the vocabulary.** A rename in `permissions.ts` would leave it demanding a permission no role can hold — denying silently. The exhaustive `Record` check fails the test suite instead.
- **Privilege escalation via the new permissions.** They use the same machinery as every other: `permissionsExceedingGrant` still ceilings role assignment, `groupMappingsExceedingGrant` still ceilings IdP group mappings, token scopes still narrow to user ∩ token. No new path grants a permission the actor lacks globally.
- **The upgrade silently widening access.** The backfill only adds the permission the held one *already implied* — it cannot grant a capability a role did not effectively have on 1.5.5. It skips system roles (re-seeded anyway) and skips empty token scope lists (empty already means "everything the user holds", so appending would have *narrowed* them).

**Fail direction:** every new check denies on absence. An unresolvable grant, an unrecognised permission string, or an unclassifiable name all end in 403.

**Out of scope:** zone creation and zonefile import write an SOA and apex NS as part of creating a whole zone and stay on `zone.create` / `zone.import` — gating those on permission to edit a zone that does not exist yet is incoherent. Noted in ADR-0023 § Consequences.

## Documentation

- **New ADR:** [`docs/adr/0023-zone-authority-permissions.md`](https://github.com/PowerDNS-AuthAdmin/powerdns-authadmin/blob/feat/granular-zone-permissions/docs/adr/0023-zone-authority-permissions.md) — the decision, the asymmetry between the two composition rules, and five rejected alternatives. Indexed in `docs/adr/README.md`.
- `docs/07-RBAC.md` — new "Splitting record editing from a zone's authority" section with the surface/read/write table and the self-service role recipe; system-role table and vocabulary updated (and the stale `oidc.*` row corrected to `auth.*`).
- `docs/FEATURES.md` § 2.3 — new "Zone-authority permissions" entry.
- `docs/09-UPGRADING.md` — 1.5.6 section: what the migration backfills, what the seeded roles now mean, and the rollback note.
- `lib/rbac/README.md` — names the classifier and records which two modules there are deliberately not `server-only`.
- `provisioning.example.yaml` — vocabulary block updated with the composition rules.
- `README.md`, `CHANGELOG.md`.
- No new env var.

## Checklist

- [x] PR title uses Conventional Commits (`feat:`)
- [x] Linked issue exists and is approved (#132, direction acked in discussion #119)
- [x] `npm run validate` passes locally (lint + typecheck + format + test)
- [x] New code is documented (file-level + JSDoc on exports)
- [x] No secrets in code, config, logs, or fixture data
- [x] If user-visible: strings go through i18n (or PR opens an i18n follow-up) — **n/a in practice:** the repo has no i18n runtime wired yet, so the one new user-visible string (`Delegation - locked`) follows existing practice in the same component. It will be picked up by whatever i18n pass lands.

## Notes for the reviewer

- **Two reviewers required** per CONTRIBUTING § Security practices (RBAC change).
- **The `audit` job was red on the first push and is not this change.** The `nanoid` advisory ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)) had its fixed-version widened after 1.5.5 shipped the 3.3.16 → 3.3.17 bump for the same GHSA, so `main` fails the gate too. Fixed here in its own `chore(deps)` commit — lockfile-only, 3.3.18 sits inside postcss' existing `^3.3.11` range.
- **No new dependencies.**
- Commits are ordered `feat` → `docs(adr)` → `chore(deps)` → `test` → `release: 1.5.6`, each self-contained, if you'd rather review them separately than as a squash.
- **The fuzz test earned its keep before merge.** CI's seed found a counterexample the local run had missed: the apex-NS properties generated "another spelling of the same name" with `String.toUpperCase()`, which is only a round-trip for ASCII — U+1F54 uppercases to a three-codepoint sequence that lowercases back to a *different* character. The test premise was wrong and the classifier was right; the properties now fold A-Z only, per RFC 4343 § 3. Worth reading the `test(rbac):` commit message: it also records why the classifier deliberately keeps full `toLowerCase()` (it must never fold *less* than `normalizeZoneId` / `normalizeName`, because folding less is the direction that misses an apex match and lets a write through). Stressed over 30 independent seeds after the fix.

Thanks to @vducros-neyrial for the report and for describing the scenario concretely enough to build against.
